### PR TITLE
信号機関係をGetterに追加

### DIFF
--- a/Runtime/RoadNetwork/Data/RoadNetworkDataGetter.cs
+++ b/Runtime/RoadNetwork/Data/RoadNetworkDataGetter.cs
@@ -28,11 +28,15 @@ namespace PLATEAU.RoadNetwork.Data
 
         private PrimitiveDataStorage primStorage;
 
-        /// <summary>
-        /// データの取得関数群
-        /// </summary>
-        /// <param name="data"></param>
 
+        /// <summary>
+        /// 取得したデータ群からIDテーブルを生成する
+        /// 注意　要素数の増減があった時には再度テーブルを作成する必要がある
+        /// 
+        /// </summary>
+        /// <typeparam name="_Type"></typeparam>
+        /// <param name="dataList"></param>
+        /// <returns></returns>
         public IReadOnlyDictionary<_Type, RnID<_Type>> GenerateIdTable<_Type>(IReadOnlyList<_Type> dataList)
             where _Type : IPrimitiveData
         {
@@ -44,6 +48,11 @@ namespace PLATEAU.RoadNetwork.Data
             }
             return table;
         }
+
+        /// <summary>
+        /// データの取得関数群
+        /// </summary>
+        /// <param name="data"></param>
 
         public IReadOnlyList<RnDataRoadBase> GetRoadBases()
         {

--- a/Runtime/RoadNetwork/Data/RoadNetworkDataGetter.cs
+++ b/Runtime/RoadNetwork/Data/RoadNetworkDataGetter.cs
@@ -130,7 +130,7 @@ namespace PLATEAU.RoadNetwork.Data
         {
             switch (typeof(_Type).Name)
             {
-                case nameof(RnRoadBase):
+                case nameof(RnDataRoadBase):
                     return primStorage.RoadBases;
                 case nameof(RnDataLane):
                     return primStorage.Lanes;
@@ -152,7 +152,7 @@ namespace PLATEAU.RoadNetwork.Data
                     return primStorage.TrafficSignalPhases;
             }
 
-            Assert.IsTrue(false);   // 未対応の型
+            Assert.IsTrue(false, "未対応の型");   // 未対応の型
             return null;
         }
     }

--- a/Runtime/RoadNetwork/Data/RoadNetworkDataGetter.cs
+++ b/Runtime/RoadNetwork/Data/RoadNetworkDataGetter.cs
@@ -60,6 +60,26 @@ namespace PLATEAU.RoadNetwork.Data
             return primStorage.Points.DataList;
         }
 
+        public IReadOnlyList<RnDataTrafficLightController> GetTrafficLightController()
+        {
+            return primStorage.TrafficLightControllers.DataList;
+        }
+
+        public IReadOnlyList<RnDataTrafficLight> GetTrafficLights()
+        {
+            return primStorage.TrafficLights.DataList;
+        }
+
+        public IReadOnlyList<RnDataTrafficSignalPattern> GetTrafficSignalPattern()
+        {
+            return primStorage.TrafficSignalPatterns.DataList;
+        }
+
+        public IReadOnlyList<RnDataTrafficSignalPhase> GetTrafficSignalPhase()
+        {
+            return primStorage.TrafficSignalPhases.DataList;
+        }
+
         /// <summary>
         /// データ検証
         /// </summary>
@@ -72,6 +92,10 @@ namespace PLATEAU.RoadNetwork.Data
             TestNull(nameof(RnDataWay), GetWays());
             TestNull(nameof(RnDataLineString), GetLineStrings());
             TestNull(nameof(RnDataPoint), GetPoints());
+            TestNull(nameof(RnDataTrafficLightController), GetTrafficLightController());
+            TestNull(nameof(RnDataTrafficLight), GetTrafficLights());
+            TestNull(nameof(RnDataTrafficSignalPattern), GetTrafficSignalPattern());
+            TestNull(nameof(RnDataTrafficSignalPhase), GetTrafficSignalPhase());
 
             void TestNull(string name, object a)
             {

--- a/Runtime/RoadNetwork/Data/RoadNetworkDataGetter.cs
+++ b/Runtime/RoadNetwork/Data/RoadNetworkDataGetter.cs
@@ -1,7 +1,7 @@
 ﻿using PLATEAU.RoadNetwork.Structure;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 namespace PLATEAU.RoadNetwork.Data
 {
@@ -33,6 +33,17 @@ namespace PLATEAU.RoadNetwork.Data
         /// </summary>
         /// <param name="data"></param>
 
+        public IReadOnlyDictionary<_Type, RnID<_Type>> GenerateIdTable<_Type>(IReadOnlyList<_Type> dataList)
+            where _Type : IPrimitiveData
+        {
+            Dictionary<_Type, RnID<_Type>> table = new Dictionary<_Type, RnID<_Type>>(dataList.Count);
+            for (int i = 0; i < dataList.Count; i++)
+            {
+                var g = GetIDGeneratable<_Type>();
+                table.Add(dataList[i], new RnID<_Type>(i, g));
+            }
+            return table;
+        }
 
         public IReadOnlyList<RnDataRoadBase> GetRoadBases()
         {
@@ -105,5 +116,35 @@ namespace PLATEAU.RoadNetwork.Data
             }
         }
 
+        private IRnIDGeneratable GetIDGeneratable<_Type>()
+            where _Type : IPrimitiveData
+        {
+            switch (typeof(_Type).Name)
+            {
+                case nameof(RnRoadBase):
+                    return primStorage.RoadBases;
+                case nameof(RnDataLane):
+                    return primStorage.Lanes;
+                case nameof(RnDataBlock):
+                    return primStorage.Blocks;
+                case nameof(RnDataWay):
+                    return primStorage.Ways;
+                case nameof(RnDataLineString):
+                    return primStorage.LineStrings;
+                case nameof(RnDataPoint):
+                    return primStorage.Points;
+                case nameof(RnDataTrafficLightController):
+                    return primStorage.TrafficLightControllers;
+                case nameof(RnDataTrafficLight):
+                    return primStorage.TrafficLights;
+                case nameof(RnDataTrafficSignalPattern):
+                    return primStorage.TrafficSignalPatterns;
+                case nameof(RnDataTrafficSignalPhase):
+                    return primStorage.TrafficSignalPhases;
+            }
+
+            Assert.IsTrue(false);   // 未対応の型
+            return null;
+        }
     }
 }


### PR DESCRIPTION
﻿## 関連リンク
無し

## 実装内容
信号機関係をGetterに追加
DataのインスタンスとIDを紐づけたテーブルを生成する関数を実装

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
Getterから信号機類のデータが取得できる。
GetterのGenerateIdTable()でDataのインスタンスとIDを紐づけたテーブルを作成出来る。

## その他
無し