### PR TITLE
属性情報の値でTypeがIntegerなのにintの範囲を超えるケースに対応

### DIFF
--- a/Runtime/CityInfo/CityObjectSerializable.cs
+++ b/Runtime/CityInfo/CityObjectSerializable.cs
@@ -150,8 +150,18 @@ namespace PLATEAU.CityInfo
                         switch(value.Type)
                         {
                             case AttributeType.Integer:
-                                IntValue = value.AsInt;
-                                StringValue = IntValue.ToString();
+                                try
+                                {
+                                    IntValue = value.AsInt;
+                                    StringValue = IntValue.ToString();
+                                }
+                                catch (OverflowException)
+                                {
+                                    // 沼津市のLOD3の道路でTypeがIntegerなのにintの範囲を超えることがあったので対応
+                                    IntValue = 0;
+                                    StringValue = value.AsString;
+                                }
+
                                 break;
                             case AttributeType.Double:
                                 DoubleValue = value.AsDouble;


### PR DESCRIPTION
﻿
沼津のLOD3の道路で属性情報の値でTypeがIntegerなのにintの範囲を超えてエラーになるケースがあったので対応

