### PR TITLE
道路構造でBorderWaysが消えるバグ修正

### DIFF
--- a/Editor/RoadNetwork/RnEditorUtil.cs
+++ b/Editor/RoadNetwork/RnEditorUtil.cs
@@ -23,7 +23,7 @@ namespace PLATEAU.Editor.RoadNetwork
             return CheckAddTarget<T, T>(targets, addTargetId, out isAdded);
         }
 
-        public static long CheckAddTarget<T, U>(HashSet<T> targets, long addTargetId, out bool isAdded) where T : ARnParts<U>
+        public static long CheckAddTarget<T, U>(HashSet<T> targets, long addTargetId, out bool isAdded) where T : ARnParts<U> where U : ARnParts<U>
         {
             isAdded = false;
             using (new EditorGUILayout.HorizontalScope())

--- a/Editor/RoadNetwork/RnEditorUtil.cs
+++ b/Editor/RoadNetwork/RnEditorUtil.cs
@@ -92,14 +92,17 @@ namespace PLATEAU.Editor.RoadNetwork
         }
 
         /// <summary>
-        /// foldoutObjectsに入っていると展開/そうじゃない場合は折りたたみ
+        /// foldoutObjectsに入っていると展開/そうじゃない場合は折りたたみ.
+        /// obj = nullの場合はlabelをobjとして扱う
         /// </summary>
         /// <param name="label"></param>
         /// <param name="foldoutObjects"></param>
         /// <param name="obj"></param>
         /// <returns></returns>
-        public static bool Foldout(string label, HashSet<object> foldoutObjects, object obj)
+        public static bool Foldout(string label, HashSet<object> foldoutObjects, object obj = null)
         {
+            // objがnullの場合はlabelをobjとして扱う
+            obj ??= label;
             var isNowVisible = foldoutObjects.Contains(obj);
             var isNextVisible = EditorGUILayout.Foldout(isNowVisible, label);
             if (isNowVisible == isNextVisible)

--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -248,9 +248,6 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                                 roadGroup.SetRightLaneCount(p.rightLaneCount);
                             }
                         }
-                        using (new EditorGUILayout.HorizontalScope())
-                        {
-                        }
                         if (GUILayout.Button("Change Both"))
                         {
                             roadGroup.SetLaneCount(p.leftLaneCount, p.rightLaneCount);
@@ -459,10 +456,14 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
             }
         }
 
-        public void Clear()
+        /// <summary>
+        /// 選択/非表示オブジェクトなどの情報を削除する
+        /// </summary>
+        public void ClearPickedObjects()
         {
             if (InstanceHelper == null)
                 return;
+            FoldOuts.Clear();
             InstanceHelper.SelectedObjects?.Clear();
             InstanceHelper.InVisibleObjects?.Clear();
         }
@@ -485,20 +486,9 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
             if (model == null)
                 return;
             var work = new Work();
-            if (GUILayout.Button("Clear"))
+            if (GUILayout.Button("Clear Picked Objects"))
             {
-                Clear();
-            }
-
-            RnEditorUtil.Separator();
-            EditorGUILayout.LabelField("Lane Edit", GUILayout.Height(20));
-
-            //addTargetId = RnEditorUtil.CheckAddTarget(InstanceHelper.TargetLanes, this.addTargetId, out var isAddLane);
-            // 内部でTargetLanesを更新するため、ToListでコピーを取得
-            foreach (var l in InstanceHelper.SelectedObjects.Select(x => x as RnLane).Where(x => x != null).ToList())
-            {
-                RnEditorUtil.Separator();
-                EditLane(l, work);
+                ClearPickedObjects();
             }
 
             bool isAdded;
@@ -510,8 +500,6 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
             }
 
             RnEditorUtil.Separator();
-            EditorGUILayout.LabelField("Road Edit", GUILayout.Height(20));
-
             InstanceHelper.SelectedObjects.RemoveWhere(s =>
             {
                 if (s is RnRoad && model.Roads.Contains(s) == false)
@@ -520,16 +508,20 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                     return true;
                 return false;
             });
