### PR TITLE
update : 中央分離帯作成関数を変更. SetMedianWidthは非推奨にし別途中央分離帯作成関数と幅拡張関数に分ける

### DIFF
--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -284,23 +284,28 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                 }
 
 
-                p.medianWidthOption = (LaneWayMoveOption)EditorGUILayout.EnumPopup("MoveOption", p.medianWidthOption);
-                using (new EditorGUILayout.HorizontalScope())
+
+                if (roadGroup.HasMedian())
                 {
-                    p.medianWidth = EditorGUILayout.FloatField("MedianWidth", p.medianWidth);
-                    if (GUILayout.Button("SetMedianWidth"))
+                    p.medianWidthOption = (LaneWayMoveOption)EditorGUILayout.EnumPopup("MoveOption", p.medianWidthOption);
+                    if (GUILayout.Button("RemoveMedian"))
                     {
-                        roadGroup.SetMedianWidth(p.medianWidth, p.medianWidthOption);
+                        roadGroup.RemoveMedian(p.medianWidthOption);
                     }
                 }
-
-
-
-                if (GUILayout.Button("RemoveMedian"))
+                else
                 {
-                    roadGroup.RemoveMedian(p.medianWidthOption);
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        p.medianWidth = EditorGUILayout.FloatField("MedianWidth", p.medianWidth);
+                        if (GUILayout.Button("CreateMedian"))
+                        {
+                            roadGroup.CreateMedianOrSkip(p.medianWidth);
+                        }
+                    }
                 }
             }
