### PR TITLE
不要なメタファイルを削除しました

### DIFF
--- a/Plugins/Windows/x86_64/plateau.pdb.meta
+++ b/Plugins/Windows/x86_64/plateau.pdb.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 2bbc67b8b6c990e4493160536494bb0f
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Git URLを用いてSDKをインストールした場合に、以下のような警告が発生していました。

```
A meta data file (.meta) exists but its asset 'Packages/com.synesthesias.plateau-unity-sdk/Plugins/Windows/x86_64/plateau.pdb' can't be found. When moving or deleting files outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it.
```

```
Couldn't delete Packages/com.synesthesias.plateau-unity-sdk/Plugins/Windows/x86_64/plateau.pdb.meta because it's in an immutable folder.
```

Git URLでインストールした場合、パッケージがRead Onlyなので、自動で.metaファイルを削除することができないようです。

## 関連リンク

## 実装内容
.metaファイルを一つ削除しました。

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
なし

## その他
なし