-            foreach (var r in model.Roads)
-            {
-                if (addTargetType == AddTargetType.Road && isAdded && r.DebugMyId == (ulong)addTargetId)
-                    InstanceHelper.SelectedObjects.Add(r);
-                if (IsSceneSelected(r) == false && InstanceHelper.SelectedObjects.Contains(r) == false)
-                    continue;
 
-                var foldout = EditorGUILayout.Foldout(FoldOuts.Contains(r), $"Road {r.GetDebugMyIdOrDefault()}");
-                if (foldout)
+            if (RnEditorUtil.Foldout($"Roads[{model.Roads.Count}]", FoldOuts))
+            {
+                using var indent = new EditorGUI.IndentLevelScope();
+                foreach (var r in model.Roads)
                 {
+                    if (addTargetType == AddTargetType.Road && isAdded && r.DebugMyId == (ulong)addTargetId)
+                        InstanceHelper.SelectedObjects.Add(r);
+                    if (IsSceneSelected(r) == false && InstanceHelper.SelectedObjects.Contains(r) == false)
+                        continue;
+
+                    if (RnEditorUtil.Foldout($"Road {r.GetDebugMyIdOrDefault()}", FoldOuts, r) == false)
+                        continue;
+
                     RnEditorUtil.Separator();
                     using (new EditorGUI.IndentLevelScope())
                     {
@@ -537,24 +529,23 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                         EditRoad(r, work);
                     }
                 }
-                else
-                {
-                    FoldOuts.Remove(r);
-                }
-
             }
 
+
             RnEditorUtil.Separator();
-            EditorGUILayout.LabelField("Intersection Edit", GUILayout.Height(20));
-            foreach (var i in model.Intersections)
+            if (RnEditorUtil.Foldout($"Intersections[{model.Intersections.Count}]", FoldOuts))
             {
-                if (addTargetType == AddTargetType.Intersection && isAdded && i.DebugMyId == (ulong)addTargetId)
-                    InstanceHelper.SelectedObjects.Add(i);
-                if (IsSceneSelected(i) == false && InstanceHelper.SelectedObjects.Contains(i) == false)
-                    continue;
-                var foldout = EditorGUILayout.Foldout(FoldOuts.Contains(i), $"InterSection {i.GetDebugMyIdOrDefault()}");
-                if (foldout)
+                using var indent = new EditorGUI.IndentLevelScope();
+                foreach (var i in model.Intersections)
                 {
+                    if (addTargetType == AddTargetType.Intersection && isAdded && i.DebugMyId == (ulong)addTargetId)
+                        InstanceHelper.SelectedObjects.Add(i);
+                    if (IsSceneSelected(i) == false && InstanceHelper.SelectedObjects.Contains(i) == false)
+                        continue;
+
+                    if (RnEditorUtil.Foldout($"InterSection {i.GetDebugMyIdOrDefault()}", FoldOuts, i) == false)
+                        continue;
+
                     RnEditorUtil.Separator();
                     using (new EditorGUI.IndentLevelScope())
                     {
@@ -562,23 +553,20 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                         EditIntersection(i, work);
                     }
                 }
-                else
-                {
-                    FoldOuts.Remove(i);
-                }
             }
 
             RnEditorUtil.Separator();
-            EditorGUILayout.LabelField("Side Walk Edit", GUILayout.Height(20));
-            foreach (var sw in model.SideWalks)
+            if (RnEditorUtil.Foldout($"SideWalks[{model.SideWalks.Count}]", FoldOuts))
             {
-                if (addTargetType == AddTargetType.SideWalk && isAdded && sw.DebugMyId == (ulong)addTargetId)
-                    InstanceHelper.SelectedObjects.Add(sw);
-                if (IsSceneSelected(sw) == false && InstanceHelper.SelectedObjects.Contains(sw) == false)
-                    continue;
-                var foldout = EditorGUILayout.Foldout(FoldOuts.Contains(sw), $"SideWalk {sw.GetDebugMyIdOrDefault()}");
-                if (foldout)
+                using var indent = new EditorGUI.IndentLevelScope();
+                foreach (var sw in model.SideWalks)
                 {
+                    if (addTargetType == AddTargetType.SideWalk && isAdded && sw.DebugMyId == (ulong)addTargetId)
+                        InstanceHelper.SelectedObjects.Add(sw);
+                    if (IsSceneSelected(sw) == false && InstanceHelper.SelectedObjects.Contains(sw) == false)
+                        continue;
+                    if (RnEditorUtil.Foldout($"SideWalk {sw.GetDebugMyIdOrDefault()}", FoldOuts, sw) == false)
+                        continue;
                     RnEditorUtil.Separator();
                     using (new EditorGUI.IndentLevelScope())
                     {
@@ -586,11 +574,43 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                         EditSideWalk(sw, work);
                     }
                 }
-                else
+            }
+
+            // 選択したレーン情報は表示しておく
+            RnEditorUtil.Separator();
+            if (RnEditorUtil.Foldout("Picked Lanes", FoldOuts))
+            {
+                using var indent = new EditorGUI.IndentLevelScope();
+                var pickedLanes = InstanceHelper.SelectedObjects.Select(x => x as RnLane).Where(x => x != null)
+                    .ToList();
+
+                //addTargetId = RnEditorUtil.CheckAddTarget(InstanceHelper.TargetLanes, this.addTargetId, out var isAddLane);
+                // 内部でTargetLanesを更新するため、ToListでコピーを取得
+                foreach (var l in pickedLanes)
                 {
-                    FoldOuts.Remove(sw);
+                    EditLane(l, work);
                 }
             }
+
+            RnEditorUtil.Separator();
+            if (RnEditorUtil.Foldout("Option", FoldOuts))
+            {
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    if (GUILayout.Button("Create Empty Road"))
+                        model.CreateEmptyRoadBetweenInteraction();
+
+                    if (GUILayout.Button("Remove Empty Road"))
+                        model.RemoveEmptyRoadBetweenIntersection();
+
+                    if (GUILayout.Button("Create Empty Intersection"))
+                        model.CreateEmptyIntersectionBetweenRoad();
+
+                    if (GUILayout.Button("Remove Empty Intersection"))
+                        model.RemoveEmptyIntersectionBetweenRoad();
+                }
+            }
+
 
             foreach (var e in work.DelayExec)
                 e.Invoke();

--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -46,6 +46,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
             Road,
             Intersection,
             SideWalk,
+            LineString,
         }
 
         public class Work
@@ -103,9 +104,9 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                     using (new EditorGUI.IndentLevelScope())
                     {
                         var border = lane.GetBorder(type);
-                        EditorGUILayout.LabelField($"BorderWay {border?.GetDebugMyIdOrDefault()}[{border?.LineString?.GetDebugMyIdOrDefault()}]");
-                        EditorGUILayout.LabelField($"Connect Lanes [{lane.GetConnectedLanes(type).Select(l => l.DebugMyId).Join2String()}]");
-                        EditorGUILayout.LabelField($"Connect Roads [{lane.GetConnectedRoads(type).Select(l => l.DebugMyId).Join2String()}]");
+                        EditorGUILayout.LabelField($"BorderWay {border?.GetDebugIdLabelOrDefault()}");
+                        EditorGUILayout.LabelField($"Connect Lanes [{lane.GetConnectedLanes(type).Select(l => l.GetDebugLabelOrDefault()).Join2String()}]");
+                        EditorGUILayout.LabelField($"Connect Roads [{lane.GetConnectedRoads(type).Select(l => l.GetDebugLabelOrDefault()).Join2String()}]");
                     }
                 }
 
