### PR TITLE
地域メッシュ単位でのインポート機能

### DIFF
--- a/Plugins/Linux/x86_64/libplateau.so
+++ b/Plugins/Linux/x86_64/libplateau.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0bf374fb11330219d525e5bc702d47083e3a5aeb2bf60368448e5fb3cb9af1b7
-size 143559168
+oid sha256:d97645524af2d6713887ebeaaa43d594aa82c1124e472ea99b70245f227a87dc
+size 148865408

--- a/Plugins/MacOS/libplateau.dylib
+++ b/Plugins/MacOS/libplateau.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdea7c113f6257555afd531a5fe06081922a8061eb2655095b24fe9c8902a3d9
-size 21009309
+oid sha256:1d07617b95a0d9f8c615ba2b8dc804722ebce9b620d9b31392f916ddaa9cac81
+size 21016477

--- a/Plugins/MacOS/libz.1.2.13.dylib
+++ b/Plugins/MacOS/libz.1.2.13.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d38e0c8649ca1cd0128de1aa1f43784be435e909c5cfac43dc05a1b3164f7ed8
+oid sha256:13ebc6f131e631dafb122e8b4f453b9db5987f992b573b32c30672fb9cd5e5d1
 size 135721

--- a/Plugins/MacOS/libz.1.dylib
+++ b/Plugins/MacOS/libz.1.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d38e0c8649ca1cd0128de1aa1f43784be435e909c5cfac43dc05a1b3164f7ed8
+oid sha256:13ebc6f131e631dafb122e8b4f453b9db5987f992b573b32c30672fb9cd5e5d1
 size 135721

--- a/Plugins/MacOS/libz.dylib
+++ b/Plugins/MacOS/libz.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d38e0c8649ca1cd0128de1aa1f43784be435e909c5cfac43dc05a1b3164f7ed8
+oid sha256:13ebc6f131e631dafb122e8b4f453b9db5987f992b573b32c30672fb9cd5e5d1
 size 135721

--- a/Plugins/Windows/x86_64/plateau.dll
+++ b/Plugins/Windows/x86_64/plateau.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:54fc49f813d4f349d9e89cf8e88de66c2ebcb6c9d868b228b1e3b853f6a16214
-size 35365376
+oid sha256:507e2e1971fa440a8db55f3e9bde65a7c50c2f5e51e45164991aee85ca297e9e
+size 21637632

--- a/Runtime/CityImport/AreaSelector/AreaSelectorBehaviour.cs
+++ b/Runtime/CityImport/AreaSelector/AreaSelectorBehaviour.cs
@@ -184,13 +184,11 @@ namespace PLATEAU.CityImport.AreaSelector
             AreaSelectorGuideGUI.Disable();
             LodLegendGUI.Disable();
             var selectedMeshCodes = this.gizmosDrawer.SelectedMeshCodes.ToArray();
-            var selectedExtent = this.gizmosDrawer.CursorExtent(this.coordinateZoneID, this.geoReference.ReferencePoint);
-
             var availablePackageLods = CalcAvailablePackageLodInMeshCodes(selectedMeshCodes, this.datasetSourceConfig);
 
             // 無名関数のキャプチャを利用して、シーン終了後も必要なデータが渡るようにします。
             #if UNITY_EDITOR
-            AreaSelectorDataPass.Exec(this.prevScenePath, selectedMeshCodes, this.areaSelectResultReceiver, availablePackageLods, selectedExtent, this.prevEditorWindow);
+            AreaSelectorDataPass.Exec(this.prevScenePath, selectedMeshCodes, this.areaSelectResultReceiver, availablePackageLods, this.prevEditorWindow);
             #endif
         }
 
@@ -227,9 +225,8 @@ namespace PLATEAU.CityImport.AreaSelector
             LodLegendGUI.Disable();
             IsAreaSelectEnabled = false;
             var emptyAreaSelectResult = new MeshCode[] { };
-            var dummyExtent = Extent.All;
             #if UNITY_EDITOR
-            AreaSelectorDataPass.Exec(this.prevScenePath, emptyAreaSelectResult, this.areaSelectResultReceiver, new PackageToLodDict(), dummyExtent, this.prevEditorWindow);
+            AreaSelectorDataPass.Exec(this.prevScenePath, emptyAreaSelectResult, this.areaSelectResultReceiver, new PackageToLodDict(), this.prevEditorWindow);
             #endif
         }
 