+
             if (RnEditorUtil.Foldout("Option", p.Foldouts, ("Option", road)))
             {
                 using var indent = new EditorGUI.IndentLevelScope();

--- a/Runtime/RoadNetwork/Data/RoadNetworkSerializer.cs
+++ b/Runtime/RoadNetwork/Data/RoadNetworkSerializer.cs
@@ -413,7 +413,7 @@ namespace PLATEAU.RoadNetwork.Data
 
         public RoadNetworkStorage Serialize(RnModel roadNetworkModel)
         {
-            var ret = new RoadNetworkStorage();
+            var ret = new RoadNetworkStorage { FactoryVersion = roadNetworkModel.FactoryVersion, };
             var refTable = CreateReferenceTable();
             CollectForSerialize(refTable, roadNetworkModel, ret.PrimitiveDataStorage.TrafficLightControllers);
             CollectForSerialize(refTable, roadNetworkModel, ret.PrimitiveDataStorage.TrafficLights);
@@ -475,7 +475,7 @@ namespace PLATEAU.RoadNetwork.Data
                     roadNetworkStorage.PrimitiveDataStorage.SideWalks);
 
             refTable.ConvertAll();
-            var ret = new RnModel();
+            var ret = new RnModel { FactoryVersion = roadNetworkStorage.FactoryVersion };
             foreach (var r in roadBases)
             {
                 if (r is RnIntersection n)

--- a/Runtime/RoadNetwork/Data/RoadNetworkStorage.cs
+++ b/Runtime/RoadNetwork/Data/RoadNetworkStorage.cs
@@ -39,6 +39,13 @@ namespace PLATEAU.RoadNetwork.Data
     [Serializable]
     public class RoadNetworkStorage : IRoadNetworkDynamicEditable
     {
+        /// <summary>
+        /// 自動生成で作成されたときのバージョン. これが現在のバージョンよりも古い場合はデータが古い可能性がある.
+        /// RoadNetworkFactory.FactoryVersion参照
+        /// </summary>
+        [field: SerializeField]
+        public string FactoryVersion { get; set; } = "";
+
         public PrimitiveDataStorage PrimitiveDataStorage { get => primitiveDataStorage; }
 
         [SerializeField]
@@ -109,13 +116,13 @@ namespace PLATEAU.RoadNetwork.Data
         [field: SerializeField]
         private PrimitiveStorage<RnDataTrafficLightController> trafficLightControllers = new PrimitiveStorage<RnDataTrafficLightController>();
 
-        [field: SerializeField] 
+        [field: SerializeField]
         private PrimitiveStorage<RnDataTrafficLight> trafficLights = new PrimitiveStorage<RnDataTrafficLight>();
 
-        [field: SerializeField] 
+        [field: SerializeField]
         private PrimitiveStorage<RnDataTrafficSignalPattern> trafficSignalPatterns = new PrimitiveStorage<RnDataTrafficSignalPattern>();
 
-        [field: SerializeField] 
+        [field: SerializeField]
         private PrimitiveStorage<RnDataTrafficSignalPhase> trafficSignalPhases = new PrimitiveStorage<RnDataTrafficSignalPhase>();
 
         public PrimitiveStorage<RnDataPoint> Points { get => points; }

--- a/Runtime/RoadNetwork/Factory/RoadNetworkFactory.cs
+++ b/Runtime/RoadNetwork/Factory/RoadNetworkFactory.cs
@@ -16,6 +16,12 @@ namespace PLATEAU.RoadNetwork.Factory
     [Serializable]
     public partial class RoadNetworkFactory
     {
+        /// <summary>
+        /// 自動生成バージョン. 作成時に番号埋め込んでおいてどのバージョンで作られたかを見れるようにする.
+        /// メジャー/マイナー分けたいので文字列
+        /// </summary>
+        public static readonly string FactoryVersion = "1.0";
+
         // --------------------
         // start:フィールド
         // --------------------
@@ -593,7 +599,7 @@ namespace PLATEAU.RoadNetwork.Factory
                     return m0 == m1;
                 }).ToList();
 
-                var ret = new RnModel();
+                var ret = new RnModel { FactoryVersion = FactoryVersion, };
                 var work = new Work { terminateAllowEdgeAngle = TerminateAllowEdgeAngle, terminateSkipAngleDeg = TerminateSkipAngle };
                 FactoryWork = work;
 

--- a/Runtime/RoadNetwork/Structure/RnLineString.cs
+++ b/Runtime/RoadNetwork/Structure/RnLineString.cs
@@ -110,7 +110,7 @@ namespace PLATEAU.RoadNetwork.Structure
                     subVertices = new List<RnPoint> { end };
                     len -= length;
                     // 次の長さを更新
-                    length = GetLength(subVertices.Count);
+                    length = GetLength(ret.Count);
                 }
                 if (subVertices.LastOrDefault() != p1)
                     subVertices.Add(p1);

--- a/Runtime/RoadNetwork/Structure/RnModel.cs
+++ b/Runtime/RoadNetwork/Structure/RnModel.cs
@@ -19,6 +19,11 @@ namespace PLATEAU.RoadNetwork.Structure
         // start: フィールド
         //----------------------------------
 
+        /// <summary>
+        /// 自動生成で作成されたときのバージョン. これが現在のバージョンよりも古い場合はデータが古い可能性がある.
+        /// RoadNetworkFactory.FactoryVersion参照
+        /// </summary>
+        public string FactoryVersion { get; set; } = "";
 
         // #NOTE : Editorが重いのでSerialize対象にしない
         private List<RnRoad> roads = new List<RnRoad>();
@@ -252,6 +257,7 @@ namespace PLATEAU.RoadNetwork.Structure
 
         public void Deserialize(RoadNetworkStorage storage, bool removeEmptyCheck = true)
         {
+            FactoryVersion = storage.FactoryVersion;
             var serializer = new RoadNetworkSerializer();
             var model = serializer.Deserialize(storage);
             CopyFrom(model);

--- a/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
@@ -326,15 +326,15 @@ namespace PLATEAU.RoadNetwork.Structure
                 return;
             }
 
-            SetLaneCountImpl(leftCount, rightCount);
+            SetLaneCountWithoutMedian(leftCount, rightCount);
         }
 
         /// <summary>
-        /// レーン数を変更する.
+        /// レーン数を変更する. 中央分離帯は削除する
         /// </summary>
         /// <param name="leftCount"></param>
         /// <param name="rightCount"></param>
-        private void SetLaneCountImpl(int leftCount, int rightCount)
+        private void SetLaneCountWithoutMedian(int leftCount, int rightCount)
         {
             if (IsValid == false)
                 return;
@@ -368,32 +368,25 @@ namespace PLATEAU.RoadNetwork.Structure
                 road.ReplaceLanes(lanes);
             }
 
-            if (leftCount == 0 || rightCount == 0)
-            {
-                foreach (var l in Roads)
-                    l.SetMedianLane(null);
-            }
-            else
-            {
-                // 中央分離帯があるリンクだけ更新する(ない場合はなにもしない
-                CreateMedianOrSkip(l => l.MedianLane != null);
-            }
+            // 中央分離帯を削除する
+            foreach (var l in Roads)
+                l.SetMedianLane(null);
         }
 
 
+
         /// <summary>
-        /// 中央分離帯の幅を設定する.
+        /// 中央分離帯の幅を設定する. 非推奨. 個別にWayを動かすことを推奨
         /// </summary>
         /// <param name="width"></param>
         /// <param name="moveOption"></param>
+        [Obsolete("非推奨. 個別にWayを動かす or ExpandMedianWidthを使うこと")]
         public bool SetMedianWidth(float width, LaneWayMoveOption moveOption)
         {
-            if (GetLeftLaneCount() == 0 || GetRightLaneCount() == 0)
+            if (HasMedian() == false)
                 return false;
+
             Align();
-            // 中央分離帯がないリンクは一度作成する
-            if (width > 0f)
-                CreateMedianOrSkip(l => l.MedianLane == null);
             foreach (var road in Roads)
             {
                 var nowWidth = road.GetMedianWidth();
@@ -415,9 +408,42 @@ namespace PLATEAU.RoadNetwork.Structure
                         centerRight.RightWay?.MoveAlongNormal(-deltaWidth);
                         break;
                 }
-
-                //l.MedianLane?.TrySetWidth(width, moveOption);
             }
+            return true;
+        }
+
+        /// <summary>
+        /// 中央分離帯の幅を拡縮する. deltaWidthが正なら幅が増加する
+        /// </summary>
+        /// <param name="deltaWidth"></param>
+        /// <param name="moveOption"></param>
+        /// <returns></returns>
+        public bool ExpandMedianWidth(float deltaWidth, LaneWayMoveOption moveOption)
+        {
+            if (HasMedian() == false)
+                return false;
+            Align();
+            foreach (var road in Roads)
+            {
+                //// サイズ0の中央分離帯だと法線方向が定まらないので、すでに幅の存在するレーンを動かすことで
+                //// 中央分離帯の幅を設定する
+                var centerLeft = road.GetLeftLanes().Last();
+                var centerRight = road.GetRightLanes().First();
+                switch (moveOption)
+                {
+                    case LaneWayMoveOption.MoveBothWay:
+                        centerLeft.RightWay?.MoveAlongNormal(-deltaWidth * 0.5f);
+                        centerRight.RightWay?.MoveAlongNormal(-deltaWidth * 0.5f);
+                        break;
+                    case LaneWayMoveOption.MoveLeftWay:
+                        centerLeft.RightWay?.MoveAlongNormal(-deltaWidth);
+                        break;
+                    case LaneWayMoveOption.MoveRightWay:
+                        centerRight.RightWay?.MoveAlongNormal(-deltaWidth);
+                        break;
+                }
+            }
+
             return true;
         }
 
@@ -542,10 +568,10 @@ namespace PLATEAU.RoadNetwork.Structure
             if (GetLeftLaneCount() == count)
                 return;
 
-            // 左車線が無い場合は左車線のサイズも含めて変更する
+            // 左車線が無い場合は全車線含めて変更する
             if (GetLeftLaneCount() == 0 || count == 0)
             {
-                SetLaneCountImpl(count, GetRightLaneCount());
+                SetLaneCountWithoutMedian(count, GetRightLaneCount());
             }
             // すでに左車線がある場合はそれだけで変更する
             else
@@ -564,10 +590,10 @@ namespace PLATEAU.RoadNetwork.Structure
             if (GetRightLaneCount() == count)
                 return;
 
-            // 右車線が無い場合は左車線のサイズも含めて変更する
+            // 右車線が無い場合は全車線含めて変更する
             if (GetRightLaneCount() == 0 || count == 0)
             {
-                SetLaneCountImpl(GetLeftLaneCount(), count);
+                SetLaneCountWithoutMedian(GetLeftLaneCount(), count);
             }
             // すでに右車線がある場合はそれだけで変更する
             else
@@ -577,54 +603,39 @@ namespace PLATEAU.RoadNetwork.Structure
         }
 
         /// <summary>
-        /// 中央分離帯を作成するかスキップする
+        /// まだ中央分離帯がない場合は作成する.
+        /// medianWidthは作成時の中央分離帯の幅. 最低1m. ただし目安であり、実際の幅は最小のレーン幅に合わせる
         /// </summary>
-        private void CreateMedianOrSkip(Func<RnRoad, bool> createTarget)
+        /// <param name="medianWidth"></param>
+        /// <param name="maxMedianLaneRate">中央分離帯の割合が全体の道のこれを超えないようにする</param>
+        public bool CreateMedianOrSkip(float medianWidth = 1f, float maxMedianLaneRate = 0.5f)
         {
-            Dictionary<RnPoint, RnPoint> replace = new Dictionary<RnPoint, RnPoint>();
-            foreach (var l in Roads)
+            // 全ての道路に中央分離帯がある場合は何もしない
+            if (HasMedian())
+                return false;
+            // 両方にレーンが無いと作成しない
+            if (GetLeftLaneCount() == 0 || GetRightLaneCount() == 0)
             {
-                if (createTarget != null && createTarget(l) == false)
-                    continue;
-
-                var centerLeft = l.GetLeftLanes().Last();
-                var rightWay = centerLeft.Replace2Clone(RnDir.Right, true);
-                var leftWay = centerLeft.RightWay;
-                leftWay = new RnWay(leftWay.LineString, leftWay.IsReversed, !leftWay.IsReverseNormal);
-                var st = rightWay.GetPoint(0);
-                var en = rightWay.GetPoint(-1);
-                var afterSt = replace.GetValueOrCreate(st, r => st.Clone());
-                var afterEn = replace.GetValueOrCreate(en, r => en.Clone());
-
-                var prev = centerLeft.GetBorder(RnLaneBorderType.Prev, RnLaneBorderDir.Left2Right);
-                var next = centerLeft.GetBorder(RnLaneBorderType.Next, RnLaneBorderDir.Left2Right);
-                prev.LineString.ReplacePoint(st, afterSt);
-                next.LineString.ReplacePoint(en, afterEn);
-                leftWay.SetPoint(0, prev.GetPoint(-1));
-                leftWay.SetPoint(-1, next.GetPoint(-1));
-
-                var prevLineString = RnLineString.Create(new[] { afterSt, st }, false);
-                var nextLineString = RnLineString.Create(new[] { afterEn, en }, false);
-
-                var prevBorder = new RnWay(prevLineString, isReverseNormal: true);
-                var nextBorder = new RnWay(nextLineString);
-                var medianLane = new RnLane(leftWay, rightWay, prevBorder, nextBorder);
-                l.SetMedianLane(medianLane);
-
-                // 交差点側にも情報を埋め込む(外形が崩れるので)
-                if (l.Prev is RnIntersection prevInter)
-                {
-                    prevInter.AddEdge(l, prevBorder.ReversedWay());
-                    prevInter.Align();
-                }
-
-                if (l.Next is RnIntersection nextInter)
-                {
-                    nextInter.AddEdge(l, nextBorder.ReversedWay());
-                    nextInter.Align();
-                }
-
+                DebugEx.LogWarning($"中央分離帯を作成するには左右の車線が必要");
+                return false;
             }
+
+            medianWidth = Mathf.Max(1, medianWidth);
+            // 1番小さい幅レーンの道幅が1[m]になるように中央分離帯を作成する
+            var width = Roads.Min(r => r.AllLanesWithMedian.Sum(l => l.CalcWidth()));
+            var medianRate = Mathf.Min(maxMedianLaneRate, medianWidth / width);
+            SetLaneCountWithMedian(GetLeftLaneCount(), GetRightLaneCount(), medianRate);
+            return true;
+        }
+
+        /// <summary>
+        /// 中央分離帯があるかどうか.
+        /// 構成するすべての道路に中央分離帯がある場合にtrueを返す
+        /// </summary>
+        /// <returns></returns>
+        public bool HasMedian()
+        {
+            return Roads.All(r => r.MedianLane != null);
         }
 
         /// <summary>


### PR DESCRIPTION
﻿## 関連リンク
https://synesthesias.atlassian.net/browse/PLTSDK3-309

## 実装内容
RnRoadGroupのSetMedianはObsoluteに
CreateMedianOrSkipをpublicにして, そちらで一度中央分離帯を作成 -> そのあと個別に幅を変更する方式に変更.
作成時には最低1mの幅にするように

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
RnRoadGroupのSetWidthの代わりにCreateMedianOrSkipを呼んで、そのうえで中央分離帯を移動できるか確認

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