@@ -116,8 +117,8 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
 
                 using (new EditorGUILayout.HorizontalScope())
                 {
-                    EditorGUILayout.LongField($"Left Way", lane.LeftWay.GetDebugMyIdOrDefault());
-                    EditorGUILayout.LongField($"Right Way", lane.RightWay.GetDebugMyIdOrDefault());
+                    EditorGUILayout.LabelField($"Left Way {lane.LeftWay.GetDebugIdLabelOrDefault()}");
+                    EditorGUILayout.LabelField($"Right Way {lane.RightWay.GetDebugIdLabelOrDefault()}");
                 }
             }
 
@@ -465,6 +466,18 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                 addTargetType = (AddTargetType)EditorGUILayout.EnumPopup("AddTargetType", addTargetType);
                 addTargetId = EditorGUILayout.LongField("AddTarget", addTargetId);
                 isAdded = GUILayout.Button("+");
+            }
+
+            if (isAdded)
+            {
+                if (addTargetType == AddTargetType.LineString)
+                {
+                    var ls = model.CollectAllLineStrings()
+                        .FirstOrDefault(ls => ls != null && ls.DebugMyId == (ulong)addTargetId);
+                    if (ls != null)
+                        InstanceHelper.SelectedObjects.Add(ls);
+                }
+
             }
 
             RnEditorUtil.Separator();

--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -416,7 +416,14 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                     {
                         using (new EditorGUILayout.HorizontalScope())
                         {
-                            EditorGUILayout.LabelField($"Track[{track.GetDebugMyIdOrDefault()}] : From:{track.FromBorder.GetDebugMyIdOrDefault()} -> To:{track.ToBorder.GetDebugMyIdOrDefault()}");
+                            void ShowLabel(string label, RnNeighbor edge)
+                            {
+                                var lane = edge.GetConnectedLane();
+                                EditorGUILayout.LabelField($"{label}:{edge.Border.GetDebugIdLabelOrDefault()}/{edge?.Road?.GetDebugLabelOrDefault()}]/{lane.GetDebugLabelOrDefault()}");
+                            }
+                            EditorGUILayout.LabelField($"Track[{track.GetDebugLabelOrDefault()}]");
+                            ShowLabel("From", intersection.FindEdges(track.FromBorder).FirstOrDefault());
+                            ShowLabel("To", intersection.FindEdges(track.ToBorder).FirstOrDefault());
                             track.TurnType = (RnTurnType)EditorGUILayout.EnumPopup("TurnType", track.TurnType);
                         }
                     }

--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -215,65 +215,9 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
             ShowBase(road);
             using (new EditorGUI.DisabledScope(false))
             {
-                using (new EditorGUILayout.HorizontalScope())
-                {
-                    EditorGUILayout.LongField("Prev", (long)(road.Prev?.DebugMyId ?? ulong.MaxValue));
-                    EditorGUILayout.LongField("Next", (long)(road.Next?.DebugMyId ?? ulong.MaxValue));
-                    EditorGUILayout.LabelField($"LaneCount L({road.GetLeftLaneCount()})-R({road.GetRightLaneCount()})");
-                }
-
-            }
-
-            var roadGroup = road.CreateRoadGroupOrDefault();
-            if (roadGroup != null)
-            {
-                using (new EditorGUILayout.VerticalScope())
-                {
-                    EditorGUILayout.LabelField("LaneCount");
-                    using (new EditorGUI.IndentLevelScope())
-                    {
-                        using (new EditorGUILayout.HorizontalScope())
-                        {
-                            EditorGUILayout.LabelField($"L({roadGroup.GetLeftLaneCount()})->", GUILayout.Width(80));
-                            p.leftLaneCount = EditorGUILayout.IntField("", p.leftLaneCount, GUILayout.Width(80));
-                            if (GUILayout.Button("Change"))
-                            {
-                                roadGroup.SetLeftLaneCount(p.leftLaneCount);
-                            }
-                            EditorGUILayout.LabelField($"R({roadGroup.GetRightLaneCount()})->", GUILayout.Width(80));
-                            p.rightLaneCount = EditorGUILayout.IntField(p.rightLaneCount, GUILayout.Width(80));
-                            if (GUILayout.Button("Change"))
-                            {
-                                roadGroup.SetRightLaneCount(p.rightLaneCount);
-                            }
-                        }
-                        if (GUILayout.Button("Change Both"))
-                        {
-                            roadGroup.SetLaneCount(p.leftLaneCount, p.rightLaneCount);
-                        }
-                    }
-                }
-
-                if (GUILayout.Button("Align"))
-                {
-                    roadGroup.Align();
-                }
-
-                using (new EditorGUILayout.HorizontalScope())
-                {
-                    p.medianWidth = EditorGUILayout.FloatField("MedianWidth", p.medianWidth);
-                    p.medianWidthOption = (LaneWayMoveOption)EditorGUILayout.EnumPopup("MoveOption", p.medianWidthOption);
-                    if (GUILayout.Button("SetMedianWidth"))
-                    {
-                        roadGroup.SetMedianWidth(p.medianWidth, p.medianWidthOption);
-                    }
-
-                    if (GUILayout.Button("RemoveMedian"))
-                    {
-                        roadGroup.RemoveMedian(p.medianWidthOption);
-                    }
-                }
-
+                using var _ = (new EditorGUILayout.HorizontalScope());
+                EditorGUILayout.LabelField($"Prev: {road.Prev.GetDebugLabelOrDefault()} | Next: {road.Next.GetDebugLabelOrDefault()}");
+                EditorGUILayout.LabelField($"LaneCount L({road.GetLeftLaneCount()})-R({road.GetRightLaneCount()})");
             }
 
             RnEditorUtil.Separator();
