### PR TITLE
範囲選択画面でギズモ表示がオフのときに「オンにしてください」と警告を出す

### DIFF
--- a/Runtime/CityImport/AreaSelector/AreaSelectorBehaviour.cs
+++ b/Runtime/CityImport/AreaSelector/AreaSelectorBehaviour.cs
@@ -6,7 +6,6 @@ using PLATEAU.CityImport.AreaSelector.Display.Gizmos;
 using PLATEAU.CityImport.AreaSelector.Display.Maps;
 using PLATEAU.CityImport.AreaSelector.Display.Windows;
 using PLATEAU.CityImport.Config;
-using PLATEAU.CityImport.Config.PackageImportConfigs;
 using PLATEAU.Geometries;
 using PLATEAU.Dataset;
 using PLATEAU.Native;
@@ -45,11 +44,11 @@ namespace PLATEAU.CityImport.AreaSelector
         public void Init(string prevScenePathArg, ConfigBeforeAreaSelect confBeforeAreaSelectArg, IAreaSelectResultReceiver areaSelectResultReceiverArg, EditorWindow prevEditorWindowArg)
         {
             IsAreaSelectEnabled = true;
-            this.prevScenePath = prevScenePathArg;
-            this.confBeforeAreaSelect = confBeforeAreaSelectArg;
-            this.areaSelectResultReceiver = areaSelectResultReceiverArg;
-            this.prevSceneCameraRotationLocked = SceneView.lastActiveSceneView.isRotationLocked;
-            this.prevEditorWindow = prevEditorWindowArg;
+            prevScenePath = prevScenePathArg;
+            confBeforeAreaSelect = confBeforeAreaSelectArg;
+            areaSelectResultReceiver = areaSelectResultReceiverArg;
+            prevSceneCameraRotationLocked = SceneView.lastActiveSceneView.isRotationLocked;
+            prevEditorWindow = prevEditorWindowArg;
         }
 #endif
 
@@ -111,7 +110,8 @@ namespace PLATEAU.CityImport.AreaSelector
             RotateSceneViewCameraDown();
 
 #if UNITY_EDITOR
-            this.mapLoader.Update(SceneView.lastActiveSceneView.camera);
+            var sceneView = SceneView.lastActiveSceneView;
+            mapLoader.Update(sceneView.camera);
 #endif
         }
 

--- a/Runtime/CityImport/AreaSelector/AreaSelectorDataPass.cs
+++ b/Runtime/CityImport/AreaSelector/AreaSelectorDataPass.cs
@@ -1,5 +1,4 @@
-﻿using PLATEAU.CityImport.Config;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.SceneManagement;
 
 #if UNITY_EDITOR

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaSelectGizmosDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaSelectGizmosDrawer.cs
@@ -27,6 +27,9 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
         private AreaLodController areaLod;
         private GeoReference geoReference;
         private AreaSelectionGizmoDrawer areaSelectionGizmoDrawer;
+        #if UNITY_EDITOR
+        private readonly GizmoActiveChecker gizmoActiveChecker = new GizmoActiveChecker();
+        #endif
         private bool isShiftButtonPressed;
         private bool isLeftMouseButtonPressed;
         private bool isLeftMouseAndShiftButtonPressed;
@@ -100,6 +103,7 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
 
         protected override void OnSceneGUI(SceneView sceneView)
         {
+            gizmoActiveChecker.CheckAndShow(sceneView);
             UpdateMousePressedStatus();
             
             this.areaLod.Update(GSIMapLoaderZoomSwitch.CalcCameraExtent(sceneView.camera, this.geoReference));

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/GizmoActiveChecker.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/GizmoActiveChecker.cs
@@ -1,0 +1,46 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
+{
+    /// <summary>
+    /// シーンビューの設定でギズモ表示がオフになっているとき、
+    /// オンにしてくださいというメッセージを表示するためのクラスです。
+    /// </summary>
+    public class GizmoActiveChecker
+    {
+        public void CheckAndShow(SceneView sceneView)
+        {
+            if (!IsGizmoActive())
+            {
+                ShowMessage(sceneView);
+            }
+        }
+
+        private bool IsGizmoActive()
+        {
+            SceneView sv =
+                EditorWindow.GetWindow<SceneView>(null, false);
+            return sv.drawGizmos;
+        }
+
+        private void ShowMessage(SceneView sceneView)
+        {
+            Handles.BeginGUI();
+            // Sceneビューの中心にメッセージボックスを配置
+            var style = new GUIStyle(EditorStyles.boldLabel)
+            {
+                normal = { textColor = Color.red, background = Texture2D.whiteTexture },
+                fontSize = 19
+            };
+            var centeredRect = new Rect((sceneView.position.width - 600) / 2, (sceneView.position.height - 120) / 2, 600,
+                120);
+            GUI.Box(centeredRect,
+                "注意：\nギズモ表示がオフです。\n範囲を表示するために、シーンビューのギズモを表示切替ボタンを\nクリックしてオンにしてください。",
+                style);
+            Handles.EndGUI();
+        }
+    }
+}
+#endif

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/GizmoActiveChecker.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/GizmoActiveChecker.cs
@@ -37,7 +37,7 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
             var centeredRect = new Rect((sceneView.position.width - 600) / 2, (sceneView.position.height - 120) / 2, 600,
                 120);
             GUI.Box(centeredRect,
-                "注意：\nギズモ表示がオフです。\n範囲を表示するために、シーンビューのギズモを表示切替ボタンを\nクリックしてオンにしてください。",
+                "注意：\nギズモ表示がオフです。\n範囲を表示するために、シーンビューのギズモ表示切替ボタンを\nクリックしてオンにしてください。",
                 style);
             Handles.EndGUI();
         }

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/GizmoActiveChecker.cs.meta
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/GizmoActiveChecker.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 860436f1b4ae450192b18ddffc53bfc2
+timeCreated: 1713580256


### PR DESCRIPTION
![image](https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/assets/1321932/5bffe2eb-93ce-411e-80be-025020526357)


問い合わせで「範囲が出ません」というお声が多かったため警告追加