--- a/Runtime/CityImport/AreaSelector/AreaSelectorDataPass.cs
+++ b/Runtime/CityImport/AreaSelector/AreaSelectorDataPass.cs
@@ -24,21 +24,17 @@ namespace PLATEAU.CityImport.AreaSelector
         private static IEnumerable<MeshCode> selectedMeshCodes;
         private static IAreaSelectResultReceiver areaSelectResultReceiver;
         private static PackageToLodDict availablePackageLods;
-        private static Extent extent;
 
 #if UNITY_EDITOR
         public static void Exec(
             string prevScenePathArg, IEnumerable<MeshCode> selectedMeshCodesArg,
             IAreaSelectResultReceiver areaSelectResultReceiverArg, PackageToLodDict availablePackageLodsArg,
-            Extent selectedExtent, EditorWindow prevEditorWindow)
+            EditorWindow prevEditorWindow)
         {
-
-
             prevScenePath = prevScenePathArg;
             selectedMeshCodes = selectedMeshCodesArg;
             areaSelectResultReceiver = areaSelectResultReceiverArg;
             availablePackageLods = availablePackageLodsArg;
-            extent = selectedExtent;
             
             EditorSceneManager.sceneOpened += OnBackToPrevScene;
             EditorSceneManager.OpenScene(prevScenePath);
@@ -70,7 +66,7 @@ namespace PLATEAU.CityImport.AreaSelector
                 Debug.Log("地域は選択されませんでした。");
             }
 
-            var areaSelectResult = new AreaSelectResult(areaMeshCodes, extent, availablePackageLods);
+            var areaSelectResult = new AreaSelectResult(areaMeshCodes, availablePackageLods);
             areaSelectResultReceiver.ReceiveResult(areaSelectResult);
         }
     }

--- a/Runtime/CityImport/AreaSelector/AreaSelectorGUI.cs
+++ b/Runtime/CityImport/AreaSelector/AreaSelectorGUI.cs
@@ -45,7 +45,7 @@ namespace PLATEAU.CityImport.AreaSelector
             EditorGUI.BeginDisabledGroup(!areaSelector.IsSelectedArea());
             if (GUILayout.Button("決定"))
             {
-                areaSelector.EndAreaSelection();
+                areaSelector.EndAreaSelection(); 
             }
             EditorGUI.EndDisabledGroup();
             if (GUILayout.Button("キャンセル"))

--- a/Runtime/CityImport/AreaSelector/IAreaSelectResultReceiver.cs
+++ b/Runtime/CityImport/AreaSelector/IAreaSelectResultReceiver.cs
@@ -1,4 +1,5 @@
 ﻿using PLATEAU.CityImport.Setting;
+using PLATEAU.Dataset;
 using PLATEAU.Native;
 
 namespace PLATEAU.CityImport.AreaSelector
@@ -11,13 +12,11 @@ namespace PLATEAU.CityImport.AreaSelector
     public class AreaSelectResult
     {
         public string[] AreaMeshCodes { get; }
-        public Extent Extent { get; }
         public PackageToLodDict PackageToLodDict { get; }
 
-        public AreaSelectResult(string[] areaMeshCodes, Extent extent, PackageToLodDict packageToLodDict)
+        public AreaSelectResult(string[] areaMeshCodes, PackageToLodDict packageToLodDict)
         {
             AreaMeshCodes = areaMeshCodes;
-            Extent = extent;
             PackageToLodDict = packageToLodDict;
         }
     }

--- a/Runtime/CityImport/AreaSelector/SceneObjs/AreaSelectGizmosDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/SceneObjs/AreaSelectGizmosDrawer.cs
@@ -74,16 +74,15 @@ namespace PLATEAU.CityImport.AreaSelector.SceneObjs
         {
             get 
             {
-                return new List<MeshCode>();
+                List<MeshCode> meshCodes = new List<MeshCode>();
+                foreach (var meshCodeGizmoDrawer in this.meshCodeDrawers)
+                {
+                    meshCodes.AddRange(meshCodeGizmoDrawer.GetSelectedMeshIds().Select(id => MeshCode.Parse(id)).ToList());
+                }
+                return meshCodes;
             }
         }
 
-        public Extent CursorExtent(int coordinateZoneID, PlateauVector3d referencePoint)
-        {
-            return new Extent();
-            // return this.cursor.GetExtent(coordinateZoneID, referencePoint);
-        }
-        
         public void ResetSelectedArea()
         {
             foreach (var meshCodeGizmoDrawer in this.meshCodeDrawers)

--- a/Runtime/CityImport/Load/CityImportProcedure/GmlImporter.cs
+++ b/Runtime/CityImport/Load/CityImportProcedure/GmlImporter.cs
@@ -87,7 +87,7 @@ namespace PLATEAU.CityImport.Load.CityImportProcedure
             var packageConf = conf.GetConfigForPackage(package);
             // ここはメインスレッドで呼ぶ必要があります。
             bool placingSucceed = await PlateauToUnityModelConverter.ConvertAndPlaceToScene(
-                cityModel, meshExtractOptions, gmlTrans, progressDisplay, gmlName, packageConf.DoSetMeshCollider, packageConf.DoSetAttrInfo, token, packageConf.FallbackMaterial
+                cityModel, meshExtractOptions, conf.AreaMeshCodes, gmlTrans, progressDisplay, gmlName, packageConf.DoSetMeshCollider, packageConf.DoSetAttrInfo, token, packageConf.FallbackMaterial
             );
 
             if (placingSucceed)

--- a/Runtime/CityImport/Load/Convert/PlateauToUnityModelConverter.cs
+++ b/Runtime/CityImport/Load/Convert/PlateauToUnityModelConverter.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using PLATEAU.CityGML;
 using PLATEAU.PolygonMesh;
+using PLATEAU.Dataset;
 using PLATEAU.Util;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Texture = UnityEngine.Texture;
 using System.Threading;
+using System.Linq;
 
 #if UNITY_EDITOR
 using UnityEditor.SceneManagement;
@@ -27,7 +29,7 @@ namespace PLATEAU.CityImport.Load.Convert
         /// 成否を bool で返します。
         /// </summary>
         public static async Task<bool> ConvertAndPlaceToScene(
-            CityModel cityModel, MeshExtractOptions meshExtractOptions,
+            CityModel cityModel, MeshExtractOptions meshExtractOptions, string[] selectedMeshCodes,
             Transform parentTrans, IProgressDisplay progressDisplay, string progressName,
             bool doSetMeshCollider, bool doSetAttrInfo, CancellationToken token,  UnityEngine.Material fallbackMaterial
             )
@@ -52,7 +54,7 @@ namespace PLATEAU.CityImport.Load.Convert
             {
                 meshObjsData = await Task.Run(() =>
                 {
-                    using var plateauModel = ExtractMeshes(cityModel, meshExtractOptions, token);
+                    using var plateauModel = ExtractMeshes(cityModel, meshExtractOptions, selectedMeshCodes, token);
                     var convertedObjData = new ConvertedGameObjData(plateauModel, new AttributeDataHelper(cityModel, meshExtractOptions.MeshGranularity, doSetAttrInfo));
                     return convertedObjData;
                 });
@@ -100,11 +102,17 @@ namespace PLATEAU.CityImport.Load.Convert
         /// メインスレッドでなくても動作します。
         /// </summary>
         private static Model ExtractMeshes(
-            CityModel cityModel, MeshExtractOptions meshExtractOptions, CancellationToken token)
+            CityModel cityModel, MeshExtractOptions meshExtractOptions, string[] selectedMeshCodes, CancellationToken token)
         {
             var model = Model.Create();
             if (cityModel == null) return model;
-            MeshExtractor.Extract(ref model, cityModel, meshExtractOptions);
+            var extents = selectedMeshCodes.Select(code => {
+                var extent = MeshCode.Parse(code).Extent;
+                extent.Min.Height = -999999.0;
+                extent.Max.Height = 999999.0;
+                return extent;
+            }).ToList();
+            MeshExtractor.ExtractInExtents(ref model, cityModel, meshExtractOptions, extents);
             Debug.Log("model extracted.");
             return model;
         }

--- a/Runtime/CityImport/Setting/PackageLoadSetting.cs
+++ b/Runtime/CityImport/Setting/PackageLoadSetting.cs
@@ -115,7 +115,7 @@ namespace PLATEAU.CityImport.Setting
         /// <summary>
         /// インポート設定について、C++のstructに変換します。
         /// </summary>
-        public virtual MeshExtractOptions ConvertToNativeOption(PlateauVector3d referencePoint, int coordinateZoneID, Extent extent)
+        public virtual MeshExtractOptions ConvertToNativeOption(PlateauVector3d referencePoint, int coordinateZoneID)
         {
 
             return new MeshExtractOptions(
@@ -132,7 +132,6 @@ namespace PLATEAU.CityImport.Setting
                 excludePolygonsOutsideExtent: ShouldExcludePolygonsOutsideExtent(Package),
                 enableTexturePacking: EnableTexturePacking,
                 texturePackingResolution: (uint)TexturePackingResolution.ToPixelCount(), 
-                extent: extent,
                 attachMapTile: false, // 土地専用の設定は ReliefLoadSetting で行うので、ここでは false に固定します。
                 mapTileZoomLevel: 15, // 土地専用の設定は ReliefLoadSetting で行うので、ここでは仮の値にします。
                 mapTileURL: ReliefLoadSetting.DefaultMapTileUrl); // 土地専用の設定
@@ -200,9 +199,9 @@ namespace PLATEAU.CityImport.Setting
             MapTileURL = DefaultMapTileUrl;
         }
 
-        public override MeshExtractOptions ConvertToNativeOption(PlateauVector3d referencePoint, int coordinateZoneID, Extent extent)
+        public override MeshExtractOptions ConvertToNativeOption(PlateauVector3d referencePoint, int coordinateZoneID)
         {
-            var nativeOption = base.ConvertToNativeOption(referencePoint, coordinateZoneID, extent);
+            var nativeOption = base.ConvertToNativeOption(referencePoint, coordinateZoneID);
             nativeOption.AttachMapTile = AttachMapTile;
             nativeOption.MapTileZoomLevel = MapTileZoomLevel;
             nativeOption.MapTileURL = MapTileURL;

--- a/Tests/TestUtils/TestCityDefinition.cs
+++ b/Tests/TestUtils/TestCityDefinition.cs
@@ -84,7 +84,7 @@ namespace PLATEAU.Tests.TestUtils
                 allPackageLods.MergePackage(package, 3);
             }
 
-            var dummyAreaSelectResult = new AreaSelectResult(AreaMeshCodes, Extent.All, allPackageLods);
+            var dummyAreaSelectResult = new AreaSelectResult(AreaMeshCodes, allPackageLods);
             conf.InitWithAreaSelectResult(dummyAreaSelectResult);
             
             // メッシュコードがあるあたりに基準点を設定します。 Extent.Allの中心を基準点にすると極端な座標になるため。  

--- a/libplateau/CSharpPLATEAU/Dataset/MeshCode.cs
+++ b/libplateau/CSharpPLATEAU/Dataset/MeshCode.cs
@@ -14,6 +14,10 @@ namespace PLATEAU.Dataset
         private readonly int SecondCol;
         private readonly int ThirdRow;
         private readonly int ThirdCol;
+        private readonly int FourthRow;
+        private readonly int FourthCol;
+        private readonly int FifthRow;
+        private readonly int FifthCol;
         public readonly int Level;
         [MarshalAs(UnmanagedType.U1)] private readonly bool isValid;
 
@@ -44,13 +48,40 @@ namespace PLATEAU.Dataset
             return NativeMethods.plateau_mesh_code_parse(code);
         }
 