@@ -309,6 +253,50 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                 }
             }
 
+            var roadGroup = road.CreateRoadGroupOrDefault();
+            if (RnEditorUtil.Foldout("RoadGroupOption", p.Foldouts, ("RoadGroupOption", road)))
+            {
+                if (GUILayout.Button("Align"))
+                {
+                    roadGroup.Align();
+                }
+
+                EditorGUILayout.LabelField($"LaneCount");
+                using (new EditorGUI.IndentLevelScope())
+                {
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        p.leftLaneCount = EditorGUILayout.IntField($"Left({roadGroup.GetLeftLaneCount()}) ->", roadGroup.GetLeftLaneCount());
+                        if (GUILayout.Button("Change Left"))
+                            work.DelayExec.Add(() => roadGroup.SetLeftLaneCount(p.leftLaneCount));
+                    }
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        p.rightLaneCount = EditorGUILayout.IntField($"Right({roadGroup.GetRightLaneCount()}) -> ", p.rightLaneCount);
+                        if (GUILayout.Button("Change Right"))
+                            work.DelayExec.Add(() => roadGroup.SetRightLaneCount(p.rightLaneCount));
+                    }
+                    if (GUILayout.Button("Change Both"))
+                    {
+                        roadGroup.SetLaneCount(p.leftLaneCount, p.rightLaneCount);
+                    }
+                }
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    p.medianWidth = EditorGUILayout.FloatField("MedianWidth", p.medianWidth);
+                    p.medianWidthOption = (LaneWayMoveOption)EditorGUILayout.EnumPopup("MoveOption", p.medianWidthOption);
+                    if (GUILayout.Button("SetMedianWidth"))
+                    {
+                        roadGroup.SetMedianWidth(p.medianWidth, p.medianWidthOption);
+                    }
+
+                    if (GUILayout.Button("RemoveMedian"))
+                    {
+                        roadGroup.RemoveMedian(p.medianWidthOption);
+                    }
+                }
+
+            }
             if (RnEditorUtil.Foldout("Option", p.Foldouts, ("Option", road)))
             {
                 using var indent = new EditorGUI.IndentLevelScope();
@@ -542,7 +530,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                         InstanceHelper.SelectedObjects.Add(sw);
                     if (IsSceneSelected(sw) == false && InstanceHelper.SelectedObjects.Contains(sw) == false)
                         continue;
-                    if (RnEditorUtil.Foldout($"SideWalk {sw.GetDebugMyIdOrDefault()}", FoldOuts, sw) == false)
+                    if (RnEditorUtil.Foldout($"{sw.GetDebugLabelOrDefault()}", FoldOuts, sw) == false)
                         continue;
                     RnEditorUtil.Separator();
                     using (new EditorGUI.IndentLevelScope())

--- a/Editor/RoadNetwork/Tester/PLATEAURoadNetworkTesterEditor.cs
+++ b/Editor/RoadNetwork/Tester/PLATEAURoadNetworkTesterEditor.cs
@@ -19,31 +19,10 @@ namespace PLATEAU.Editor.RoadNetwork.Tester
             if (!obj)
                 return;
 
-
             base.OnInspectorGUI();
             if (GUILayout.Button("Create"))
                 obj.CreateNetwork().ContinueWithErrorCatch();
 
-            using (new EditorGUILayout.HorizontalScope())
-            {
-                var model = obj.GetComponent<PLATEAURnStructureModel>();
-                if (model && model.RoadNetwork != null)
-                {
-                    if (GUILayout.Button("Create Empty Road"))
-                        model.RoadNetwork.CreateEmptyRoadBetweenInteraction();
-
-                    if (GUILayout.Button("Remove Empty Road"))
-                        model.RoadNetwork.RemoveEmptyRoadBetweenIntersection();
-                }
-                if (model && model.RoadNetwork != null)
-                {
-                    if (GUILayout.Button("Create Empty Intersection"))
-                        model.RoadNetwork.CreateEmptyIntersectionBetweenRoad();
-
-                    if (GUILayout.Button("Remove Empty Intersection"))
-                        model.RoadNetwork.RemoveEmptyIntersectionBetweenRoad();
-                }
-            }
             if (GUILayout.Button("Check Lod"))
                 obj.RemoveSameNameCityObjectGroup();
 

--- a/Runtime/RoadNetwork/ARnParts.cs
+++ b/Runtime/RoadNetwork/ARnParts.cs
@@ -1,5 +1,7 @@
 ﻿using PLATEAU.RoadNetwork.Structure;
+using PLATEAU.Util;
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace PLATEAU.RoadNetwork
@@ -20,6 +22,21 @@ namespace PLATEAU.RoadNetwork
 
     public static class ARnPartsEx
     {
+        private static readonly Dictionary<Type, string> s_debugIdPrefix = new()
+        {
+            [typeof(RnRoadBase)] = "Rb",
+            [typeof(RnIntersection)] = "In",
+            [typeof(RnRoad)] = "Rd",
+            [typeof(RnWay)] = "W",
+            [typeof(RnLane)] = "Ln",
+            [typeof(RnLineString)] = "Ls",
+            [typeof(RnPoint)] = "Pt",
+            [typeof(RnNeighbor)] = "Nb",
+            [typeof(RnTrack)] = "Tr",
+            [typeof(RnSideWalk)] = "Sw",
+            [typeof(RnBorder)] = "Bd",
+        };
+
         /// <summary>
         /// self.DebugMyIdをlong型で取得. nullの場合は-1を返す
         /// </summary>
@@ -32,6 +49,7 @@ namespace PLATEAU.RoadNetwork
                 return -1;
             return (long)self.DebugMyId;
         }
+
 
         /// <summary>
         /// self.DebugMyIdをlong型で取得. nullの場合は-1を返す
@@ -76,6 +94,32 @@ namespace PLATEAU.RoadNetwork
         public static long GetDebugMyIdOrDefault(this RnWay self)
         {
             return self?.LineString?.GetDebugMyIdOrDefault() ?? -1;
+        }
+
+        /// <summary>
+        /// DebugIdにパーツタイプを表すプレフィックスを付与して返す
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="self"></param>
+        /// <param name="prefix"></param>
+        /// <returns></returns>
+        public static string GetDebugLabelOrDefault<T>(this T self, string prefix = null) where T : ARnParts<T>
+        {
+            if (self == null)
+                return "null";
+            if (prefix.IsNullOrEmpty() && s_debugIdPrefix.TryGetValue(self.GetType(), out prefix))
+                return $"{prefix}[{self.DebugMyId}]";
+            return self.DebugMyId.ToString();
+        }
+
+        /// <summary>
+        /// Wayは内部のLineStringで比較することが多いのでIdもそっちを使う
+        /// </summary>
+        /// <param name="self"></param>
+        /// <returns></returns>
+        public static string GetDebugIdLabelOrDefault(this RnWay self)
+        {
+            return self.LineString.GetDebugLabelOrDefault("W");
         }
     }
 }

