### PR TITLE
Toolkitsからの要請でテクスチャ結合または結合分割を使ったという情報を残すようにした

### DIFF
--- a/Runtime/CityImport/Load/CityImportProcedure/GmlImporter.cs
+++ b/Runtime/CityImport/Load/CityImportProcedure/GmlImporter.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using PLATEAU.CityGML;
 using PLATEAU.CityImport.Load.Convert;
 using PLATEAU.CityImport.Config;
+using PLATEAU.CityInfo;
 using PLATEAU.Dataset;
 using PLATEAU.PolygonMesh;
 using PLATEAU.Util;
@@ -85,9 +86,12 @@ namespace PLATEAU.CityImport.Load.CityImportProcedure
             }
 
             var packageConf = conf.GetConfigForPackage(package);
+            var infoForToolkits = new CityObjectGroupInfoForToolkits(packageConf.EnableTexturePacking);
             // ここはメインスレッドで呼ぶ必要があります。
             var placingResult = await PlateauToUnityModelConverter.CityModelToScene(
-                cityModel, meshExtractOptions, conf.AreaMeshCodes, gmlTrans, progressDisplay, gmlName, packageConf.DoSetMeshCollider, packageConf.DoSetAttrInfo, token, packageConf.FallbackMaterial
+                cityModel, meshExtractOptions, conf.AreaMeshCodes, gmlTrans, progressDisplay, gmlName,
+                packageConf.DoSetMeshCollider, packageConf.DoSetAttrInfo, token, packageConf.FallbackMaterial,
+                infoForToolkits
             );
 
             if (placingResult.IsSucceed)

--- a/Runtime/CityImport/Load/Convert/ConvertedGameObjData.cs
+++ b/Runtime/CityImport/Load/Convert/ConvertedGameObjData.cs
@@ -69,13 +69,15 @@ namespace PLATEAU.CityImport.Load.Convert
         /// 再帰によって子も配置します。
         /// 配置したゲームオブジェクトのリストを返します。
         /// </summary>
-        public async Task<PlateauToUnityModelConverter.ConvertResult> PlaceToScene(Transform parent, Dictionary<MaterialSet, Material> cachedMaterials, bool skipRoot, bool doSetMeshCollider, CancellationToken? token, Material fallbackMaterial)
+        public async Task<PlateauToUnityModelConverter.ConvertResult> PlaceToScene(
+            Transform parent, Dictionary<MaterialSet, Material> cachedMaterials, bool skipRoot, bool doSetMeshCollider,
+            CancellationToken? token, Material fallbackMaterial, CityObjectGroupInfoForToolkits infoForToolkits)
         {
             var result = new PlateauToUnityModelConverter.ConvertResult();
             try
             {
                 await PlaceToSceneRecursive(result, parent, cachedMaterials, skipRoot, doSetMeshCollider, token,
-                    fallbackMaterial, 0);
+                    fallbackMaterial, 0, infoForToolkits);
             }
             catch (Exception e)
             {
@@ -88,7 +90,8 @@ namespace PLATEAU.CityImport.Load.Convert
 
         private async Task PlaceToSceneRecursive(PlateauToUnityModelConverter.ConvertResult result, Transform parent,
             Dictionary<MaterialSet, Material> cachedMaterials, bool skipRoot, bool doSetMeshCollider,
-            CancellationToken? token, Material fallbackMaterial, int recursiveDepth)
+            CancellationToken? token, Material fallbackMaterial, int recursiveDepth,
+            CityObjectGroupInfoForToolkits infoForToolkits)
         {
             token?.ThrowIfCancellationRequested();
 
@@ -132,7 +135,7 @@ namespace PLATEAU.CityImport.Load.Convert
                     if (serialized != null)
                     {
                         var attrInfo = nextParent.gameObject.AddComponent<PLATEAUCityObjectGroup>();
-                        attrInfo.SetSerializableCityObject(serialized);
+                        attrInfo.Init(serialized, infoForToolkits);
                     }
                 }
             }