+
+        private static bool getHalfMeshNumber(out int num, int row, int col)
+        {
+            if (row < 0 || row > 1 ||
+                col < 0 || col > 1)
+            {
+                num = 0;
+                return false;
+            }
+
+            // 番号順に左下→右下→左上→右上
+            num = row * 2 + col + 1;
+            return true;
+        }
+
         public override string ToString()
         {
             ThrowIfInvalid();
             string secondString = Level2();
             if (this.Level == 2)
                 return secondString;
-            return secondString + $"{this.ThirdRow | 0}{this.ThirdCol | 0}";
+
+            string thirdString = secondString + $"{this.ThirdRow | 0}{this.ThirdCol | 0}";
+            if (this.Level == 3)
+                return thirdString;
+
+            getHalfMeshNumber(out int fourthNum, this.FourthRow, this.FourthCol);
+            string fourthString = thirdString + $"{fourthNum}";
+            if (this.Level == 4)
+                return fourthString;
+
+            getHalfMeshNumber(out int fifthNum, this.FifthRow, this.FifthCol);
+            string fifthString = fourthString + $"{fifthNum}";
+            return fifthString;
         }
 
         public string Level2()
@@ -79,7 +110,7 @@ namespace PLATEAU.Dataset
             [DllImport(DLLUtil.DllName)]
             internal static extern APIResult plateau_mesh_code_is_valid(
                 [In] MeshCode meshCode,
-                [MarshalAs(UnmanagedType.U1)]out bool outIsValid);
+                [MarshalAs(UnmanagedType.U1)] out bool outIsValid);
         }
     }
 }