--- a/Runtime/RoadNetwork/ARnParts.cs
+++ b/Runtime/RoadNetwork/ARnParts.cs
@@ -7,16 +7,27 @@ using UnityEngine;
 namespace PLATEAU.RoadNetwork
 {
     [Serializable]
-    public abstract class ARnParts<TSelf>
+    public abstract class ARnPartsBase
     {
-        private static ulong counter = 0;
-        [SerializeField] private ulong debugId;
+        [SerializeField]
+        private ulong debugId;
 
         public ulong DebugMyId => debugId;
 
-        protected ARnParts()
+        protected ARnPartsBase(ulong id)
         {
-            debugId = counter++;
+            debugId = id;
+        }
+    }
+
+    [Serializable]
+    public abstract class ARnParts<TSelf> : ARnPartsBase where TSelf : ARnParts<TSelf>
+    {
+        private static ulong counter = 0;
+
+        protected ARnParts()
+        : base(counter++)
+        {
         }
     }
 
@@ -43,47 +54,11 @@ namespace PLATEAU.RoadNetwork
         /// <typeparam name="T"></typeparam>
         /// <param name="self"></param>
         /// <returns></returns>
-        public static long GetDebugMyIdOrDefault<T>(this T self) where T : ARnParts<T>
+        public static long GetDebugMyIdOrDefault(this ARnPartsBase self)
         {
             if (self == null)
                 return -1;
             return (long)self.DebugMyId;
-        }
-
-
-        /// <summary>
-        /// self.DebugMyIdをlong型で取得. nullの場合は-1を返す
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="self"></param>
-        /// <returns></returns>
-        public static long GetDebugMyIdOrDefault<T>(this ARnParts<T> self)
-        {
-            if (self == null)
-                return -1;
-            return (long)self.DebugMyId;
-        }
-
-        /// <summary>
-        /// self.DebugMyIdをlong型で取得. nullの場合は-1を返す
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="self"></param>
-        /// <returns></returns>
-        public static long GetDebugMyIdOrDefault(this RnRoad self)
-        {
-            return self.GetDebugMyIdOrDefault<RnRoadBase>();
-        }
-
-        /// <summary>
-        /// self.DebugMyIdをlong型で取得. nullの場合は-1を返す
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="self"></param>
-        /// <returns></returns>
-        public static long GetDebugMyIdOrDefault(this RnIntersection self)
-        {
-            return self.GetDebugMyIdOrDefault<RnRoadBase>();
         }
 
         /// <summary>
@@ -103,13 +78,13 @@ namespace PLATEAU.RoadNetwork
         /// <param name="self"></param>
         /// <param name="prefix"></param>
         /// <returns></returns>
-        public static string GetDebugLabelOrDefault<T>(this T self, string prefix = null) where T : ARnParts<T>
+        public static string GetDebugLabelOrDefault(this ARnPartsBase self, string prefix = null)
         {
             if (self == null)
                 return "null";
-            if (prefix.IsNullOrEmpty() && s_debugIdPrefix.TryGetValue(self.GetType(), out prefix))
-                return $"{prefix}[{self.DebugMyId}]";
-            return self.DebugMyId.ToString();
+            if (prefix.IsNullOrEmpty())
+                s_debugIdPrefix.TryGetValue(self.GetType(), out prefix);
+            return $"{prefix}[{self.DebugMyId}]";
         }
 
         /// <summary>
@@ -119,7 +94,7 @@ namespace PLATEAU.RoadNetwork
         /// <returns></returns>
         public static string GetDebugIdLabelOrDefault(this RnWay self)
         {
-            return self.LineString.GetDebugLabelOrDefault("W");
+            return self.LineString.GetDebugLabelOrDefault();
         }
     }
 }

--- a/Runtime/RoadNetwork/Data/RnDataWay.cs
+++ b/Runtime/RoadNetwork/Data/RnDataWay.cs
@@ -22,5 +22,14 @@ namespace PLATEAU.RoadNetwork.Data
         [RoadNetworkSerializeMember(nameof(RnWay.LineString))]
         public RnID<RnDataLineString> LineString { get; set; }
 
+        /// <summary>
+        /// 同じ線分かどうか(向きや法線の逆転は考慮しない)
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public bool IsSameLine(RnDataWay other)
+        {
+            return LineString.IsValid && LineString == other.LineString;
+        }
     }
 }

