### PR TITLE
沼津バグ対応: テクスチャの幅か高さが1ピクセルの時に圧縮に失敗するのを修正

### DIFF
--- a/Runtime/CityImport/Load/Convert/ConvertedMeshData.cs
+++ b/Runtime/CityImport/Load/Convert/ConvertedMeshData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using PLATEAU.Util;
 using PLATEAU.Util.Async;
@@ -142,7 +143,7 @@ namespace PLATEAU.CityImport.Load.Convert
                 Debug.Log($"Loading Texture : {textureFullPath}");
 
                 // 非同期でテクスチャをロードします。
-                Texture texture = await TextureLoader.LoadAsync($"file://{textureFullPath}", 3);
+                var texture = await TextureLoader.LoadAsync($"file://{textureFullPath}", 3);
 
                 if (texture == null) continue;
 
@@ -159,13 +160,15 @@ namespace PLATEAU.CityImport.Load.Convert
         }
         
         // テクスチャを圧縮します。
-        private static Texture2D Compress(Texture src)
+        private static Texture2D Compress(Texture2D src)
         {
             // Compressメソッドで圧縮する準備として、幅・高さを4の倍数にする必要があります。
             // 最も近い4の倍数を求めます。
             var widthX4 = (src.width + 2) / 4 * 4;
             var heightX4 = (src.height + 2) / 4 * 4;
-            
+            widthX4 = Math.Max(4, widthX4); // 幅・高さが 1ピクセルのケースで 0 に丸められてしまうのを防止します。
+            heightX4 = Math.Max(4, heightX4);
+
             // テクスチャをリサイズします。
             // 参考: https://light11.hatenadiary.com/entry/2018/04/19/194015
             var rt = RenderTexture.GetTemporary(widthX4, heightX4);

--- a/Runtime/CityImport/Load/Convert/PlateauToUnityModelConverter.cs
+++ b/Runtime/CityImport/Load/Convert/PlateauToUnityModelConverter.cs
@@ -78,7 +78,7 @@ namespace PLATEAU.CityImport.Load.Convert
             }
             catch (Exception e)
             {
-                Debug.Log("メッシュデータの配置に失敗しました。\n" + e);
+                Debug.LogError("メッシュデータの配置に失敗しました。\n" + e);
                 return false;
             }
 

--- a/Runtime/Util/Async/TextureLoader.cs
+++ b/Runtime/Util/Async/TextureLoader.cs
@@ -14,7 +14,7 @@ namespace PLATEAU.Util.Async
         /// コルーチンを使うので、メインスレッドで行われる必要があります。
         /// 失敗した場合は null を返します。
         /// </summary>
-        public static async Task<Texture> LoadAsync(string url, int timeOutSec)
+        public static async Task<Texture2D> LoadAsync(string url, int timeOutSec)
         {
             var request = UnityWebRequestTexture.GetTexture(url);
             request.timeout = timeOutSec;
@@ -29,7 +29,7 @@ namespace PLATEAU.Util.Async
                 return null;
             }
 
-            Texture texture = ((DownloadHandlerTexture)request.downloadHandler).texture;
+            var texture = ((DownloadHandlerTexture)request.downloadHandler).texture;
             return texture;
         }
     }


### PR DESCRIPTION
![image](https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/assets/1321932/b851596a-b73f-4cee-8eb0-4d970b1b2811)

## 実装内容
沼津で frn のテクスチャ読込に失敗するバグ報告に関し、原因となるバグを修正しました。
原因:  
テクスチャの幅か高さが 1ピクセルの時に圧縮失敗するバグがありました。  
沼津のfrnで 1×1ピクセルのテクスチャが増えていたのを読み込めるようにしました。

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
沼津で LOD3 に対応している地域の frn を読み込みます。