@@ -141,7 +144,7 @@ namespace PLATEAU.CityImport.Load.Convert
             // 子を再帰的に配置します。
             foreach (var child in this.children)
             {
-                await child.PlaceToSceneRecursive(result, nextParent, cachedMaterials, false, doSetMeshCollider, token, fallbackMaterial, nextRecursiveDepth);
+                await child.PlaceToSceneRecursive(result, nextParent, cachedMaterials, false, doSetMeshCollider, token, fallbackMaterial, nextRecursiveDepth, infoForToolkits);
             }
         }
     }

--- a/Runtime/CityImport/Load/Convert/PlateauToUnityModelConverter.cs
+++ b/Runtime/CityImport/Load/Convert/PlateauToUnityModelConverter.cs
@@ -9,6 +9,7 @@ using PLATEAU.Util;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using System.Threading;
+using PLATEAU.CityInfo;
 using Material = UnityEngine.Material;
 
 #if UNITY_EDITOR
@@ -31,7 +32,8 @@ namespace PLATEAU.CityImport.Load.Convert
         public static async Task<ConvertResult> CityModelToScene(
             CityModel cityModel, MeshExtractOptions meshExtractOptions, string[] selectedMeshCodes,
             Transform parentTrans, IProgressDisplay progressDisplay, string progressName,
-            bool doSetMeshCollider, bool doSetAttrInfo, CancellationToken token,  UnityEngine.Material fallbackMaterial
+            bool doSetMeshCollider, bool doSetAttrInfo, CancellationToken token,  UnityEngine.Material fallbackMaterial,
+            CityObjectGroupInfoForToolkits infoForToolkits
             )
         {
             Debug.Log($"load started");
@@ -51,7 +53,9 @@ namespace PLATEAU.CityImport.Load.Convert
                 return ConvertResult.Fail();
             }
 
-            return await PlateauModelToScene(parentTrans, progressDisplay, progressName, doSetMeshCollider, token, fallbackMaterial, plateauModel, attributeDataHelper, true);
+            return await PlateauModelToScene(
+                parentTrans, progressDisplay, progressName, doSetMeshCollider, token, 
+                fallbackMaterial, plateauModel, attributeDataHelper, true, infoForToolkits);
         }
 
         /// <summary>
@@ -60,7 +64,7 @@ namespace PLATEAU.CityImport.Load.Convert
         /// </summary>
         public static async Task<ConvertResult> PlateauModelToScene(Transform parentTrans, IProgressDisplay progressDisplay,
             string progressName, bool doSetMeshCollider, CancellationToken? token, Material fallbackMaterial, Model plateauModel, 
-            AttributeDataHelper attributeDataHelper, bool skipRoot)
+            AttributeDataHelper attributeDataHelper, bool skipRoot, CityObjectGroupInfoForToolkits infoForToolkits)
         {
             // ここの処理は 処理A と 処理B に分割されています。
             // Unityのメッシュデータを操作するのは 処理B のみであり、
@@ -100,7 +104,7 @@ namespace PLATEAU.CityImport.Load.Convert
             var result = new ConvertResult();
 
             var innerResult = await meshObjsData.PlaceToScene(parentTrans, cachedMaterials, skipRoot, doSetMeshCollider,
-                token, fallbackMaterial);
+                token, fallbackMaterial, infoForToolkits);
             if (innerResult.IsSucceed)
             {
                 result.Merge(innerResult);

--- a/Runtime/CityInfo/CityObjectGroupInfoForToolkits.cs
+++ b/Runtime/CityInfo/CityObjectGroupInfoForToolkits.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace PLATEAU.CityInfo
+{
+    /// <summary>
+    /// <see cref="PLATEAUCityObjectGroup"/>が保持する情報のうち、Toolkitsとの連携に必要な情報です。
+    /// </summary>
+    [Serializable]
+    public struct CityObjectGroupInfoForToolkits
+    {
+        public CityObjectGroupInfoForToolkits(bool isTextureCombinedOrGranularityConverted)
+        {
+            this.isTextureCombinedOrGranularityConverted = isTextureCombinedOrGranularityConverted;
+        }
+        /// <summary>
+        /// インポート時の設定で、テクスチャ結合にチェックが入っていたとき、または、
+        /// 分割結合機能を利用したときにtrueになります。
+        /// Toolkitsのテクスチャ生成の動作に影響します。
+        /// </summary>
+        private bool isTextureCombinedOrGranularityConverted;
+    }
+}

--- a/Runtime/CityInfo/CityObjectGroupInfoForToolkits.cs.meta
+++ b/Runtime/CityInfo/CityObjectGroupInfoForToolkits.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 17ff2222c00a4c8ab5d4958ccf605539
+timeCreated: 1699887443

--- a/Runtime/CityInfo/PLATEAUCityObjectGroup.cs
+++ b/Runtime/CityInfo/PLATEAUCityObjectGroup.cs
@@ -14,6 +14,20 @@ namespace PLATEAU.CityInfo
     /// </summary>
     public class PLATEAUCityObjectGroup : MonoBehaviour
     {
+        
+        /// <summary>
+        /// <see cref="CityObject"/>に関する情報はここに収められます。
+        /// </summary>
+        [HideInInspector][SerializeField] private string serializedCityObjects;
+        
+        private CityObjectList cityObjects;
+        private CityObject outsideParent;
+        private UnityEngine.Mesh currentMesh;
+        
+        /// <summary> Toolkits向けの情報です。 </summary>
+        [SerializeField] private CityObjectGroupInfoForToolkits infoForToolkits;
+        public CityObjectGroupInfoForToolkits InfoForToolkits => infoForToolkits;
+        
         public CityObjectList CityObjects
         {
             get
@@ -28,10 +42,11 @@ namespace PLATEAU.CityInfo
                 return this.cityObjects;               
             }
         }
-
-        public void SetSerializableCityObject(CityObjectList cityObjectSerializable)
+        
+        public void Init(CityObjectList cityObjectSerializable, CityObjectGroupInfoForToolkits cogInfoForToolkits)
         {
             serializedCityObjects = JsonConvert.SerializeObject(cityObjectSerializable, Formatting.Indented);
+            infoForToolkits = cogInfoForToolkits;
         }
 
         /// <summary>
@@ -277,11 +292,7 @@ namespace PLATEAU.CityInfo
             return objs;
         }
 
-        [HideInInspector][SerializeField] private string serializedCityObjects;
-
-        private CityObjectList cityObjects;
-        private CityObject outsideParent;
-        private UnityEngine.Mesh currentMesh;
+        
 
         /// <summary>
         /// 最小地物の場合、親となるPLATEAUCityObjectGroupを検索しCityObjectを取得します

--- a/Runtime/GranularityConvert/CityGranularityConverter.cs
+++ b/Runtime/GranularityConvert/CityGranularityConverter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using PLATEAU.CityExport.ModelConvert;
 using PLATEAU.CityImport.Load.Convert;
+using PLATEAU.CityInfo;
 using PLATEAU.Native;
 using PLATEAU.PolygonMesh;
 using PLATEAU.Util;
@@ -48,11 +49,12 @@ namespace PLATEAU.GranularityConvert
 
                 // Modelをゲームオブジェクトに変換して配置します。
                 var commonParent = CalcCommonParent(srcGameObjs.Select(obj => obj.transform).ToArray());
+                var infoForToolkits = new CityObjectGroupInfoForToolkits(true);
                 var result = await PlateauToUnityModelConverter.PlateauModelToScene(
                     commonParent, new DummyProgressDisplay(), "", true,
                     null, null, dstModel,
                     new AttributeDataHelper(new SerializedCityObjectGetterFromDict(attributes), option.Granularity,
-                        true), true);
+                        true), true, infoForToolkits);
                 if (!result.IsSucceed)
                 {
                     throw new Exception("Failed to convert plateau model to scene game objects.");


### PR DESCRIPTION


## 実装内容
Toolkitsからの次の要請を実装しました：  
PLATEAUCityObjectGroupに、「テクスチャ結合を利用した、または分割結合機能を利用した」のboolを残すようにしました。

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
インポート後、ヒエラルキービューをデバッグモードにするとInfoForToolkitsという変数の中に情報を見ることが出来ます

