### PR TITLE
マテリアル分けで変換後にmissingになるのを変換後自動選択に修正。全て除くボタン、対象をヒエラルキー上で選択ボタンを実装

### DIFF
--- a/Editor/Window/Main/Tab/MaterialAdjustGUI/CityMaterialAdjustGUI.cs
+++ b/Editor/Window/Main/Tab/MaterialAdjustGUI/CityMaterialAdjustGUI.cs
@@ -23,7 +23,19 @@ namespace PLATEAU.Editor.Window.Main.Tab.MaterialAdjustGUI
         
         public MAKeySearcher CurrentSearcher => Guis?.Get<MaterialCriterionGui>()?.CurrentSearcher;
         public MaterialCriterion SelectedCriterion => Guis.Get<MaterialCriterionGui>().SelectedCriterion;
-        public UniqueParentTransformList SelectedObjects => Guis.Get<ObjectSelectGui>().UniqueSelected;
+        public UniqueParentTransformList SelectedObjects
+        {
+            get
+            {
+                return Guis.Get<ObjectSelectGui>().UniqueSelected;
+            }
+            set
+            {
+                Guis.Get<ObjectSelectGui>().UniqueSelected = value;
+            }
+        }
+
+        public bool DoDestroySrcObjs => Guis.Get<DestroyOrPreserveSrcGui>().DoDestroySrcObjs;
 
         /// <summary>
         /// マテリアル分けの選択画面を出すために、利用可能な分類項目を検索したかどうかです。
@@ -98,8 +110,8 @@ namespace PLATEAU.Editor.Window.Main.Tab.MaterialAdjustGUI
         {
             SearchArg searchArg = SelectedCriterion switch
             {
-                MaterialCriterion.ByType => new SearchArg(Guis.Get<ObjectSelectGui>().UniqueSelected),
-                MaterialCriterion.ByAttribute => new SearchArgByArr(Guis.Get<ObjectSelectGui>().UniqueSelected, Guis.Get<AttributeKeyGui>().AttrKey),
+                MaterialCriterion.ByType => new SearchArg(SelectedObjects),
+                MaterialCriterion.ByAttribute => new SearchArgByArr(SelectedObjects, Guis.Get<AttributeKeyGui>().AttrKey),
                 _ => throw new ArgumentOutOfRangeException()
             };
             return searchArg;
@@ -145,17 +157,17 @@ namespace PLATEAU.Editor.Window.Main.Tab.MaterialAdjustGUI
                 
                 MaterialCriterion.ByType => new MAExecutorConf(
                     CurrentSearcher.MaterialAdjustConf,
-                    Guis.Get<ObjectSelectGui>().UniqueSelected,
+                    SelectedObjects,
                     granularity,
-                    Guis.Get<DestroyOrPreserveSrcGui>().DoDestroySrcObjs,
+                    DoDestroySrcObjs,
                     true
                 ),
                     
                 MaterialCriterion.ByAttribute => new MAExecutorConfByAttr(
                     CurrentSearcher.MaterialAdjustConf,
-                    Guis.Get<ObjectSelectGui>().UniqueSelected,
+                    SelectedObjects,
                     granularity,
-                    Guis.Get<DestroyOrPreserveSrcGui>().DoDestroySrcObjs,
+                    DoDestroySrcObjs,
                     true,
                     Guis.Get<AttributeKeyGui>().AttrKey
                 ),
@@ -174,6 +186,17 @@ namespace PLATEAU.Editor.Window.Main.Tab.MaterialAdjustGUI
                 MaterialCriterion.ByAttribute => MAExecutorFactory.CreateAttrExecutor((MAExecutorConfByAttr)executorConf),
                 _ => throw new ArgumentOutOfRangeException()
             };
+        }
+
+        /// <summary>
+        /// 処理が完了したとき
+        /// </summary>
+        public void ReceiveMAResult(UniqueParentTransformList converted)
+        {
+            if (DoDestroySrcObjs)
+            {
+                SelectedObjects = converted;
+            }
         }
     }
 }

