### PR TITLE
x64 macバイナリ追加

### DIFF
--- a/Plugins/MacOS/x86_64/libplateau.dylib
+++ b/Plugins/MacOS/x86_64/libplateau.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:547df9184ef28bef6e46503b17320262e87d757b6172b633dc79ce80d09a3a27
-size 22351464
+oid sha256:693c35f29be96b7a8d1a5c35829eed8b1d18bda6aee4706e3cf2a03014a4abc9
+size 22277084


### PR DESCRIPTION
﻿## 関連リンク
https://github.com/Synesthesias/libplateau/commit/9ea9258902c63acf8649e82965f9e9aa8b1060c7

## 実装内容
- x64 mac向けのバイナリを最新版で差し替え