### PR TITLE
TypeNodeにLOD4の地物の種類を対応

### DIFF
--- a/Runtime/CityAdjust/MaterialAdjust/MaterialAdjustConf.cs
+++ b/Runtime/CityAdjust/MaterialAdjust/MaterialAdjustConf.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using PLATEAU.CityGML;
@@ -21,6 +22,11 @@ namespace PLATEAU.CityAdjust.MaterialAdjust
             data = new();
             foreach (var type in types)
             {
+                var typeNode = CityObjectTypeHierarchy.GetNodeByType(type);
+                if (typeNode == null)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(types), $"Unknown Type: {type.ToString()}");
+                }
                 data.TryAdd(CityObjectTypeHierarchy.GetNodeByType(type), new MaterialAdjustConfPerType());
             }
         }
@@ -32,7 +38,7 @@ namespace PLATEAU.CityAdjust.MaterialAdjust
         public MaterialAdjustConfPerType GetConfFor(CityObjectType type)
         {
             var typeNode = CityObjectTypeHierarchy.GetNodeByType(type);
-            if (data.TryGetValue(typeNode, out var typeConf))
+            if (typeNode != null && data.TryGetValue(typeNode, out var typeConf))
             {
                 return typeConf;
             }

--- a/Runtime/CityInfo/CityObjectTypeHierarchy.cs
+++ b/Runtime/CityInfo/CityObjectTypeHierarchy.cs
@@ -34,7 +34,13 @@ namespace PLATEAU.CityInfo
                     new Node("接地面 (GroundSurface)", Package.None, new[] { COType.COT_GroundSurface }, null),
                     new Node("開口部 (ClosureSurface)", Package.None, new[] { COType.COT_ClosureSurface }, null),
                     new Node("外側の天井 (OuterCeilingSurface)", Package.None, new[] { COType.COT_OuterCeilingSurface }, null),
-                    new Node("屋根の通行可能部分 (OuterFloorSurface)", Package.None, new[] { COType.COT_OuterFloorSurface }, null)
+                    new Node("屋根の通行可能部分 (OuterFloorSurface)", Package.None, new[] { COType.COT_OuterFloorSurface }, null),
+                    new Node("部屋(Room)", Package.None, new[]{COType.COT_Room}, null),
+                    new Node("天井(CeilingSurface)", Package.None, new[]{COType.COT_CeilingSurface}, null),
+                    new Node("床(FloorSurface)", Package.None, new[]{COType.COT_FloorSurface}, null),
+                    new Node("内装壁(InteriorWallSurface)", Package.None, new[]{COType.COT_InteriorWallSurface}, null),
+                    new Node("内装付属設備(IntBuildingInstallation)", Package.None, new[]{COType.COT_IntBuildingInstallation}, null),
+                    
                 }),
                 new Node("道路 (Road)", Package.Road, new[] { COType.COT_Road }, null),
                 new Node("都市設備 (CityFurniture)", Package.CityFurniture, new[] { COType.COT_CityFurniture }, null),


### PR DESCRIPTION


## 実装内容
- 地物タイプでのマテリアル分けでLOD4建物を対象とするとエラーログが出て処理が止まる問題を修正しました。

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること


