### PR TITLE
update : RnSideWalkにLaneTypeを追加. 手動編集専用のデータ( 道路の右側/左側のどっちかを表す. 交差点だと意…

### DIFF
--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -425,6 +425,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
             using (new EditorGUI.DisabledScope(false))
             {
                 EditorGUILayout.LabelField($"ParentRoad:{sideWalk.ParentRoad.GetDebugMyIdOrDefault()}");
+                EditorGUILayout.EnumPopup("LaneType", sideWalk.LaneType);
             }
         }
 

--- a/Runtime/RoadNetwork/Data/RnDataSideWalk.cs
+++ b/Runtime/RoadNetwork/Data/RnDataSideWalk.cs
@@ -30,5 +30,9 @@ namespace PLATEAU.RoadNetwork.Data
         [field: SerializeField]
         [RoadNetworkSerializeMember("endEdgeWay")]
         public RnID<RnDataWay> EndEdgeWay { get; set; }
+
+        [field: SerializeField]
+        [RoadNetworkSerializeMember("laneType")]
+        public RnSideWalkLaneType LaneType { get; set; }
     }
 }

--- a/Runtime/RoadNetwork/Factory/RoadNetworkFactory.cs
+++ b/Runtime/RoadNetwork/Factory/RoadNetworkFactory.cs
@@ -665,7 +665,9 @@ namespace PLATEAU.RoadNetwork.Factory
                                 {
                                     // #NOTE : 自動生成の段階だと線分共通なので同一判定でチェックする
                                     // #TODO : 自動生成の段階で分かれているケースが存在するならは点や法線方向で判定するように変える
-                                    if (insideWay.IsSameLine(way))
+                                    if (way == null)
+                                        laneType = RnSideWalkLaneType.Undefined;
+                                    else if (insideWay.IsSameLine(way))
                                         laneType = RnSideWalkLaneType.LeftLane;
                                     else
                                         laneType = RnSideWalkLaneType.RightLane;

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -380,8 +380,8 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
             if (p.showWayFilter != RnSideWalkWayTypeMask.None && sideWalk.GetValidWayTypeMask() != p.showWayFilter)
                 return;
 
-            if (p.showLaneTypeFilter != SideWalkLaneTypeMask.None &&
-                ((1 << (int)sideWalk.LaneType) & (int)p.showLaneTypeFilter) == 0)
+            // レーンタイプで見る
+            if (((1 << (int)sideWalk.LaneType) & (int)p.showLaneTypeFilter) == 0)
                 return;
 
             // 非表示設定

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Splines;
+using static PLATEAU.RoadNetwork.Structure.Drawer.PLATEAURnModelDrawerDebug.SideWalkOption;
 
 namespace PLATEAU.RoadNetwork.Structure.Drawer
 {
@@ -185,6 +186,17 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
         [Serializable]
         public class SideWalkOption
         {
+            [Serializable]
+            [Flags]
+            public enum SideWalkLaneTypeMask
+            {
+                None = 0,
+                Undefined = 1 << (RnSideWalkLaneType.Undefined),
+                LeftLane = 1 << (RnSideWalkLaneType.LeftLane),
+                RightLane = 1 << (RnSideWalkLaneType.RightLane),
+                All = ~0,
+            }
+
             public bool visible = true;
             public DrawOption showOutsideWay = new DrawOption(true, Color.red);
             public DrawOption showInsideWay = new DrawOption(true, Color.blue);
@@ -192,6 +204,8 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
             public DrawOption showEndEdgeWay = new DrawOption(true, Color.yellow);
             // Noneの時はすべて表示. それ以外はRnSideWalk.GetValidWayTypeMaskが一致したものだけ表示する(不正なSideWalk検出用)
             public RnSideWalkWayTypeMask showWayFilter = RnSideWalkWayTypeMask.None;
+            public SideWalkLaneTypeMask showLaneTypeFilter = SideWalkLaneTypeMask.All;
+
         }
         [SerializeField] public SideWalkOption sideWalkRoadOp = new SideWalkOption();
 
@@ -364,6 +378,10 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
 
             // 一致判定
             if (p.showWayFilter != RnSideWalkWayTypeMask.None && sideWalk.GetValidWayTypeMask() != p.showWayFilter)
+                return;
+
+            if (p.showLaneTypeFilter != SideWalkLaneTypeMask.None &&
+                ((1 << (int)sideWalk.LaneType) & (int)p.showLaneTypeFilter) == 0)
                 return;
 
             // 非表示設定

--- a/Runtime/RoadNetwork/Structure/RnModel.cs
+++ b/Runtime/RoadNetwork/Structure/RnModel.cs
@@ -726,7 +726,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 // 切断線の境界
                 var midEdgeWay = new RnWay(RnLineString.Create(new[] { inside.midPoint, outside.midPoint }));
 
-                var newSideWalk = RnSideWalk.Create(newNextRoad, nextOutsideWay, nextInsideWay, midEdgeWay, endEdgeWay);
+                var newSideWalk = RnSideWalk.Create(newNextRoad, nextOutsideWay, nextInsideWay, midEdgeWay, endEdgeWay, sideWalk.LaneType);
                 sideWalk.SetSideWays(prevOutsideWay, prevInsideWay);
                 sideWalk.SetEdgeWays(startEdgeWay, midEdgeWay);
                 self.AddSideWalk(newSideWalk);

--- a/Runtime/RoadNetwork/Structure/RnSideWalk.cs
+++ b/Runtime/RoadNetwork/Structure/RnSideWalk.cs
@@ -14,6 +14,20 @@ namespace PLATEAU.RoadNetwork.Structure
         EndEdge = 1 << 3,
     }
 
+    /// <summary>
+    /// 道路専用. 手動編集で道路の左側/右側どっちに所属するかが取りたいみたいなので専用フラグを用意する.
+    /// 交差点だと意味がない
+    /// </summary>
+    public enum RnSideWalkLaneType
+    {
+        // 交差点 or その他(デフォルト値)
+        Undefined,
+        // 左レーン
+        LeftLane,
+        // 右レーン
+        RightLane,
+    }
+
     public class RnSideWalk : ARnParts<RnSideWalk>
     {
         //----------------------------------
@@ -38,6 +52,8 @@ namespace PLATEAU.RoadNetwork.Structure
         // シリアライズ化の為にフィールドに
         private RnWay endEdgeWay;
 
+        private RnSideWalkLaneType laneType = RnSideWalkLaneType.Undefined;
+
         //----------------------------------
         // end: フィールド
         //----------------------------------
@@ -51,6 +67,12 @@ namespace PLATEAU.RoadNetwork.Structure
         public RnWay StartEdgeWay => startEdgeWay;
 
         public RnWay EndEdgeWay => endEdgeWay;
+
+        public RnSideWalkLaneType LaneType
+        {
+            get => laneType;
+            set => laneType = value;
+        }
 
         /// <summary>
         /// 左右のWay(OutsideWay, InsideWay)を列挙
@@ -92,13 +114,14 @@ namespace PLATEAU.RoadNetwork.Structure
 
         public RnSideWalk() { }
 
-        private RnSideWalk(RnRoadBase parent, RnWay outsideWay, RnWay insideWay, RnWay startEdgeWay, RnWay endEdgeWay)
+        private RnSideWalk(RnRoadBase parent, RnWay outsideWay, RnWay insideWay, RnWay startEdgeWay, RnWay endEdgeWay, RnSideWalkLaneType laneType)
         {
             this.parentRoad = parent;
             this.outsideWay = outsideWay;
             this.insideWay = insideWay;
             this.startEdgeWay = startEdgeWay;
             this.endEdgeWay = endEdgeWay;
+            this.laneType = laneType;
         }
 
         public RnSideWalkWayTypeMask GetValidWayTypeMask()
@@ -156,10 +179,11 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <param name="insideWay"></param>
         /// <param name="startEdgeWay"></param>
         /// <param name="endEdgeWay"></param>
+        /// <param name="laneType"></param>
         /// <returns></returns>
-        public static RnSideWalk Create(RnRoadBase parent, RnWay outsideWay, RnWay insideWay, RnWay startEdgeWay, RnWay endEdgeWay)
+        public static RnSideWalk Create(RnRoadBase parent, RnWay outsideWay, RnWay insideWay, RnWay startEdgeWay, RnWay endEdgeWay, RnSideWalkLaneType laneType = RnSideWalkLaneType.Undefined)
         {
-            var sideWalk = new RnSideWalk(parent, outsideWay, insideWay, startEdgeWay, endEdgeWay);
+            var sideWalk = new RnSideWalk(parent, outsideWay, insideWay, startEdgeWay, endEdgeWay, laneType);
             parent.AddSideWalk(sideWalk);
             return sideWalk;
         }


### PR DESCRIPTION
…味無し)

﻿## 関連リンク
https://synesthesias.atlassian.net/browse/PLTSDK3-288

## 実装内容
RnSideWalkにLaneTypeを追加.
道路の時だけ意味を持つ. 道路の左側の歩道か右側の歩道かを表すenumを追加し、自動生成の時に入れるように
交差点ではUndefinedに

## 動作確認
新規データなので、改めて道路ネットワークを作り直す。
PLATEAURnModelDrawerDebugでSideWalkRoadOpの中に、ShowLaneTypeFilterを追加.チェックを入れたレーンタイプの歩道だけが表示されるようになるのでそれでチェックする。
![image](https://github.com/user-attachments/assets/33104de2-7b98-4cad-93fe-45f1742b4f7c)

![image](https://github.com/user-attachments/assets/fd0495fa-f11c-4ced-b703-9216509ffe52)
![image](https://github.com/user-attachments/assets/b11e27ae-00e3-48cf-a825-ce7f7e24f66c)
![image](https://github.com/user-attachments/assets/6cdd44ad-d0b0-4730-9c34-e9172549e750)


## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
-->