--- a/Editor/Window/Main/Tab/MaterialAdjustGUI/Parts/MAExecButton.cs
+++ b/Editor/Window/Main/Tab/MaterialAdjustGUI/Parts/MAExecButton.cs
@@ -1,5 +1,8 @@
 using PLATEAU.Editor.Window.Common;
+using PLATEAU.Util;
 using PLATEAU.Util.Async;
+using System.CodeDom.Compiler;
+using System.Threading.Tasks;
 
 namespace PLATEAU.Editor.Window.Main.Tab.MaterialAdjustGUI.Parts
 {
@@ -19,11 +22,16 @@ namespace PLATEAU.Editor.Window.Main.Tab.MaterialAdjustGUI.Parts
         {
             if (PlateauEditorStyle.MainButton("マテリアル分けを実行"))
             {
-                var executor = adjustGui.GenerateExecutor();
-                
-                // 実行
-                executor.Exec().ContinueWithErrorCatch();
+                Exec().ContinueWithErrorCatch();
             }
+        }
+
+        /// <summary> 実行 </summary>
+        private async Task Exec()
+        {
+            var executor = adjustGui.GenerateExecutor();
+            var result = await executor.Exec();
+            adjustGui.ReceiveMAResult(result);
         }
 
         public override void Dispose()

--- a/Editor/Window/Main/Tab/MaterialAdjustGUI/Parts/ObjectSelectGui.cs
+++ b/Editor/Window/Main/Tab/MaterialAdjustGUI/Parts/ObjectSelectGui.cs
@@ -10,13 +10,24 @@ namespace PLATEAU.Editor.Window.Main.Tab.MaterialAdjustGUI.Parts
 {
     internal class ObjectSelectGui : Element, IPackageSelectResultReceiver
     {
-        private readonly List<GameObject> selectedGameObjs = new();
-        public UniqueParentTransformList UniqueSelected => 
-            new (
-                selectedGameObjs
-                    .Where(obj => obj != null)
-                    .Select(obj => obj.transform)
+        private List<GameObject> selectedGameObjs = new();
+        public UniqueParentTransformList UniqueSelected  {
+            get
+            {
+                return new (
+                    selectedGameObjs
+                        .Where(obj => obj != null)
+                        .Select(obj => obj.transform)
                 );
+            }
+            set
+            {
+                var val = new UniqueParentTransformList(value.Get.Where(tran => tran != null));
+                val.ParentalShift();
+                selectedGameObjs = val.Get.Select(t => t.gameObject).ToList();
+            }
+        }
+            
 
         public bool LockChange { get; set; }
         private readonly EditorWindow parentEditorWindow;
@@ -100,6 +111,18 @@ namespace PLATEAU.Editor.Window.Main.Tab.MaterialAdjustGUI.Parts
                         selectedGameObjs.RemoveAt(indexToDelete);
                     }
                 });// end scrollView
+
+                PlateauEditorStyle.RightAlign(() =>
+                {
+                    if (PlateauEditorStyle.TinyButton("全て除く", 75))
+                    {
+                        selectedGameObjs.Clear();
+                    }
+                    if(PlateauEditorStyle.TinyButton("対象をヒエラルキー上で選択", 150))
+                    {
+                        Selection.objects = selectedGameObjs.Cast<Object>().ToArray();
+                    }
+                });
                 
             }
         }

--- a/Runtime/Util/Async/TaskExtension.cs
+++ b/Runtime/Util/Async/TaskExtension.cs
@@ -19,7 +19,7 @@ namespace PLATEAU.Util.Async
                 }
             });
         }
-
+        
         private static void LogInnerExceptions(AggregateException age)
         {
             var innerExceptions = age.InnerExceptions;


### PR DESCRIPTION
![image](https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/assets/1321932/f95c9f74-0946-4f5b-9c52-36289e5284a7)