--- a/libplateau/CSharpPLATEAU/Native/NativeVectorExtent.cs
+++ b/libplateau/CSharpPLATEAU/Native/NativeVectorExtent.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using PLATEAU.Dataset;
+using PLATEAU.Interop;
+
+namespace PLATEAU.Native
+{
+    public class NativeVectorExtent : NativeVectorDisposableBase<Extent>
+    {
+        private NativeVectorExtent(IntPtr ptr) : base(ptr)
+        {
+        }
+
+        public static NativeVectorExtent Create()
+        {
+            var result = NativeMethods.plateau_create_vector_extent(out var ptr);
+            DLLUtil.CheckDllError(result);
+            return new NativeVectorExtent(ptr);
+        }
+
+        public override Extent At(int index)
+        {
+            ThrowIfDisposed();
+            var meshCode = DLLUtil.GetNativeValue<Extent>(Handle, index,
+                NativeMethods.plateau_vector_extent_get_value);
+            return meshCode;
+        }
+
+        public override int Length
+        {
+            get
+            {
+                ThrowIfDisposed();
+                int count = DLLUtil.GetNativeValue<int>(Handle,
+                    NativeMethods.plateau_vector_extent_count);
+                return count;
+            }
+        }
+
+        public void Add(Extent extent)
+        {
+            var result = NativeMethods.plateau_vector_extent_push_back_value(
+                Handle, extent);
+            DLLUtil.CheckDllError(result);
+        }
+
+
+        protected override void DisposeNative()
+        {
+            var result = NativeMethods.plateau_delete_vector_extent(Handle);
+            DLLUtil.CheckDllError(result);
+        }
+
+        private static class NativeMethods
+        {
+            [DllImport(DLLUtil.DllName)]
+            internal static extern APIResult plateau_create_vector_extent(
+                out IntPtr outVectorPtr);
+
+            [DllImport(DLLUtil.DllName)]
+            internal static extern APIResult plateau_delete_vector_extent(
+                [In] IntPtr vectorPtr);
+
+            [DllImport(DLLUtil.DllName)]
+            internal static extern APIResult plateau_vector_extent_get_value(
+                [In] IntPtr vectorPtr,
+                out Extent outExtent,
+                int index);
+        
+            [DllImport(DLLUtil.DllName)]
+            internal static extern APIResult plateau_vector_extent_count(
+                [In] IntPtr handle,
+                out int outCount);
+
+            [DllImport(DLLUtil.DllName)]
+            internal static extern APIResult plateau_vector_extent_push_back_value(
+                [In] IntPtr handle,
+                [In] Extent extent);
+        }
+    }
+}

--- a/libplateau/CSharpPLATEAU/Native/NativeVectorExtent.cs.meta
+++ b/libplateau/CSharpPLATEAU/Native/NativeVectorExtent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41c4eb3e6a4bf6a458886957677efb3f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/libplateau/CSharpPLATEAU/PolygonMesh/MeshExtractOptions.cs
+++ b/libplateau/CSharpPLATEAU/PolygonMesh/MeshExtractOptions.cs
@@ -6,7 +6,7 @@ using PLATEAU.Native;
 
 namespace PLATEAU.PolygonMesh
 {
-    
+
     /// <summary>
     /// メッシュの結合単位
     /// </summary>
@@ -25,8 +25,8 @@ namespace PLATEAU.PolygonMesh
         /// </summary>
         PerCityModelArea
     }
-    
-    
+
+
     /// <summary>
     /// GMLファイルから3Dメッシュを取り出すための設定です。
     /// </summary>