--- a/Runtime/RoadNetwork/Data/RnID.cs
+++ b/Runtime/RoadNetwork/Data/RnID.cs
@@ -15,7 +15,7 @@ namespace PLATEAU.RoadNetwork.Data
         // PropertyDrawerでアクセスするため
         public const string IdFieldName = nameof(id);
 
-        public readonly static RnID<TPrimDataType> Undefind = new RnID<TPrimDataType> { id = -1 };
+        public static readonly RnID<TPrimDataType> Undefined = new RnID<TPrimDataType> { id = -1 };
 
         // Listのindexアクセスがintなのでuintじゃなくてintにしておく
         // structなので初期値は基本0. その時に不正値扱いにするために0は不正値とする
@@ -32,5 +32,13 @@ namespace PLATEAU.RoadNetwork.Data
             this.id = id + 1;
         }
 
+        public static bool operator ==(RnID<TPrimDataType> a, RnID<TPrimDataType> b)
+        {
+            return a.id == b.id;
+        }
+        public static bool operator !=(RnID<TPrimDataType> a, RnID<TPrimDataType> b)
+        {
+            return !(a == b);
+        }
     }
 }

--- a/Runtime/RoadNetwork/Data/RoadNetworkSerializer.cs
+++ b/Runtime/RoadNetwork/Data/RoadNetworkSerializer.cs
@@ -143,7 +143,7 @@ namespace PLATEAU.RoadNetwork.Data
             {
                 if (val == null)
                 {
-                    return RnID<TData>.Undefind;
+                    return RnID<TData>.Undefined;
                 }
 
                 if (Table.ContainsKey(val) == false)

--- a/Runtime/RoadNetwork/Graph/Drawer/PLATEAURGraphDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Graph/Drawer/PLATEAURGraphDrawerDebug.cs
@@ -56,6 +56,8 @@ namespace PLATEAU.RoadNetwork.Graph.Drawer
         public class EdgeOption : DrawOption
         {
             public bool useAnyFaceVertexColor = false;
+            // 辺が属するFaceの数を表示する
+            public bool showNeighborCount = false;
         }
         public EdgeOption edgeOption = new EdgeOption();
 
@@ -241,6 +243,11 @@ namespace PLATEAU.RoadNetwork.Graph.Drawer
                 DrawLine(edge.V0.Position, edge.V1.Position, color);
                 if (showId.HasFlag(RPartsFlag.Edge))
                     DrawString($"[{edge.DebugMyId}]", (edge.V0.Position + edge.V1.Position) / 2);
+
+                if (op.showNeighborCount)
+                {
+                    DrawString($"{edge.Faces.Count}", (edge.V0.Position + edge.V1.Position) / 2);
+                }
             }
 
             Draw(vertexOption, edge.V0, work);

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -706,12 +706,11 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
                             track.Spline.Evaluate(i0 / (n - 1), out var v0, out var _, out var _);
                             track.Spline.Evaluate(i1 / (n - 1), out var v1, out var _, out var _);
                             var v = Vector3.Lerp(v0, v1, 1f - (p - i0));
-                            var s = e.Road is RnRoad ? "R" : "I";
                             var c = e.Road is RnRoad ? Color.green : Color.red;
                             DebugEx.DrawRegularPolygon(v, 0.5f, color: c);
                         }
 
-                        Draw(0.5f, intersection.FindEdges(track.ToBorder).FirstOrDefault());
+                        Draw(0.5f, intersection.FindEdges(track.FromBorder).FirstOrDefault());
                         Draw(n - 1.5f, intersection.FindEdges(track.ToBorder).FirstOrDefault());
                     }
                 }

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -346,6 +346,12 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
                 }
             }
 
+            if (showPartsType.HasFlag(RnPartsTypeMask.Way))
+            {
+                way.GetLerpPoint(0.5f, out var p);
+                DebugEx.DrawString($"P[{way.DebugMyId}]", p);
+            }
+
             foreach (var p in way.Points)
             {
                 DrawPoint(p);

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -154,6 +154,7 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
             public float validWayAlpha = 0.75f;
             public float invalidWayAlpha = 0.3f;
             public bool showAttrText = false;
+            public float reverseWayAlpha = 1f;
             public DrawOption showLeftWay = new DrawOption(true, Color.red);
             public DrawOption showRightWay = new DrawOption(true, Color.blue);
             // 境界線を表示する
@@ -167,6 +168,8 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
             /// <returns></returns>
             public float GetLaneAlpha(RnLane self)
             {
+                if (self.IsReverse)
+                    return reverseWayAlpha;
                 if (self.IsBothConnectedLane)
                     return bothConnectedLaneAlpha;
                 if (self.IsValidWay)
@@ -449,6 +452,11 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
                         DebugEx.DrawString($"[{lane.DebugMyId}]next={type.ToString()}", lane.NextBorder.Points.Last() + offset, Vector2.up * 100);
                     DrawWay(lane.NextBorder, color: op.showNextBorder.color);
                 }
+            }
+
+            if (lane.NextBorder != null && lane.PrevBorder != null && lane.NextBorder.IsSameLine(lane.PrevBorder))
+            {
+                DebugEx.DrawString($"Invalid Border Lane ", lane.GetCenter());
             }
 
             if (showSplitLane && lane.HasBothBorder)
@@ -771,6 +779,11 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
                 else if (x is RnSideWalk sw)
                 {
                     DrawSideWalk(sw, sideWalkRoadOp);
+                }
+                else if (x is RnLineString ls)
+                {
+                    DrawArrows(ls.Points.Select(p => p.Vertex), false, color: wayOp.normalWayArrowColor, arrowSize: wayOp.arrowSize);
+
                 }
             }
 