@@ -38,7 +38,7 @@ namespace PLATEAU.PolygonMesh
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
     public struct MeshExtractOptions
     {
-        public MeshExtractOptions(PlateauVector3d referencePoint, CoordinateSystem meshAxes, MeshGranularity meshGranularity, uint minLOD, uint maxLOD, bool exportAppearance, int gridCountOfSide, float unitScale, int coordinateZoneID, bool excludeCityObjectOutsideExtent, bool excludePolygonsOutsideExtent, bool enableTexturePacking, uint texturePackingResolution, Extent extent, bool attachMapTile, int mapTileZoomLevel, string mapTileURL)
+        public MeshExtractOptions(PlateauVector3d referencePoint, CoordinateSystem meshAxes, MeshGranularity meshGranularity, uint minLOD, uint maxLOD, bool exportAppearance, int gridCountOfSide, float unitScale, int coordinateZoneID, bool excludeCityObjectOutsideExtent, bool excludePolygonsOutsideExtent, bool enableTexturePacking, uint texturePackingResolution, bool attachMapTile, int mapTileZoomLevel, string mapTileURL)
         {
             this.ReferencePoint = referencePoint;
             this.MeshAxes = meshAxes;
@@ -47,9 +47,8 @@ namespace PLATEAU.PolygonMesh
             this.CoordinateZoneID = coordinateZoneID;
             this.ExcludeCityObjectOutsideExtent = excludeCityObjectOutsideExtent;
             this.ExcludePolygonsOutsideExtent = excludePolygonsOutsideExtent;
-            this.EnableTexturePacking = enableTexturePacking; 
-            this.TexturePackingResolution = texturePackingResolution; 
-            this.Extent = extent;
+            this.EnableTexturePacking = enableTexturePacking;
+            this.TexturePackingResolution = texturePackingResolution;
             this.minLOD = minLOD;
             this.maxLOD = maxLOD;
             this.unitScale = unitScale;
@@ -57,7 +56,7 @@ namespace PLATEAU.PolygonMesh
             this.AttachMapTile = attachMapTile;
             this.MapTileZoomLevel = mapTileZoomLevel;
             this.mapTileURL = mapTileURL;
-            
+
             // 上で全てのメンバー変数を設定できてますが、バリデーションをするため念のためメソッドやプロパティも呼びます。
             SetLODRange(minLOD, maxLOD);
             UnitScale = unitScale;
@@ -68,16 +67,16 @@ namespace PLATEAU.PolygonMesh
         /// <summary> 直交座標系における座標で、3Dモデルの原点をどこに設定するかです。 </summary>
         public PlateauVector3d ReferencePoint;
 
-        
+
         /// <summary> 座標軸の向きです。 </summary>
         public CoordinateSystem MeshAxes;
-        
+
         /// <summary> メッシュ結合の粒度です。 </summary>
         public MeshGranularity MeshGranularity;
-        
+
         /// <summary> 出力するLODの範囲上限です。 </summary>
         private uint maxLOD;
-        
+
         /// <summary> 出力するLODの範囲の下限です。 </summary>
         private uint minLOD;
 
@@ -90,10 +89,10 @@ namespace PLATEAU.PolygonMesh
             this.maxLOD = maxLODArg;
             this.minLOD = minLODArg;
         }
-        
+
         /// <summary> テクスチャを含めるかどうかです。 </summary>
         [MarshalAs(UnmanagedType.U1)] public bool ExportAppearance;
-        
+
         /// <summary> メッシュ結合の粒度が「都市モデル単位」の時のみ有効で、この設定では都市を格子状のグリッドに分割するので、その1辺あたりの分割数(縦の数 = 横の数)です。</summary>
         private int gridCountOfSide;
 
@@ -109,7 +108,7 @@ namespace PLATEAU.PolygonMesh
                 this.gridCountOfSide = value;
             }
         }
-        
+
         /// <summary>  大きさ補正です。  </summary>
         private float unitScale;
 
@@ -125,14 +124,14 @@ namespace PLATEAU.PolygonMesh
                 this.unitScale = value;
             }
         }
-        
+
         /// <summary>
         /// 国土交通省が規定する、日本の平面直角座標系の基準点の番号です。
         /// 詳しくは次の国土地理院のサイトをご覧ください。
         /// <see href="https://www.gsi.go.jp/sokuchikijun/jpc.html"/>
         /// </summary>
         public int CoordinateZoneID;
-        
+
         /// <summary>
         /// 範囲外の3Dモデルを出力から除外するための、2つの方法のうち1つを有効にするかどうかを bool で指定します。
         /// その方法とは、都市オブジェクトの最初の頂点の位置が範囲外のとき、そのオブジェクトはすべて範囲外とみなして出力から除外します。