--- a/Runtime/RoadNetwork/Structure/RnLane.cs
+++ b/Runtime/RoadNetwork/Structure/RnLane.cs
@@ -142,6 +142,17 @@ namespace PLATEAU.RoadNetwork.Structure
         }
 
         /// <summary>
+        /// Border/Side両方合わせた全てのWayを返す
+        /// </summary>
+        public IEnumerable<RnWay> AllWays
+        {
+            get
+            {
+                return BothWays.Concat(AllBorders);
+            }
+        }
+
+        /// <summary>
         /// 有効なレーンかどうか
         /// Left/Rightどっちも有効ならtrue
         /// </summary>

--- a/Runtime/RoadNetwork/Structure/RnLineString.cs
+++ b/Runtime/RoadNetwork/Structure/RnLineString.cs
@@ -338,7 +338,6 @@ namespace PLATEAU.RoadNetwork.Structure
         /// </summary>
         /// <param name="x"></param>
         /// <param name="y"></param>
-        /// <param name="shallowEqual"></param>
         /// <returns></returns>
         public static bool Equals(RnLineString x, RnLineString y)
         {

--- a/Runtime/RoadNetwork/Structure/RnModel.cs
+++ b/Runtime/RoadNetwork/Structure/RnModel.cs
@@ -99,16 +99,29 @@ namespace PLATEAU.RoadNetwork.Structure
             return Roads.SelectMany(l => l.AllLanesWithMedian);
         }
 
+        public IEnumerable<RnNeighbor> CollectAllEdges()
+        {
+            return Intersections.SelectMany(i => i.Edges);
+        }
+
         /// <summary>
         /// Intersection/RoadのWayを全て取得
         /// </summary>
         /// <returns></returns>
         public IEnumerable<RnWay> CollectAllWays()
         {
-            return CollectAllLanes().SelectMany(l => l.AllBorders.Concat(l.BothWays)).Distinct();
+            // #TODO : 実際はもっとある
+            return CollectAllLanes()
+                .SelectMany(l => l.AllWays)
+                .Concat(CollectAllEdges().Select(e => e.Border))
+                .Concat(SideWalks.SelectMany(sw => sw.AllWays))
+                .Distinct();
         }
 
-        // #TODO : 実際はもっとある
+        /// <summary>
+        /// Modelが所持する全てのLineStringを取得
+        /// </summary>
+        /// <returns></returns>
         public IEnumerable<RnLineString> CollectAllLineStrings()
         {
             return CollectAllWays().Select(w => w.LineString).Distinct();
@@ -456,9 +469,9 @@ namespace PLATEAU.RoadNetwork.Structure
                     var rightLaneCount = num - leftLaneCount;
                     linkGroup.SetLaneCount(leftLaneCount, rightLaneCount);
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
-                    //Debug.LogException(e);
+                    Debug.LogException(e);
                     failedRoads.Add(link.DebugMyId);
                 }
             }

--- a/Runtime/RoadNetwork/Structure/RnRoad.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoad.cs
@@ -68,17 +68,21 @@ namespace PLATEAU.RoadNetwork.Structure
         {
             get
             {
-                foreach (var lane in GetLeftLanes())
+                // このイテレータを回している途中でlane.IsReversedが変わると困るので
+                // 最初にカウントを取ってからにする
+                // mainLanesの前半がIsLeftLane, 後半がIsRightLaneである前提の挙動
+                var leftLaneCount = GetLeftLaneCount();
+                for (var i = 0; i < leftLaneCount; ++i)
                 {
-                    yield return lane;
+                    yield return mainLanes[i];
                 }
 
                 if (MedianLane != null)
                     yield return MedianLane;
 
-                foreach (var lane in GetRightLanes())
+                for (var i = leftLaneCount; i < mainLanes.Count; ++i)
                 {
-                    yield return lane;
+                    yield return mainLanes[i];
                 }
             }
         }
@@ -386,7 +390,8 @@ namespace PLATEAU.RoadNetwork.Structure
         }
 
         /// <summary>
-        /// 逆転する
+        /// Next,Prevを逆転する.
+        /// その結果, レーンのIsReverseも逆転/mainLanesの配列順も逆転する
         /// </summary>
         public void Reverse()
         {

--- a/Runtime/RoadNetwork/Structure/RnRoad.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoad.cs
@@ -29,10 +29,10 @@ namespace PLATEAU.RoadNetwork.Structure
         // 対象のtranオブジェクト
         public PLATEAUCityObjectGroup TargetTran { get; set; }
 
-        // 接続先
+        // 接続先(nullの場合は接続なし)
         public RnRoadBase Next { get; private set; }
 
-        // 接続元
+        // 接続元(nullの場合は接続なし)
         public RnRoadBase Prev { get; private set; }
 
         // レーンリスト
@@ -61,7 +61,8 @@ namespace PLATEAU.RoadNetwork.Structure
         public IEnumerable<RnLane> AllLanes => MainLanes;
 
         /// <summary>
-        /// 中央分離帯を含めた全てのレーン
+        /// 中央分離帯を含めた全てのレーン。
+        /// 左車線 -> 中央分離帯 -> 右車線の順番になっている
         /// </summary>
         public IEnumerable<RnLane> AllLanesWithMedian
         {
@@ -214,7 +215,6 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <returns></returns>
         public int GetLeftLaneCount()
         {
-            //return lane.GetNextRoad() == Next;
             return GetLeftLanes().Count();
         }
 
@@ -224,7 +224,6 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <returns></returns>
         public int GetRightLaneCount()
         {
-            //return lane.GetNextRoad() == Prev;
             return GetRightLanes().Count();
         }
 
@@ -294,14 +293,8 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <returns></returns>
         public IEnumerable<RnWay> GetBorderWays(RnLaneBorderType type, bool includeMedian = true)
         {
-            // 左側
-            var lanes = MainLanes.TakeWhile(IsLeftLane);
-            // 中央分離帯
-            lanes = lanes.Concat(Enumerable.Repeat(MedianLane, MedianLane == null ? 0 : 1));
-            // 右側
-            lanes = lanes.Concat(MainLanes.SkipWhile(IsLeftLane));
-
-            foreach (var l in lanes)
+            // 左 -> 中央分離帯 -> 右の順番
+            foreach (var l in AllLanesWithMedian)
             {
                 var laneBorderType = type;
                 var laneBorderDir = RnLaneBorderDir.Left2Right;
@@ -398,8 +391,12 @@ namespace PLATEAU.RoadNetwork.Structure
         public void Reverse()
         {
             (Next, Prev) = (Prev, Next);
-            foreach (var lane in mainLanes)
-                lane.Reverse();
+
+            // 親の向きが変わるので,レーンの親に対する向きも変わる
+            // 各レーンのWayの向きは変えずにIsRevereだけ変える
+            // 左車線/右車線の関係が変わるので配列の並びも逆にする
+            foreach (var lane in AllLanesWithMedian)
+                lane.IsReverse = !lane.IsReverse;
             mainLanes.Reverse();
         }
 

--- a/Runtime/RoadNetwork/Structure/RnSideWalk.cs
+++ b/Runtime/RoadNetwork/Structure/RnSideWalk.cs
@@ -81,6 +81,11 @@ namespace PLATEAU.RoadNetwork.Structure
         }
 
         /// <summary>
+        /// 全てのWay
+        /// </summary>
+        public IEnumerable<RnWay> AllWays => SideWays.Concat(EdgeWays);
+
+        /// <summary>
         /// Inside/OutsideのWayが両方ともValidかどうか. (Edgeは角の道だとnullの場合もあり得るのでチェックしない)
         /// </summary>
         public bool IsValid => InsideWay.IsValidOrDefault() && OutsideWay.IsValidOrDefault();

--- a/Runtime/Util/DebugEx.cs
+++ b/Runtime/Util/DebugEx.cs
@@ -382,6 +382,15 @@ namespace PLATEAU.Util
             }
             return v;
         }
+
+        /// <summary>
+        /// 球を描画する
+        /// </summary>
+        /// <param name="pos"></param>
+        /// <param name="radius"></param>
+        /// <param name="color"></param>
+        /// <param name="duration"></param>
+        /// <param name="depthTest"></param>
         public static void DrawSphere(Vector3 pos, float radius, Color? color = null, float duration = 0f, bool depthTest = true)
         {
             Vector4[] v = s_unitSphere;
@@ -400,6 +409,36 @@ namespace PLATEAU.Util
                 DrawLine(sX, eX, col, duration, depthTest);
                 DrawLine(sY, eY, col, duration, depthTest);
                 DrawLine(sZ, eZ, col, duration, depthTest);
+            }
+        }
+
+        /// <summary>
+        /// 円を描画
+        /// </summary>
+        /// <param name="pos"></param>
+        /// <param name="radius"></param>
+        /// <param name="polygon">多角形のサイズ</param>
+        /// <param name="up"></param>
+        /// <param name="color"></param>
+        /// <param name="duration"></param>
+        /// <param name="depthTest"></param>
+        public static void DrawRegularPolygon(Vector3 pos, float radius, int polygon = 5, Vector3? up = null,
+            Color? color = null, float duration = 0f, bool depthTest = true)
+        {
+            up ??= Vector3.up;
+            var rot = Quaternion.AngleAxis(360f / polygon, up.Value);
+
+            var d = Vector3.right;
+            if (Vector3.Dot(d, up.Value) == 0f)
+                d = Vector3.forward;
+
+            d = Vector3.Cross(d, up.Value).normalized;
+            var p0 = radius * d;
+            for (var i = 0; i < polygon; ++i)
+            {
+                var p1 = rot * p0;
+                DebugEx.DrawLine(p0 + pos, p1 + pos, color, duration, depthTest);
+                p0 = p1;
             }
         }
 
@@ -510,6 +549,26 @@ namespace PLATEAU.Util
             Debug.Log(message);
         }
 
+        /// <summary>
+        /// Debug.LogWarningのラッパー. 後で切れるように
+        /// </summary>
+        /// <param name="message"></param>
+        [Conditional("UNITY_EDITOR")]
+        public static void LogWarning(object message)
+        {
+            Debug.LogWarning(message);
+        }
+
+
+        /// <summary>
+        /// Debug.LogExceptionのラッパー. 後で切れるように
+        /// </summary>
+        /// <param name="e"></param>
+        [Conditional("UNITY_EDITOR")]
+        public static void LogException(Exception e)
+        {
+            Debug.LogException(e);
+        }
         /// <summary>
         /// Debug.LogErrorのラッパー. 後で切れるように
         /// </summary>


### PR DESCRIPTION
fix : RoadGroup.Alignで0番目のRoadが整列されないバグ修正. Road.Reverseを呼んだ時に意味がずれる(左車線から順に格納されるようにならない)バグ修正

﻿## 関連リンク
https://synesthesias.atlassian.net/browse/PLTSDK3-289

## 実装内容
RnRoad.Reverse/RnRoadGroup.Alignでレーンの接続関係がずれるようになっていたので修正.
デバッグエディタウィンドウのレイアウト調整 & Trackなどの情報を細かに見るように

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
https://synesthesias.slack.com/archives/C0261M64C15/p1728462516670109
で道路ネットワークを生成してみて正しくボーダーが生成されているか確認する

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