@@ -141,7 +140,7 @@ namespace PLATEAU.PolygonMesh
         /// したがって、この値は建物では true, 地形では false となるべきです。
         /// </summary>
         [MarshalAs(UnmanagedType.U1)] public bool ExcludeCityObjectOutsideExtent;
-        
+
         /// <summary>
         /// 範囲外の3Dモデルを出力から除外するための、2つの方法のうち1つを有効にするかどうかを bool で指定します。
         /// その方法とは、メッシュ操作によって、範囲外に存在するポリゴンを除外します。
@@ -156,9 +155,6 @@ namespace PLATEAU.PolygonMesh
 
         /// <summary> テクスチャ結合時の結合先のテクスチャ画像の解像度（縦：texture_packing_resolution x 横:texture_packing_resolution） </summary>
         public uint TexturePackingResolution;
-        
-        /// <summary>  対象範囲を緯度・経度・高さで指定します。 </summary>
-        public Extent Extent;
 
         /// <summary>
         /// 土地でのみ利用します。
@@ -193,7 +189,7 @@ namespace PLATEAU.PolygonMesh
                 this.mapTileURL = value;
             }
         }
-        
+
         /// <summary> デフォルト値の設定を返します。 </summary>
         internal static MeshExtractOptions DefaultValue()
         {
@@ -203,10 +199,10 @@ namespace PLATEAU.PolygonMesh
         }
 
         private static class NativeMethods
-         {
-             [DllImport(DLLUtil.DllName)]
-             internal static extern APIResult plateau_mesh_extract_options_default_value(
-                 out MeshExtractOptions outDefaultOptions);
-         }
+        {
+            [DllImport(DLLUtil.DllName)]
+            internal static extern APIResult plateau_mesh_extract_options_default_value(
+                out MeshExtractOptions outDefaultOptions);
+        }
     }
 }

--- a/libplateau/CSharpPLATEAU/PolygonMesh/MeshExtractor.cs
+++ b/libplateau/CSharpPLATEAU/PolygonMesh/MeshExtractor.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using PLATEAU.CityGML;
 using PLATEAU.Interop;
+using PLATEAU.Native;
 
 namespace PLATEAU.PolygonMesh
 {
@@ -24,12 +26,39 @@ namespace PLATEAU.PolygonMesh
             DLLUtil.CheckDllError(result);
         }
 
+
+        /// <summary>
+        /// <see cref="CityModel"/> から範囲内の <see cref="Model"/> を抽出します。
+        /// 結果は <paramref name="outModel"/> に格納されます。
+        /// 通常、<paramref name="outModel"/> には new したばかりの Model を渡してください。
+        /// </summary>
+        public static void ExtractInExtents(ref Model outModel, CityModel cityModel, MeshExtractOptions options, List<Extent> extents)
+        {
+            var nativeExtents = NativeVectorExtent.Create();
+            foreach (var extent in extents)
+            {
+                nativeExtents.Add(extent);
+            }
+
+            var result = NativeMethods.plateau_mesh_extractor_extract_in_extents(
+                cityModel.Handle, options, nativeExtents.Handle, outModel.Handle
+            );
+            DLLUtil.CheckDllError(result);
+        }
+
         private static class NativeMethods
         {
             [DllImport(DLLUtil.DllName)]
             internal static extern APIResult plateau_mesh_extractor_extract(
                 [In] IntPtr cityModelPtr,
                 MeshExtractOptions options,
+                [In] IntPtr outModelPtr);
+
+            [DllImport(DLLUtil.DllName)]
+            internal static extern APIResult plateau_mesh_extractor_extract_in_extents(
+                [In] IntPtr cityModelPtr,
+                MeshExtractOptions options,
+                [In] IntPtr extentsPtr,
                 [In] IntPtr outModelPtr);
         }
     }


### PR DESCRIPTION
﻿## 関連リンク
* libplateauのバージョン
  * https://github.com/Synesthesias/libplateau/commit/186f1f10733f1269a44f9fc55ae8c3c4e1360f6d
  * https://github.com/Synesthesias/libplateau/actions/runs/6347429725

## 実装内容
範囲選択画面の選択地域メッシュをインポートするように実装
![image](https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/assets/10482465/9da20a82-f11f-4140-8fe8-ce0748a40e9f)
