### PR TITLE
Feature/road network width editing sub2

### DIFF
--- a/Editor/RoadNetwork/EditingSystemSubMod/EditingSystemGizmos.cs
+++ b/Editor/RoadNetwork/EditingSystemSubMod/EditingSystemGizmos.cs
@@ -14,41 +14,53 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
     /// </summary>
     public class EditingSystemGizmos
     {
+        /// <summary>
+        /// 描画コマンド群
+        /// </summary>
         private List<System.Action> drawFuncs = new List<Action>();
 
+        // 交差間の繋がり(RnRoadGroup)を表現する頂点リスト
         private List<Vector3> intersectionConnectionLinePairs = new List<Vector3>();
-        private List<List<Vector3>> intersectionConnectionLinePairs2 = new List<List<Vector3>>();
 
+        // 選択中のwayを表現する頂点リスト
         private List<Vector3> selectingWay = new List<Vector3>();
 
+        // 左側、右側車線のwayを表現する頂点リスト
         private List<List<Vector3>> leftLaneWayList = new List<List<Vector3>>();
         private List<List<Vector3>> rightLaneWayList = new List<List<Vector3>>();
 
+        // 中央分離帯
         private List<List<Vector3>> medianWayList = new List<List<Vector3>>();
 
+        // 歩道
         private List<List<Vector3>> sideWalks = new List<List<Vector3>>();
 
+        // 選択中のwayをスライドした時の結果表示
         private List<List<Vector3>> slideDummyWayList = new List<List<Vector3>>();
 
+        // 交差点の外周
         private List<List<Vector3>> intersectionOutline = new List<List<Vector3>>();
+        // 交差点と道路の境界
         private List<List<Vector3>> intersectionBorder = new List<List<Vector3>>();
+
+        // それぞれのwayの色
 
         private readonly Color selectingColorOffset = new Color(0.2f, 0.2f, 0.2f, 0);
         private readonly Color dummyColorOffset = new Color(-0.2f, -0.2f, -0.2f, 0);
 
-        private Color connectionColor = Color.blue;
-        private Color selectingWayColor = Color.red;
-        //private Color selectableWayColor = Color.yellow;
-        private Color leftSideWayColor = Color.yellow;
-        private Color rightSideWayColor = Color.green;
-        private Color medianWayColor = Color.blue;
-
-        private Color guideWayColor = Color.black;
-        private Color sideWalkColor = Color.magenta;
-        private Color slideDummyWayColor = Color.red + new Color(-0.2f, -0.2f, -0.2f, 0);
-
-        private Color intersectionOutlineColor = Color.gray;
-        private Color intersectionBorderColor = Color.gray + new Color(-0.2f, -0.2f, -0.2f, 0);
+        private readonly Color connectionColor = Color.blue;
+        private readonly Color selectingWayColor = Color.red;
+                
+        private readonly Color leftSideWayColor = Color.yellow;
+        private readonly Color rightSideWayColor = Color.green;
+        private readonly Color medianWayColor = Color.blue;
+                
+        private readonly Color guideWayColor = Color.black;
+        private readonly Color sideWalkColor = Color.magenta;
+        private readonly Color slideDummyWayColor = Color.red + new Color(-0.2f, -0.2f, -0.2f, 0);
+                
+        private readonly Color intersectionOutlineColor = Color.gray;
+        private readonly Color intersectionBorderColor = Color.gray + new Color(-0.2f, -0.2f, -0.2f, 0);
 
         public EditingSystemGizmos()
         {
@@ -294,19 +306,6 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                 {
                     Gizmos.color = connectionColor;
                     Gizmos.DrawLineList(intersectionConnectionLinePairs.ToArray());
-                });
-            }
-
-            var nParis2 = intersectionConnectionLinePairs2.Count;
-            if (nParis2 >= 2)
-            {
-                drawFuncs.Add(() =>
-                {
-                    Gizmos.color = connectionColor;
-                    foreach (var item in intersectionConnectionLinePairs2)
-                    {
-                        Gizmos.DrawLineList(item.ToArray());
-                    }
                 });
             }
 

--- a/Editor/RoadNetwork/EditingSystemSubMod/EditingSystemGizmos.cs
+++ b/Editor/RoadNetwork/EditingSystemSubMod/EditingSystemGizmos.cs
@@ -167,25 +167,22 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                         continue;
                     }
 
-                    if (wayEditorData.IsSelectable)
+                    var way = new List<Vector3>(wayEditorData.Ref.Points.Count());
+                    var points = wayEditorData.Ref.Points;
+                    foreach (var p in points)
                     {
-                        var way = new List<Vector3>(wayEditorData.Ref.Points.Count());
-                        var points = wayEditorData.Ref.Points;
-                        foreach (var p in points)
-                        {
-                            way.Add(p);
-                        }
+                        way.Add(p);
+                    }
                         
-                        var parent = wayEditorData.Parent;
-                        Debug.Assert(parent != null);
-                        if (parent.IsReverse == false)
-                        {
-                            leftLaneWayList.Add(way);
-                        }
-                        else
-                        {
-                            rightLaneWayList.Add(way);
-                        }
+                    var parent = wayEditorData.Parent;
+                    Debug.Assert(parent != null);
+                    if (parent.IsReverse == false)
+                    {
+                        leftLaneWayList.Add(way);
+                    }
+                    else
+                    {
+                        rightLaneWayList.Add(way);
                     }
                 }
 
@@ -203,17 +200,14 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                         continue;
                     }
 
-                    if (wayEditorData.IsSelectable)
+                    var way = new List<Vector3>(wayEditorData.Ref.Points.Count());
+                    var points = wayEditorData.Ref.Points;
+                    foreach (var p in points)
                     {
-                        var way = new List<Vector3>(wayEditorData.Ref.Points.Count());
-                        var points = wayEditorData.Ref.Points;
-                        foreach (var p in points)
-                        {
-                            way.Add(p);
-                        }
-
-                        sideWalks.Add(way);
+                        way.Add(p);
                     }
+
+                    sideWalks.Add(way);
                 }
 
                 // 中央分離帯のwayを描画
@@ -230,17 +224,14 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                         continue;
                     }
 
-                    if (wayEditorData.IsSelectable)
+                    var way = new List<Vector3>(wayEditorData.Ref.Points.Count());
+                    var points = wayEditorData.Ref.Points;
+                    foreach (var p in points)
                     {
-                        var way = new List<Vector3>(wayEditorData.Ref.Points.Count());
-                        var points = wayEditorData.Ref.Points;
-                        foreach (var p in points)
-                        {
-                            way.Add(p);
-                        }
-
-                        medianWayList.Add(way);
+                        way.Add(p);
                     }
+
+                    medianWayList.Add(way);
                 }
 
 

--- a/Editor/RoadNetwork/EditingSystemSubMod/EditingSystemGizmos.cs
+++ b/Editor/RoadNetwork/EditingSystemSubMod/EditingSystemGizmos.cs
@@ -48,12 +48,12 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
         private readonly Color selectingColorOffset = new Color(0.2f, 0.2f, 0.2f, 0);
         private readonly Color dummyColorOffset = new Color(-0.2f, -0.2f, -0.2f, 0);
 
-        private readonly Color connectionColor = Color.blue;
+        private readonly Color connectionColor = Color.blue - new Color(0.1f, 0.1f, 0, 0);
         private readonly Color selectingWayColor = Color.red;
                 
         private readonly Color leftSideWayColor = Color.yellow;
         private readonly Color rightSideWayColor = Color.green;
-        private readonly Color medianWayColor = Color.blue;
+        private readonly Color medianWayColor = Color.blue - new Color(0.1f, 0.1f, 0, 0);
                 
         private readonly Color guideWayColor = Color.black;
         private readonly Color sideWalkColor = Color.magenta;
@@ -135,6 +135,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
             rightLaneWayList.Clear();
             leftLaneWayList.Clear();
             sideWalks.Clear();
+            medianWayList.Clear();
             if (selectingElement is EditorData<RnRoadGroup> roadGroupEditorData)
             {
 

--- a/Editor/RoadNetwork/EditingSystemSubMod/EditingSystemGizmos.cs
+++ b/Editor/RoadNetwork/EditingSystemSubMod/EditingSystemGizmos.cs
@@ -21,9 +21,10 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
 
         private List<Vector3> selectingWay = new List<Vector3>();
 
-        //private List<List<Vector3>> selectableWayList = new List<List<Vector3>>();
         private List<List<Vector3>> leftLaneWayList = new List<List<Vector3>>();
         private List<List<Vector3>> rightLaneWayList = new List<List<Vector3>>();
+
+        private List<List<Vector3>> medianWayList = new List<List<Vector3>>();
 
         private List<List<Vector3>> sideWalks = new List<List<Vector3>>();
 
@@ -40,7 +41,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
         //private Color selectableWayColor = Color.yellow;
         private Color leftSideWayColor = Color.yellow;
         private Color rightSideWayColor = Color.green;
-        private Color medianWayColor = Color.red;
+        private Color medianWayColor = Color.blue;
 
         private Color guideWayColor = Color.black;
         private Color sideWalkColor = Color.magenta;
@@ -148,7 +149,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                         continue;
                     }
 
-                    if (wayEditorData.IsSideWalk)
+                    if (wayEditorData.Type != WayEditorData.WayType.Main)
                     {
                         continue;
                     }
@@ -184,7 +185,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                         continue;
                     }
 
-                    if (wayEditorData.IsSideWalk == false)
+                    if (wayEditorData.Type != WayEditorData.WayType.SideWalk)
                     {
                         continue;
                     }
@@ -201,6 +202,34 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                         sideWalks.Add(way);
                     }
                 }
+
+                // 中央分離帯のwayを描画
+                foreach (var wayEditorData in wayEditorDataList)
+                {
+                    // 選択中のwayは別の描画処理で対応するためスキップ
+                    if (selectingElement == wayEditorData)
+                    {
+                        continue;
+                    }
+
+                    if (wayEditorData.Type != WayEditorData.WayType.Median)
+                    {
+                        continue;
+                    }
+
+                    if (wayEditorData.IsSelectable)
+                    {
+                        var way = new List<Vector3>(wayEditorData.Ref.Points.Count());
+                        var points = wayEditorData.Ref.Points;
+                        foreach (var p in points)
+                        {
+                            way.Add(p);
+                        }
+
+                        medianWayList.Add(way);
+                    }
+                }
+
 
 
             }
@@ -301,6 +330,8 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
             AddDrawFunc(ref drawFuncs, intersectionOutline, intersectionOutlineColor);
 
             AddDrawFunc(ref drawFuncs, intersectionBorder, intersectionBorderColor);
+
+            AddDrawFunc(ref drawFuncs, medianWayList, medianWayColor);
 
             return drawFuncs;
         }

--- a/Editor/RoadNetwork/EditingSystemSubMod/EditingSystemGizmos.cs
+++ b/Editor/RoadNetwork/EditingSystemSubMod/EditingSystemGizmos.cs
@@ -21,9 +21,9 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
 
         private List<Vector3> selectingWay = new List<Vector3>();
 
-        private List<List<Vector3>> selectableWayList = new List<List<Vector3>>();
-
-        private List<List<Vector3>> guideWayList = new List<List<Vector3>>();
+        //private List<List<Vector3>> selectableWayList = new List<List<Vector3>>();
+        private List<List<Vector3>> leftLaneWayList = new List<List<Vector3>>();
+        private List<List<Vector3>> rightLaneWayList = new List<List<Vector3>>();
 
         private List<List<Vector3>> sideWalks = new List<List<Vector3>>();
 
@@ -37,9 +37,13 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
 
         private Color connectionColor = Color.blue;
         private Color selectingWayColor = Color.red;
-        private Color selectableWayColor = Color.yellow;
+        //private Color selectableWayColor = Color.yellow;
+        private Color leftSideWayColor = Color.yellow;
+        private Color rightSideWayColor = Color.green;
+        private Color medianWayColor = Color.red;
+
         private Color guideWayColor = Color.black;
-        private Color sideWalkColor = Color.grey;
+        private Color sideWalkColor = Color.magenta;
         private Color slideDummyWayColor = Color.red + new Color(-0.2f, -0.2f, -0.2f, 0);
 
         private Color intersectionOutlineColor = Color.gray;
@@ -115,8 +119,8 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
             }
 
             // RoadGroupが選択されている
-            selectableWayList.Clear();
-            guideWayList.Clear();
+            rightLaneWayList.Clear();
+            leftLaneWayList.Clear();
             sideWalks.Clear();
             if (selectingElement is EditorData<RnRoadGroup> roadGroupEditorData)
             {
@@ -135,7 +139,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
 
                 var wayEditorDataList = roadGroupEditorData.GetSubData<List<WayEditorData>>();
 
-                // 選択可能なwayを描画
+                // 車線のwayを描画
                 foreach (var wayEditorData in wayEditorDataList)
                 {
                     // 選択中のwayは別の描画処理で対応するためスキップ
@@ -144,30 +148,57 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                         continue;
                     }
 
-                    var way = new List<Vector3>(wayEditorData.Ref.Points.Count());
-                    selectableWayList.Add(way);
+                    if (wayEditorData.IsSideWalk)
+                    {
+                        continue;
+                    }
+
                     if (wayEditorData.IsSelectable)
                     {
+                        var way = new List<Vector3>(wayEditorData.Ref.Points.Count());
                         var points = wayEditorData.Ref.Points;
                         foreach (var p in points)
                         {
                             way.Add(p);
+                        }
+                        
+                        var parent = wayEditorData.Parent;
+                        Debug.Assert(parent != null);
+                        if (parent.IsReverse == false)
+                        {
+                            leftLaneWayList.Add(way);
+                        }
+                        else
+                        {
+                            rightLaneWayList.Add(way);
                         }
                     }
                 }
 
-                // ガイド用のwayを描画
+                // 歩道のwayを描画
                 foreach (var wayEditorData in wayEditorDataList)
                 {
-                    var way = new List<Vector3>(wayEditorData.Ref.Points.Count());
-                    guideWayList.Add(way);
-                    if (wayEditorData.IsSelectable == false)
+                    // 選択中のwayは別の描画処理で対応するためスキップ
+                    if (selectingElement == wayEditorData)
                     {
+                        continue;
+                    }
+
+                    if (wayEditorData.IsSideWalk == false)
+                    {
+                        continue;
+                    }
+
+                    if (wayEditorData.IsSelectable)
+                    {
+                        var way = new List<Vector3>(wayEditorData.Ref.Points.Count());
                         var points = wayEditorData.Ref.Points;
                         foreach (var p in points)
                         {
                             way.Add(p);
                         }
+
+                        sideWalks.Add(way);
                     }
                 }
 
@@ -250,9 +281,8 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                 });
             }
 
-            AddDrawFunc(ref drawFuncs, selectableWayList, selectableWayColor);
-
-            AddDrawFunc(ref drawFuncs, guideWayList, guideWayColor);
+            AddDrawFunc(ref drawFuncs, leftLaneWayList, leftSideWayColor);
+            AddDrawFunc(ref drawFuncs, rightLaneWayList, rightSideWayColor);
 
             // 選択中のwayを描画
             if (selectingWay.Count >= 2)

--- a/Editor/RoadNetwork/RoadNetworkEditingData.cs
+++ b/Editor/RoadNetwork/RoadNetworkEditingData.cs
@@ -440,6 +440,14 @@ namespace PLATEAU.Editor.RoadNetwork
     /// </summary>
     public class WayEditorData
     {
+        public enum WayType
+        {
+            _Undefind = 0,
+            Main,
+            SideWalk,
+            Median
+        }
+
         public WayEditorData(RnWay target, RnLane parent)
         {
             Assert.IsNotNull(target);
@@ -476,7 +484,7 @@ namespace PLATEAU.Editor.RoadNetwork
         /// </summary>
         public bool IsSelectable { get; set; } = true;
 
-        public bool IsSideWalk { get; set; } = false;
+        public WayType Type { get; set; } = WayEditorData.WayType._Undefind;
     }
 
 }

--- a/Editor/RoadNetwork/RoadNetworkEditingData.cs
+++ b/Editor/RoadNetwork/RoadNetworkEditingData.cs
@@ -440,11 +440,13 @@ namespace PLATEAU.Editor.RoadNetwork
     /// </summary>
     public class WayEditorData
     {
-        public WayEditorData(RnWay target)
+        public WayEditorData(RnWay target, RnLane parent)
         {
             Assert.IsNotNull(target);
             BaseWay = target.Vertices.ToList();
             Ref = target;
+
+            Parent = parent;    // null許容
         }
 
         float sliderVarVals;
@@ -468,7 +470,7 @@ namespace PLATEAU.Editor.RoadNetwork
 
         public List<Vector3> BaseWay { get; private set; } = new List<Vector3>();
         public RnWay Ref { get; private set; } = null;
-
+        public RnLane Parent { get; private set; } = null;
         /// <summary>
         /// 選択可能か？
         /// </summary>

--- a/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
@@ -1334,17 +1334,17 @@ namespace PLATEAU.Editor.RoadNetwork
                 StringBuilder sb = new StringBuilder("Node".Length + "XXX".Length);
                 foreach (var node in roadNetwork.Intersections)
                 {
-                    var name = sb.AppendFormat("Node{0}", id).ToString();
-                    var obj = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                    //var obj = new GameObject(name, typeof(MeshFilter));
-                    obj.transform.position = node.GetCenterPoint();
-                    obj.transform.SetParent(roadNetworkEditingSystemObjRoot.transform, false);
-                    //var obj = GameObject.InstantiateGameObjects(prefab,);
-                    //var obj = GameObject.Instantiate(
-                    //    prefab, node.GetCenterPoint(), Quaternion.Euler(90.0f,0.0f,0.0f), roadNetworkEditingSystemObjRoot.transform);
-                    obj.name = name;
-                    obj.transform.hasChanged = false;   // transformの変更を検知するためfalseを設定
-                    var subData = new NodeEditorData(obj);
+                    //var name = sb.AppendFormat("Node{0}", id).ToString();
+                    //var obj = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                    ////var obj = new GameObject(name, typeof(MeshFilter));
+                    //obj.transform.position = node.GetCenterPoint();
+                    //obj.transform.SetParent(roadNetworkEditingSystemObjRoot.transform, false);
+                    ////var obj = GameObject.InstantiateGameObjects(prefab,);
+                    ////var obj = GameObject.Instantiate(
+                    ////    prefab, node.GetCenterPoint(), Quaternion.Euler(90.0f,0.0f,0.0f), roadNetworkEditingSystemObjRoot.transform);
+                    //obj.name = name;
+                    //obj.transform.hasChanged = false;   // transformの変更を検知するためfalseを設定
+                    var subData = new NodeEditorData();
                     nodeEditorData.Add(node, subData);
 
                     id++;
@@ -1414,7 +1414,7 @@ namespace PLATEAU.Editor.RoadNetwork
                         var node1 = linkGroup.NextIntersection;
                         var editorData = new EditorData<RnRoadGroup>(linkGroup);
 
-                        var cn = new LinkGroupEditorData(editorData, nodeEditorData[node0], nodeEditorData[node1], linkGroup.Roads);
+                        var cn = new LinkGroupEditorData(editorData, linkGroup.Roads);
                         // 同じものを格納済みかチェック
                         var isContain = false;
                         foreach (var group in linkGroups)
@@ -1619,8 +1619,6 @@ namespace PLATEAU.Editor.RoadNetwork
 
                     var cameraPos = camera.transform.position;
                     var val = data.Value;
-                    var transform = val.RefGameObject.transform;
-                    transform.LookAt(cameraPos, Vector3.up);
                 }
                 if (camera)
                 {
@@ -1661,8 +1659,10 @@ namespace PLATEAU.Editor.RoadNetwork
                     var wayEditorDataList = roadGroupEditorData.GetSubData<List<WayEditorData>>();
 
                     // way用の編集データがない場合は作成
-                    CreateWayEditorData(system, roadGroupEditorData, wayEditorDataList);
-
+                    if (wayEditorDataList == null)
+                    {
+                        CreateWayEditorData(system, roadGroupEditorData, wayEditorDataList);
+                    }
                     var isMouseOnViewport = true;
                     if (currentState == State.Default)
                     {

--- a/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
@@ -1846,7 +1846,6 @@ namespace PLATEAU.Editor.RoadNetwork
 
                 // 中央分離帯のwayを重複無しでコレクションする
                 Dictionary<RnRoad, HashSet<RnWay>> medianWays = new();
-                //IReadOnlyCollection<RnWay> medianWays = null;
                 foreach (var road in roadGroupEditorData.Ref.Roads)
                 {
                     HashSet<RnWay> ways = new HashSet<RnWay>();
@@ -1860,7 +1859,6 @@ namespace PLATEAU.Editor.RoadNetwork
                     {
                         ways.Add(way);
                     }
-                    //medianWays = leftWays.Concat(rightWays).ToArray();
                 }
 
                 // way用の編集データの作成準備
@@ -1869,12 +1867,18 @@ namespace PLATEAU.Editor.RoadNetwork
                 wayEditorDataList?.Clear();
 
                 // 車線のwayから中央分離帯のwayを除外
-                if (medianWays != null) {
-                    foreach (var ways in laneWays.Values)
+                foreach (var ways in laneWays.Values)
+                {
+                    foreach (var editingTarget in medianWays)
                     {
-                        foreach (var medianWay in medianWays)
+                        if (editingTarget.Value == null)
                         {
-                            //ways.Remove(medianWay);
+                            continue;
+                        }
+
+                        foreach (var medianWay in editingTarget.Value)
+                        { 
+                            ways.Remove(medianWay);
                         }
                     }
                 }
@@ -1911,22 +1915,18 @@ namespace PLATEAU.Editor.RoadNetwork
                 }
 
                 // 中央分離帯の編集用データを作成
-                if (medianWays != null)
+                foreach (var editingTarget in medianWays)
                 {
-                    foreach (var editingTarget in medianWays)
+                    if (editingTarget.Value == null)
                     {
-                        if (editingTarget.Value == null)
-                        {
-                            continue;
-                        }
+                        continue;
+                    }
 
-                        foreach (var way in editingTarget.Value)
-                        {
-                            var wayEditorData = new WayEditorData(way, null);
-                            wayEditorData.Type = WayEditorData.WayType.Median;
-                            wayEditorDataList.Add(wayEditorData);
-                        }
-
+                    foreach (var way in editingTarget.Value)
+                    {
+                        var wayEditorData = new WayEditorData(way, null);
+                        wayEditorData.Type = WayEditorData.WayType.Median;
+                        wayEditorDataList.Add(wayEditorData);
                     }
                 }
 

--- a/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
@@ -1845,11 +1845,22 @@ namespace PLATEAU.Editor.RoadNetwork
                 }
 
                 // 中央分離帯のwayを重複無しでコレクションする
-                IReadOnlyCollection<RnWay> medianWays = null;
+                Dictionary<RnRoad, HashSet<RnWay>> medianWays = new();
+                //IReadOnlyCollection<RnWay> medianWays = null;
                 foreach (var road in roadGroupEditorData.Ref.Roads)
                 {
+                    HashSet<RnWay> ways = new HashSet<RnWay>();
                     roadGroupEditorData.Ref.GetMedians(out var leftWays, out var rightWays);
-                    medianWays = leftWays.Concat(rightWays).ToArray();
+                    medianWays.TryAdd(road, ways);
+                    foreach (var way in leftWays)
+                    {
+                        ways.Add(way);
+                    }
+                    foreach (var way in rightWays)
+                    {
+                        ways.Add(way);
+                    }
+                    //medianWays = leftWays.Concat(rightWays).ToArray();
                 }
 
                 // way用の編集データの作成準備
@@ -1858,11 +1869,13 @@ namespace PLATEAU.Editor.RoadNetwork
                 wayEditorDataList?.Clear();
 
                 // 車線のwayから中央分離帯のwayを除外
-                foreach (var ways in laneWays.Values)
-                {
-                    foreach (var medianWay in medianWays)
+                if (medianWays != null) {
+                    foreach (var ways in laneWays.Values)
                     {
-                        ways.Remove(medianWay);
+                        foreach (var medianWay in medianWays)
+                        {
+                            //ways.Remove(medianWay);
+                        }
                     }
                 }
 
@@ -1898,11 +1911,23 @@ namespace PLATEAU.Editor.RoadNetwork
                 }
 
                 // 中央分離帯の編集用データを作成
-                foreach (var way in medianWays)
+                if (medianWays != null)
                 {
-                    var wayEditorData = new WayEditorData(way, null);
-                    wayEditorData.Type = WayEditorData.WayType.Median;
-                    wayEditorDataList.Add(wayEditorData);
+                    foreach (var editingTarget in medianWays)
+                    {
+                        if (editingTarget.Value == null)
+                        {
+                            continue;
+                        }
+
+                        foreach (var way in editingTarget.Value)
+                        {
+                            var wayEditorData = new WayEditorData(way, null);
+                            wayEditorData.Type = WayEditorData.WayType.Median;
+                            wayEditorDataList.Add(wayEditorData);
+                        }
+
+                    }
                 }
 
                 // 詳細編集モードではwayの選択は行わない

--- a/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
@@ -332,7 +332,6 @@ namespace PLATEAU.Editor.RoadNetwork
         public Color connectionColor = Color.blue;
 
         public ICollection<EditorData<RnIntersection>> intersections = new EditorData<RnIntersection>[0];
-        //public List<Vector3> intersections = new List<Vector3>();
         public Color intersectionColor = Color.green;
         public float intersectionRadius = 30.0f;
 
@@ -359,8 +358,8 @@ namespace PLATEAU.Editor.RoadNetwork
 
                 var subData = item.GetSubData<LinkGroupEditorData>();
 
-                var p1 = subData.A.RefGameObject.transform.position;
-                var p2 = subData.B.RefGameObject.transform.position;
+                var p1 = subData.A.GetCenter();
+                var p2 = subData.B.GetCenter();
                 var btnP = (p1 + p2) / 2.0f;
 
 
@@ -374,7 +373,7 @@ namespace PLATEAU.Editor.RoadNetwork
                     var isClicked = Button2DOn3D(camera, pos2d_dis, laneTex);
                     if (isClicked)
                     {
-                        Debug.Log(subData.A.RefGameObject.name + "-" + subData.B.RefGameObject.name);
+                        Debug.Log(subData.A.ToString() + "-" + subData.B.ToString());
                         editorSystem.SelectedRoadNetworkElement = item;
                         return;
                     }
@@ -382,13 +381,8 @@ namespace PLATEAU.Editor.RoadNetwork
             }
 
 
-            // ノードが重複して描画されるので nodeEitorDataで走査
-            HashSet<NodeEditorData> nodeEitorData = new HashSet<NodeEditorData>(connections.Count * 2);
-            foreach (var item in cns)
-            {
-                nodeEitorData.Add(item.A);
-                nodeEitorData.Add(item.B);
-            }
+            // ノード
+            var nodeEitorData = intersections;
 
             //foreach (var item in nodeEitorData)
             //{

--- a/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
@@ -499,9 +499,9 @@ namespace PLATEAU.Editor.RoadNetwork
                     //    unionWay.Remove(otherLane.RightWay);
                     //}
 
-                    var wayEditorDataList = roadGroupEditorData.GetSubData<List<WayEditorData>>();
+                    //var wayEditorDataList = roadGroupEditorData.GetSubData<List<WayEditorData>>();
                     //var nSlider = unionWay.Count; // 左右の
-                    if (wayEditorDataList == null)
+                    //if (wayEditorDataList == null)
                     {
                         //wayEditorDataList = new List<WayEditorData>(nSlider);
                         //foreach (var editingTarget in unionWay)
@@ -511,7 +511,7 @@ namespace PLATEAU.Editor.RoadNetwork
                         //roadGroupEditorData.TryAdd(wayEditorDataList);
                     }
 
-                    Assert.IsNotNull(wayEditorDataList);
+                    //Assert.IsNotNull(wayEditorDataList);
                     //if (wayEditorDataList.Count != nSlider)
                     //{
                     //    wayEditorDataList.Clear();
@@ -547,28 +547,28 @@ namespace PLATEAU.Editor.RoadNetwork
                     GUILayout.EndArea();
                     Handles.EndGUI();
 
-                    // 変更あったものに対してのみ差分を適用する
-                    foreach (var wayEditorData in wayEditorDataList)
-                    {
-                        if (wayEditorData.IsChanged == false)
-                        {
-                            continue;
-                        }
+                    //// 変更あったものに対してのみ差分を適用する
+                    //foreach (var wayEditorData in wayEditorDataList)
+                    //{
+                    //    if (wayEditorData.IsChanged == false)
+                    //    {
+                    //        continue;
+                    //    }
 
-                        var target = wayEditorData.Ref;
+                    //    var target = wayEditorData.Ref;
 
-                        // デフォルトの状態に戻す
-                        var baseWay = wayEditorData.BaseWay;
-                        for (int i = 0; i < baseWay.Count; i++)
-                        {
-                            var p = baseWay[i];
-                            var p2 = target.GetPoint(i);
-                            p2.Vertex = p;
-                        }
-                        var offset = wayEditorData.SliderVarVals;
-                        target.MoveAlongNormal(offset);
-                        Debug.Log($"way.MoveAlongNormal({offset})");
-                    }
+                    //    // デフォルトの状態に戻す
+                    //    var baseWay = wayEditorData.BaseWay;
+                    //    for (int i = 0; i < baseWay.Count; i++)
+                    //    {
+                    //        var p = baseWay[i];
+                    //        var p2 = target.GetPoint(i);
+                    //        p2.Vertex = p;
+                    //    }
+                    //    var offset = wayEditorData.SliderVarVals;
+                    //    target.MoveAlongNormal(offset);
+                    //    Debug.Log($"way.MoveAlongNormal({offset})");
+                    //}
                 }
                 else // 詳細モードでのみ表示
                 {

--- a/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
@@ -486,41 +486,6 @@ namespace PLATEAU.Editor.RoadNetwork
                     }
                     unionWay = ways.ToList();
 
-                    // 仕様上動かしてはいけないwayを除外する
-                    //// レーンが一つの場合は必ず歩道に接するので
-                    //if (lanes.Count == 1)
-                    //{
-                    //    unionWay.Clear();
-                    //}
-                    //else if (lanes.Count > 0)
-                    //{
-                    //    unionWay.Remove(lanes[0].LeftWay);
-                    //    var otherLane = lanes[lanes.Count - 1];
-                    //    unionWay.Remove(otherLane.RightWay);
-                    //}
-
-                    //var wayEditorDataList = roadGroupEditorData.GetSubData<List<WayEditorData>>();
-                    //var nSlider = unionWay.Count; // 左右の
-                    //if (wayEditorDataList == null)
-                    {
-                        //wayEditorDataList = new List<WayEditorData>(nSlider);
-                        //foreach (var editingTarget in unionWay)
-                        //{
-                        //    wayEditorDataList.Add(new WayEditorData(editingTarget));
-                        //}
-                        //roadGroupEditorData.TryAdd(wayEditorDataList);
-                    }
-
-                    //Assert.IsNotNull(wayEditorDataList);
-                    //if (wayEditorDataList.Count != nSlider)
-                    //{
-                    //    wayEditorDataList.Clear();
-                    //    wayEditorDataList.Capacity = nSlider;
-                    //    foreach (var editingTarget in unionWay)
-                    //    {
-                    //        wayEditorDataList.Add(new WayEditorData(editingTarget));
-                    //    }
-                    //}
                     Handles.BeginGUI();
                     GUILayout.BeginArea(new Rect(100, 100, 200, 300));
                     //GUILayout.BeginVertical();

--- a/Editor/RoadNetwork/RoadNetworkUIDoc.cs
+++ b/Editor/RoadNetwork/RoadNetworkUIDoc.cs
@@ -291,7 +291,7 @@ namespace PLATEAU.Editor.RoadNetwork
                 // UIへバインドするモデルオブジェクトの生成
                 var testObj = ScriptableObject.CreateInstance<ScriptableRoadMdl>();
                 testObj.Construct(linkGroupEditorData.Ref);
-                mdl = new SerializedScriptableRoadMdl(testObj, system.RoadNetworkSimpleEditModule);
+                mdl = new SerializedScriptableRoadMdl(testObj, linkGroupEditorData, system.RoadNetworkSimpleEditModule);
 
                 // 参照を持たせる
                 linkGroupEditorData.TryAdd(mdl);

--- a/Editor/RoadNetwork/UIDocBind/ScriptableRoadMdl.cs
+++ b/Editor/RoadNetwork/UIDocBind/ScriptableRoadMdl.cs
@@ -17,58 +17,21 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public List<RnLane> lanes { get; }
     }
 
-    //public class ObservableData<_Type> : IObservable<_Type>
-    //{
-
-    //    public ObservableData(in _Type data)
-    //    {
-    //        this.data = data;
-    //    }
-
-    //    private _Type data;
-    //    private Action<IObserver<_Type>> subScribe;
-
-    //    public IDisposable Subscribe(IObserver<_Type> observer)
-    //    {
-    //        throw new NotImplementedException();
-    //    }
-    //}
-
     /// <summary>
     /// 道路を編集する際に利用するデータモデルのインターフェイス
     /// クラス内でのLink、LaneはNode間を繋ぐLinkリスト、Laneリストを指す
     /// </summary>
     public interface IScriptableRoadMdl
     {
-        //public bool SetEditingTarget(INodeConnectionLink target);
-
-        //public INodeConnectionLink EditingTarget{ get; set; }
         public void Apply();
-
-        // 処理の成否を返す
-        // 値の設定後に確認するようにする
-        public bool IsSuccess { get; }
         public bool IsEditingDetailMode { get; set; }
         public int NumLeftLane { get; set; }
         public int NumRightLane { get; set; }
         public float MedianWidth { get; set; }
-        public float LeftSideWalkWidth { get; set; }
-        public float RightSideWalkWidth { get; set; }
-        public float RoadWidth { get; set; }
 
         public bool EnableLeftSideWalk { get; set; }
         public bool EnableRightSideWalk { get; set; }
 
-
-        //public bool ChangeLeftLaneCount(int count);
-        //public bool ChangeRightLaneCount(int count);
-        //public bool SetEnableSideWalk(bool isEnable);
-
-        //public bool ChangeRoadWidth(float width);
-        //public bool ChangeLeftSideWalkWidth(float width);
-        //public bool ChangeRightSideWalkWidth(float width);
-
-        //public bool ChangeLaneWidth(float width);
     }
 
     public struct ScriptableRoadMdlData
@@ -90,9 +53,6 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
             numLeftLane = mdl.NumLeftLane;
             numRightLane = mdl.NumRightLane;
             medianWidth = mdl.MedianWidth;
-            leftSideWalkWidth = mdl.LeftSideWalkWidth;
-            rightSideWalkWidth = mdl.RightSideWalkWidth;
-            roadWidth = mdl.RoadWidth;
 
             enableLeftSideWalk = mdl.EnableLeftSideWalk;
             enableRightSideWalk = mdl.EnableRightSideWalk;
@@ -100,7 +60,6 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         }
 
     }
-
 
     public class ScriptableRoadMdl : ScriptableObject, IScriptableRoadMdl
     {
@@ -126,9 +85,6 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public int numLeftLane = 3;
         public int numRightLane = 3;
         public float medianWidth = 0.0f;    // 0.0fは中央分離帯がないことを示す
-        public float leftSideWalkWidth = 0.0f;
-        public float rightSideWalkWidth = 0.0f;
-        public float roadWidth = 0.0f;
 
         public bool enableLeftSideWalk = true;
         public bool enableRightSideWalk = true;
@@ -146,7 +102,6 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         {
             throw new NotImplementedException();
         }
-        public bool IsSuccess { get; set; }
 
         public bool IsEditingDetailMode 
         {
@@ -164,22 +119,6 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
             set => SetPropety(value, ref numRightLane, nameof(NumRightLane));
         }
 
-        public float LeftSideWalkWidth
-        {
-            get => leftSideWalkWidth;
-            set => SetPropety(value, ref leftSideWalkWidth, nameof(leftSideWalkWidth));
-        }
-        public float RightSideWalkWidth
-        {
-            get => rightSideWalkWidth;
-            set => SetPropety(value, ref rightSideWalkWidth, nameof(rightSideWalkWidth));
-        }
-
-        public float RoadWidth
-        {
-            get => roadWidth;
-            set => SetPropety(value, ref roadWidth, nameof(roadWidth));
-        }
         public float MedianWidth 
         { 
             get => medianWidth; 
@@ -224,21 +163,13 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         {
             Assert.IsNotNull(mdl);
             Assert.IsNotNull(mod);
-            //serializedObject = mdl;
             this.mod = mod;
 
-            //            public float _leftSideWalkWidth = 0.0f;
-            //public float _rightSideWalkWidth = 0.0f;
-            //public float _laneWidth = 0.0f;
-            //public bool _isApply = false;
             road = FindProperty("road");
             isEditingDetailMode = FindProperty("isEditingDetailMode");
             numLeftLane = FindProperty("numLeftLane");
             numRightLane = FindProperty("numRightLane");
             medianWidth = FindProperty("medianWidth");
-            leftSideWalkWidth = FindProperty("leftSideWalkWidth");
-            rightSideWalkWidth = FindProperty("rightSideWalkWidth");
-            roadWidth = FindProperty("roadWidth");
 
             isApply = FindProperty("_isApply");
 
@@ -256,9 +187,6 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public SerializedProperty numLeftLane;
         public SerializedProperty numRightLane;
         public SerializedProperty medianWidth;
-        public SerializedProperty leftSideWalkWidth;
-        public SerializedProperty rightSideWalkWidth;
-        public SerializedProperty roadWidth;
 
         public SerializedProperty enableLeftSideWalk;
         public SerializedProperty enableRightSideWalk;
@@ -269,14 +197,9 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public RnSideWalk rPre;
 
         ScriptableRoadMdlData cache;
-        public bool IsSuccess => throw new NotImplementedException();
-
         public int NumLeftLane { get => numLeftLane.intValue; set => numLeftLane.intValue = value; }
         public int NumRightLane { get => numRightLane.intValue; set => numRightLane.intValue = value; }
         public float MedianWidth { get => medianWidth.floatValue; set => medianWidth.floatValue = value; }
-        public float LeftSideWalkWidth { get => leftSideWalkWidth.floatValue; set => leftSideWalkWidth.floatValue = value; }
-        public float RightSideWalkWidth { get => rightSideWalkWidth.floatValue; set => rightSideWalkWidth.floatValue = value; }
-        public float RoadWidth { get => roadWidth.floatValue; set => roadWidth.floatValue = value; }
         public bool IsEditingDetailMode { get => isEditingDetailMode.boolValue; set => isEditingDetailMode.boolValue = value; }
         public bool EnableLeftSideWalk { get => enableLeftSideWalk.boolValue; set => enableLeftSideWalk.boolValue = value; }
         public bool EnableRightSideWalk { get => enableRightSideWalk.boolValue; set => enableRightSideWalk.boolValue = value; }
@@ -345,22 +268,6 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
                 {
                     roadGroup.SetMedianWidth(MedianWidth, LaneWayMoveOption.MoveBothWay);
                 }
-            }
-
-            if (cache.roadWidth != RoadWidth)
-            {
-                Notify(RoadWidth, cache.roadWidth, nameof(RoadWidth));
-                cache.roadWidth = RoadWidth;
-            }
-            if (cache.leftSideWalkWidth != LeftSideWalkWidth)
-            {
-                Notify(LeftSideWalkWidth, cache.leftSideWalkWidth, nameof(LeftSideWalkWidth));
-                cache.leftSideWalkWidth = LeftSideWalkWidth;
-            }
-            if (cache.rightSideWalkWidth != RightSideWalkWidth)
-            {
-                Notify(RightSideWalkWidth, cache.rightSideWalkWidth, nameof(RightSideWalkWidth));
-                cache.rightSideWalkWidth = RightSideWalkWidth;
             }
 
             if (cache.enableLeftSideWalk != EnableLeftSideWalk)

--- a/Editor/RoadNetwork/UIDocBind/ScriptableRoadMdl.cs
+++ b/Editor/RoadNetwork/UIDocBind/ScriptableRoadMdl.cs
@@ -17,21 +17,54 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public List<RnLane> lanes { get; }
     }
 
+    //public class ObservableData<_Type> : IObservable<_Type>
+    //{
+
+    //    public ObservableData(in _Type data)
+    //    {
+    //        this.data = data;
+    //    }
+
+    //    private _Type data;
+    //    private Action<IObserver<_Type>> subScribe;
+
+    //    public IDisposable Subscribe(IObserver<_Type> observer)
+    //    {
+    //        throw new NotImplementedException();
+    //    }
+    //}
+
     /// <summary>
     /// 道路を編集する際に利用するデータモデルのインターフェイス
     /// クラス内でのLink、LaneはNode間を繋ぐLinkリスト、Laneリストを指す
     /// </summary>
     public interface IScriptableRoadMdl
     {
+        //public bool SetEditingTarget(INodeConnectionLink target);
+
+        //public INodeConnectionLink EditingTarget{ get; set; }
         public void Apply();
+
+        // 処理の成否を返す
+        // 値の設定後に確認するようにする
+        public bool IsSuccess { get; }
         public bool IsEditingDetailMode { get; set; }
         public int NumLeftLane { get; set; }
         public int NumRightLane { get; set; }
         public float MedianWidth { get; set; }
+        public float LeftSideWalkWidth { get; set; }
+        public float RightSideWalkWidth { get; set; }
+        public float RoadWidth { get; set; }
 
-        public bool EnableLeftSideWalk { get; set; }
-        public bool EnableRightSideWalk { get; set; }
+        //public bool ChangeLeftLaneCount(int count);
+        //public bool ChangeRightLaneCount(int count);
+        //public bool SetEnableSideWalk(bool isEnable);
 
+        //public bool ChangeRoadWidth(float width);
+        //public bool ChangeLeftSideWalkWidth(float width);
+        //public bool ChangeRightSideWalkWidth(float width);
+
+        //public bool ChangeLaneWidth(float width);
     }
 
     public struct ScriptableRoadMdlData
@@ -44,22 +77,20 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public float rightSideWalkWidth;
         public float roadWidth;
 
-        public bool enableLeftSideWalk;
-        public bool enableRightSideWalk;
-
         public void Reset(IScriptableRoadMdl mdl)
         {
             isEditingDetailMode = mdl.IsEditingDetailMode;
             numLeftLane = mdl.NumLeftLane;
             numRightLane = mdl.NumRightLane;
             medianWidth = mdl.MedianWidth;
-
-            enableLeftSideWalk = mdl.EnableLeftSideWalk;
-            enableRightSideWalk = mdl.EnableRightSideWalk;
+            leftSideWalkWidth = mdl.LeftSideWalkWidth;
+            rightSideWalkWidth = mdl.RightSideWalkWidth;
+            roadWidth = mdl.RoadWidth;
 
         }
 
     }
+
 
     public class ScriptableRoadMdl : ScriptableObject, IScriptableRoadMdl
     {
@@ -75,7 +106,6 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
             numLeftLane = this.road.GetLeftLaneCount();
             numRightLane = this.road.GetRightLaneCount();
             
-
             ResetCache();
         }
 
@@ -85,9 +115,9 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public int numLeftLane = 3;
         public int numRightLane = 3;
         public float medianWidth = 0.0f;    // 0.0fは中央分離帯がないことを示す
-
-        public bool enableLeftSideWalk = true;
-        public bool enableRightSideWalk = true;
+        public float leftSideWalkWidth = 0.0f;
+        public float rightSideWalkWidth = 0.0f;
+        public float roadWidth = 0.0f;
 
         ScriptableRoadMdlData cache;
 
@@ -101,7 +131,38 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public void Apply()
         {
             throw new NotImplementedException();
+            //if (cache.numLeftLane != NumLeftLane)
+            //{
+            //    Notify(NumLeftLane, cache.numLeftLane, nameof(NumLeftLane));
+            //    cache.numLeftLane = NumLeftLane;
+            //}
+            //if (cache.numRightLane != NumRightLane)
+            //{
+            //    Notify(NumRightLane, cache.numRightLane, nameof(NumRightLane));
+            //    cache.numRightLane = NumRightLane;
+            //}
+            //if (cache.medianWidth != MedianWidth)
+            //{
+            //    Notify(MedianWidth, cache.medianWidth, nameof(MedianWidth));
+            //    cache.medianWidth = MedianWidth;
+            //}
+            //if (cache.leftSideWalkWidth != LeftSideWalkWidth)
+            //{
+            //    Notify(LeftSideWalkWidth, cache.leftSideWalkWidth, nameof(LeftSideWalkWidth));
+            //    cache.leftSideWalkWidth = LeftSideWalkWidth;
+            //}
+            //if (cache.rightSideWalkWidth != RightSideWalkWidth)
+            //{
+            //    Notify(RightSideWalkWidth, cache.rightSideWalkWidth, nameof(RightSideWalkWidth));
+            //    cache.rightSideWalkWidth = RightSideWalkWidth;
+            //}
+            //if (cache.roadWidth != RoadWidth)
+            //{
+            //    Notify(RoadWidth, cache.roadWidth, nameof(RoadWidth));
+            //    cache.roadWidth = RoadWidth;
+            //}
         }
+        public bool IsSuccess { get; set; }
 
         public bool IsEditingDetailMode 
         {
@@ -119,20 +180,26 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
             set => SetPropety(value, ref numRightLane, nameof(NumRightLane));
         }
 
+        public float LeftSideWalkWidth
+        {
+            get => leftSideWalkWidth;
+            set => SetPropety(value, ref leftSideWalkWidth, nameof(leftSideWalkWidth));
+        }
+        public float RightSideWalkWidth
+        {
+            get => rightSideWalkWidth;
+            set => SetPropety(value, ref rightSideWalkWidth, nameof(rightSideWalkWidth));
+        }
+
+        public float RoadWidth
+        {
+            get => roadWidth;
+            set => SetPropety(value, ref roadWidth, nameof(roadWidth));
+        }
         public float MedianWidth 
         { 
             get => medianWidth; 
             set => SetPropety(value, ref medianWidth, nameof(medianWidth)); 
-        }
-        public bool EnableLeftSideWalk 
-        { 
-            get => enableLeftSideWalk; 
-            set => SetPropety(value, ref enableLeftSideWalk, nameof(enableLeftSideWalk)); 
-        }
-        public bool EnableRightSideWalk 
-        {
-            get => enableRightSideWalk;
-            set => SetPropety(value, ref enableRightSideWalk, nameof(enableRightSideWalk));
         }
 
         private static void SetPropety<_T>(in _T v, ref _T current, in string name)
@@ -163,18 +230,29 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         {
             Assert.IsNotNull(mdl);
             Assert.IsNotNull(mod);
+            //serializedObject = mdl;
             this.mod = mod;
 
+            //            public float _leftSideWalkWidth = 0.0f;
+            //public float _rightSideWalkWidth = 0.0f;
+            //public float _laneWidth = 0.0f;
+            //public bool _isApply = false;
             road = FindProperty("road");
             isEditingDetailMode = FindProperty("isEditingDetailMode");
             numLeftLane = FindProperty("numLeftLane");
             numRightLane = FindProperty("numRightLane");
             medianWidth = FindProperty("medianWidth");
+            leftSideWalkWidth = FindProperty("leftSideWalkWidth");
+            rightSideWalkWidth = FindProperty("rightSideWalkWidth");
+            roadWidth = FindProperty("roadWidth");
 
             isApply = FindProperty("_isApply");
-
-            enableLeftSideWalk = FindProperty("enableLeftSideWalk");
-            enableRightSideWalk = FindProperty("enableRightSideWalk");
+            //_numLeftLane = serializedObject.FindProperty("_numLeftLane");
+            //_numRightLane = serializedObject.FindProperty("_numRightLane");
+            //_enableSideWalk = serializedObject.FindProperty("_enableSideWalk");
+            //_leftSideWalkWidth = serializedObject.FindProperty("_leftSideWalkWidth");
+            //_rightSideWalkWidth = serializedObject.FindProperty("_rightSideWalkWidth");
+            //_isApply = serializedObject.FindProperty("_isApply");
 
             ResetCache();
         }
@@ -187,22 +265,28 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public SerializedProperty numLeftLane;
         public SerializedProperty numRightLane;
         public SerializedProperty medianWidth;
-
-        public SerializedProperty enableLeftSideWalk;
-        public SerializedProperty enableRightSideWalk;
+        public SerializedProperty leftSideWalkWidth;
+        public SerializedProperty rightSideWalkWidth;
+        public SerializedProperty roadWidth;
 
         public SerializedProperty isApply;
-
-        public RnSideWalk lPre;
-        public RnSideWalk rPre;
+        //public UIDocBindHelper.IAccessor<int> _numLeftLane;
+        //public UIDocBindHelper.IAccessor<int> _numRightLane;
+        //public UIDocBindHelper.IAccessor<bool> _enableSideWalk ;
+        //public UIDocBindHelper.IAccessor<float> _leftSideWalkWidth;
+        //public UIDocBindHelper.IAccessor<float> _rightSideWalkWidth;
+        //public UIDocBindHelper.IAccessor<bool> _isApply;
 
         ScriptableRoadMdlData cache;
+        public bool IsSuccess => throw new NotImplementedException();
+
         public int NumLeftLane { get => numLeftLane.intValue; set => numLeftLane.intValue = value; }
         public int NumRightLane { get => numRightLane.intValue; set => numRightLane.intValue = value; }
         public float MedianWidth { get => medianWidth.floatValue; set => medianWidth.floatValue = value; }
+        public float LeftSideWalkWidth { get => leftSideWalkWidth.floatValue; set => leftSideWalkWidth.floatValue = value; }
+        public float RightSideWalkWidth { get => rightSideWalkWidth.floatValue; set => rightSideWalkWidth.floatValue = value; }
+        public float RoadWidth { get => roadWidth.floatValue; set => roadWidth.floatValue = value; }
         public bool IsEditingDetailMode { get => isEditingDetailMode.boolValue; set => isEditingDetailMode.boolValue = value; }
-        public bool EnableLeftSideWalk { get => enableLeftSideWalk.boolValue; set => enableLeftSideWalk.boolValue = value; }
-        public bool EnableRightSideWalk { get => enableRightSideWalk.boolValue; set => enableRightSideWalk.boolValue = value; }
 
         public bool ChangeLaneWidth(float width)
         {
@@ -225,7 +309,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
 
             bool isChanged = false;
             var roadObj = targetObject as ScriptableRoadMdl;
-            var roadGroup = roadObj.road;
+            var road = roadObj.road;
 
             if (cache.isEditingDetailMode != IsEditingDetailMode)
             {
@@ -243,7 +327,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
                 Notify(NumLeftLane, cache.numLeftLane, nameof(NumLeftLane));
                 cache.numLeftLane = NumLeftLane;
                 isChanged = true;
-                roadGroup.SetLeftLaneCount(NumLeftLane);
+                road.SetLeftLaneCount(NumLeftLane);
 
             }
             if (cache.numRightLane != NumRightLane)
@@ -251,7 +335,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
                 Notify(NumRightLane, cache.numRightLane, nameof(NumRightLane));
                 cache.numRightLane = NumRightLane;
                 isChanged = true;
-                roadGroup.SetRightLaneCount(NumRightLane);
+                road.SetRightLaneCount(NumRightLane);
 
             }
             if (cache.medianWidth != MedianWidth) 
@@ -262,37 +346,28 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
 
                 if (MedianWidth == 0.0f)
                 {
-                    roadGroup.RemoveMedian();
+                    road.RemoveMedian();
                 }
                 else
                 {
-                    roadGroup.SetMedianWidth(MedianWidth, LaneWayMoveOption.MoveBothWay);
+                    road.SetMedianWidth(MedianWidth, LaneWayMoveOption.MoveBothWay);
                 }
             }
 
-            if (cache.enableLeftSideWalk != EnableLeftSideWalk)
+            if (cache.roadWidth != RoadWidth)
             {
-                Notify(EnableLeftSideWalk, cache.enableLeftSideWalk, nameof(EnableLeftSideWalk));
-                cache.enableLeftSideWalk = EnableLeftSideWalk;
-                foreach (var road in roadGroup.Roads)
-                {
-                    //road.SideWalks
-                    ////road.SideWalks.Count() == ; // レーンの向きを見て　左右の判断
-                    //foreach (var lane in road.GetLeftLanes())
-                    //{
-                    //    lane
-                    //}
-                    //road.SideWalks[0].SetWidth(LeftSideWalkWidth);
-                    //road.RemoveSideWalk(SideWalkType.Left);
-                }
-                isChanged = true;
+                Notify(RoadWidth, cache.roadWidth, nameof(RoadWidth));
+                cache.roadWidth = RoadWidth;
             }
-
-            if (cache.enableRightSideWalk != EnableRightSideWalk)
+            if (cache.leftSideWalkWidth != LeftSideWalkWidth)
             {
-                Notify(EnableRightSideWalk, cache.enableRightSideWalk, nameof(EnableRightSideWalk));
-                cache.enableRightSideWalk = EnableRightSideWalk;
-                isChanged = true;
+                Notify(LeftSideWalkWidth, cache.leftSideWalkWidth, nameof(LeftSideWalkWidth));
+                cache.leftSideWalkWidth = LeftSideWalkWidth;
+            }
+            if (cache.rightSideWalkWidth != RightSideWalkWidth)
+            {
+                Notify(RightSideWalkWidth, cache.rightSideWalkWidth, nameof(RightSideWalkWidth));
+                cache.rightSideWalkWidth = RightSideWalkWidth;
             }
 
 

--- a/Editor/RoadNetwork/UIDocBind/ScriptableRoadMdl.cs
+++ b/Editor/RoadNetwork/UIDocBind/ScriptableRoadMdl.cs
@@ -225,13 +225,22 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
 
     public class SerializedScriptableRoadMdl : SerializedObject, IScriptableRoadMdl
     {
-        public SerializedScriptableRoadMdl(ScriptableRoadMdl mdl, RoadNetworkSimpleEditSysModule mod)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="mdl"></param>
+        /// <param name="editorData">ScriptableRoadMdlで扱っているRnRoadGroupと対象が同じである必要</param>
+        /// <param name="mod"></param>
+        public SerializedScriptableRoadMdl(ScriptableRoadMdl mdl, EditorData<RnRoadGroup> editorData, RoadNetworkSimpleEditSysModule mod)
             : base(mdl)
         {
             Assert.IsNotNull(mdl);
             Assert.IsNotNull(mod);
+            Assert.IsTrue(mdl.road == editorData.Ref);
             //serializedObject = mdl;
             this.mod = mod;
+
+            this.editorData = editorData;
 
             //            public float _leftSideWalkWidth = 0.0f;
             //public float _rightSideWalkWidth = 0.0f;
@@ -259,6 +268,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
 
         public RoadNetworkSimpleEditSysModule mod;
 
+        public EditorData<RnRoadGroup> editorData;
         public SerializedProperty road;
 
         public SerializedProperty isEditingDetailMode;
@@ -310,7 +320,6 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
             bool isChanged = false;
             var roadObj = targetObject as ScriptableRoadMdl;
             var road = roadObj.road;
-
             if (cache.isEditingDetailMode != IsEditingDetailMode)
             {
                 //if (mod.CanSetDtailMode())
@@ -328,7 +337,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
                 cache.numLeftLane = NumLeftLane;
                 isChanged = true;
                 road.SetLeftLaneCount(NumLeftLane);
-
+                editorData.ClearSubData();
             }
             if (cache.numRightLane != NumRightLane)
             {
@@ -336,7 +345,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
                 cache.numRightLane = NumRightLane;
                 isChanged = true;
                 road.SetRightLaneCount(NumRightLane);
-
+                editorData.ClearSubData();
             }
             if (cache.medianWidth != MedianWidth) 
             {
@@ -347,6 +356,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
                 if (MedianWidth == 0.0f)
                 {
                     road.RemoveMedian();
+                    editorData.ClearSubData();
                 }
                 else
                 {

--- a/Editor/RoadNetwork/UIDocBind/ScriptableRoadMdl.cs
+++ b/Editor/RoadNetwork/UIDocBind/ScriptableRoadMdl.cs
@@ -51,7 +51,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public bool IsEditingDetailMode { get; set; }
         public int NumLeftLane { get; set; }
         public int NumRightLane { get; set; }
-        public float MedianWidth { get; set; }
+        public bool EnableMedianLane { get; set; }
         public float LeftSideWalkWidth { get; set; }
         public float RightSideWalkWidth { get; set; }
         public float RoadWidth { get; set; }
@@ -72,7 +72,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public bool isEditingDetailMode;
         public int numLeftLane;
         public int numRightLane;
-        public float medianWidth;
+        public bool enableMedianLane;
         public float leftSideWalkWidth;
         public float rightSideWalkWidth;
         public float roadWidth;
@@ -82,7 +82,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
             isEditingDetailMode = mdl.IsEditingDetailMode;
             numLeftLane = mdl.NumLeftLane;
             numRightLane = mdl.NumRightLane;
-            medianWidth = mdl.MedianWidth;
+            enableMedianLane = mdl.EnableMedianLane;
             leftSideWalkWidth = mdl.LeftSideWalkWidth;
             rightSideWalkWidth = mdl.RightSideWalkWidth;
             roadWidth = mdl.RoadWidth;
@@ -105,7 +105,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
 
             numLeftLane = this.road.GetLeftLaneCount();
             numRightLane = this.road.GetRightLaneCount();
-            
+            enableMedianLane = this.road.HasMedians();
             ResetCache();
         }
 
@@ -114,7 +114,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public bool isEditingDetailMode;
         public int numLeftLane = 3;
         public int numRightLane = 3;
-        public float medianWidth = 0.0f;    // 0.0fは中央分離帯がないことを示す
+        public bool enableMedianLane = true;
         public float leftSideWalkWidth = 0.0f;
         public float rightSideWalkWidth = 0.0f;
         public float roadWidth = 0.0f;
@@ -196,10 +196,10 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
             get => roadWidth;
             set => SetPropety(value, ref roadWidth, nameof(roadWidth));
         }
-        public float MedianWidth 
+        public bool EnableMedianLane
         { 
-            get => medianWidth; 
-            set => SetPropety(value, ref medianWidth, nameof(medianWidth)); 
+            get => enableMedianLane; 
+            set => SetPropety(value, ref enableMedianLane, nameof(enableMedianLane)); 
         }
 
         private static void SetPropety<_T>(in _T v, ref _T current, in string name)
@@ -250,7 +250,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
             isEditingDetailMode = FindProperty("isEditingDetailMode");
             numLeftLane = FindProperty("numLeftLane");
             numRightLane = FindProperty("numRightLane");
-            medianWidth = FindProperty("medianWidth");
+            enableMedianLane = FindProperty("enableMedianLane");
             leftSideWalkWidth = FindProperty("leftSideWalkWidth");
             rightSideWalkWidth = FindProperty("rightSideWalkWidth");
             roadWidth = FindProperty("roadWidth");
@@ -274,7 +274,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public SerializedProperty isEditingDetailMode;
         public SerializedProperty numLeftLane;
         public SerializedProperty numRightLane;
-        public SerializedProperty medianWidth;
+        public SerializedProperty enableMedianLane;
         public SerializedProperty leftSideWalkWidth;
         public SerializedProperty rightSideWalkWidth;
         public SerializedProperty roadWidth;
@@ -292,7 +292,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
 
         public int NumLeftLane { get => numLeftLane.intValue; set => numLeftLane.intValue = value; }
         public int NumRightLane { get => numRightLane.intValue; set => numRightLane.intValue = value; }
-        public float MedianWidth { get => medianWidth.floatValue; set => medianWidth.floatValue = value; }
+        public bool EnableMedianLane { get => enableMedianLane.boolValue; set => enableMedianLane.boolValue = value; }
         public float LeftSideWalkWidth { get => leftSideWalkWidth.floatValue; set => leftSideWalkWidth.floatValue = value; }
         public float RightSideWalkWidth { get => rightSideWalkWidth.floatValue; set => rightSideWalkWidth.floatValue = value; }
         public float RoadWidth { get => roadWidth.floatValue; set => roadWidth.floatValue = value; }
@@ -347,20 +347,21 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
                 road.SetRightLaneCount(NumRightLane);
                 editorData.ClearSubData();
             }
-            if (cache.medianWidth != MedianWidth) 
+            if (cache.enableMedianLane != EnableMedianLane) 
             {
-                Notify(MedianWidth, cache.medianWidth, nameof(MedianWidth));
-                cache.medianWidth = MedianWidth;
+                Notify(EnableMedianLane, cache.enableMedianLane, nameof(EnableMedianLane));
+                cache.enableMedianLane = EnableMedianLane;
                 isChanged = true;
 
-                if (MedianWidth == 0.0f)
+                if (EnableMedianLane == false)
                 {
                     road.RemoveMedian();
                     editorData.ClearSubData();
                 }
                 else
                 {
-                    road.SetMedianWidth(MedianWidth, LaneWayMoveOption.MoveBothWay);
+                    const float medianWidth = 10.0f;
+                    road.SetMedianWidth(medianWidth, LaneWayMoveOption.MoveBothWay);
                 }
             }
 

--- a/Editor/RoadNetwork/UIDocBind/ScriptableRoadMdl.cs
+++ b/Editor/RoadNetwork/UIDocBind/ScriptableRoadMdl.cs
@@ -56,6 +56,10 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public float RightSideWalkWidth { get; set; }
         public float RoadWidth { get; set; }
 
+        public bool EnableLeftSideWalk { get; set; }
+        public bool EnableRightSideWalk { get; set; }
+
+
         //public bool ChangeLeftLaneCount(int count);
         //public bool ChangeRightLaneCount(int count);
         //public bool SetEnableSideWalk(bool isEnable);
@@ -77,6 +81,9 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public float rightSideWalkWidth;
         public float roadWidth;
 
+        public bool enableLeftSideWalk;
+        public bool enableRightSideWalk;
+
         public void Reset(IScriptableRoadMdl mdl)
         {
             isEditingDetailMode = mdl.IsEditingDetailMode;
@@ -86,6 +93,9 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
             leftSideWalkWidth = mdl.LeftSideWalkWidth;
             rightSideWalkWidth = mdl.RightSideWalkWidth;
             roadWidth = mdl.RoadWidth;
+
+            enableLeftSideWalk = mdl.EnableLeftSideWalk;
+            enableRightSideWalk = mdl.EnableRightSideWalk;
 
         }
 
@@ -106,6 +116,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
             numLeftLane = this.road.GetLeftLaneCount();
             numRightLane = this.road.GetRightLaneCount();
             
+
             ResetCache();
         }
 
@@ -119,6 +130,9 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public float rightSideWalkWidth = 0.0f;
         public float roadWidth = 0.0f;
 
+        public bool enableLeftSideWalk = true;
+        public bool enableRightSideWalk = true;
+
         ScriptableRoadMdlData cache;
 
 
@@ -131,36 +145,6 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public void Apply()
         {
             throw new NotImplementedException();
-            //if (cache.numLeftLane != NumLeftLane)
-            //{
-            //    Notify(NumLeftLane, cache.numLeftLane, nameof(NumLeftLane));
-            //    cache.numLeftLane = NumLeftLane;
-            //}
-            //if (cache.numRightLane != NumRightLane)
-            //{
-            //    Notify(NumRightLane, cache.numRightLane, nameof(NumRightLane));
-            //    cache.numRightLane = NumRightLane;
-            //}
-            //if (cache.medianWidth != MedianWidth)
-            //{
-            //    Notify(MedianWidth, cache.medianWidth, nameof(MedianWidth));
-            //    cache.medianWidth = MedianWidth;
-            //}
-            //if (cache.leftSideWalkWidth != LeftSideWalkWidth)
-            //{
-            //    Notify(LeftSideWalkWidth, cache.leftSideWalkWidth, nameof(LeftSideWalkWidth));
-            //    cache.leftSideWalkWidth = LeftSideWalkWidth;
-            //}
-            //if (cache.rightSideWalkWidth != RightSideWalkWidth)
-            //{
-            //    Notify(RightSideWalkWidth, cache.rightSideWalkWidth, nameof(RightSideWalkWidth));
-            //    cache.rightSideWalkWidth = RightSideWalkWidth;
-            //}
-            //if (cache.roadWidth != RoadWidth)
-            //{
-            //    Notify(RoadWidth, cache.roadWidth, nameof(RoadWidth));
-            //    cache.roadWidth = RoadWidth;
-            //}
         }
         public bool IsSuccess { get; set; }
 
@@ -200,6 +184,16 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         { 
             get => medianWidth; 
             set => SetPropety(value, ref medianWidth, nameof(medianWidth)); 
+        }
+        public bool EnableLeftSideWalk 
+        { 
+            get => enableLeftSideWalk; 
+            set => SetPropety(value, ref enableLeftSideWalk, nameof(enableLeftSideWalk)); 
+        }
+        public bool EnableRightSideWalk 
+        {
+            get => enableRightSideWalk;
+            set => SetPropety(value, ref enableRightSideWalk, nameof(enableRightSideWalk));
         }
 
         private static void SetPropety<_T>(in _T v, ref _T current, in string name)
@@ -247,12 +241,9 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
             roadWidth = FindProperty("roadWidth");
 
             isApply = FindProperty("_isApply");
-            //_numLeftLane = serializedObject.FindProperty("_numLeftLane");
-            //_numRightLane = serializedObject.FindProperty("_numRightLane");
-            //_enableSideWalk = serializedObject.FindProperty("_enableSideWalk");
-            //_leftSideWalkWidth = serializedObject.FindProperty("_leftSideWalkWidth");
-            //_rightSideWalkWidth = serializedObject.FindProperty("_rightSideWalkWidth");
-            //_isApply = serializedObject.FindProperty("_isApply");
+
+            enableLeftSideWalk = FindProperty("enableLeftSideWalk");
+            enableRightSideWalk = FindProperty("enableRightSideWalk");
 
             ResetCache();
         }
@@ -269,13 +260,13 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public SerializedProperty rightSideWalkWidth;
         public SerializedProperty roadWidth;
 
+        public SerializedProperty enableLeftSideWalk;
+        public SerializedProperty enableRightSideWalk;
+
         public SerializedProperty isApply;
-        //public UIDocBindHelper.IAccessor<int> _numLeftLane;
-        //public UIDocBindHelper.IAccessor<int> _numRightLane;
-        //public UIDocBindHelper.IAccessor<bool> _enableSideWalk ;
-        //public UIDocBindHelper.IAccessor<float> _leftSideWalkWidth;
-        //public UIDocBindHelper.IAccessor<float> _rightSideWalkWidth;
-        //public UIDocBindHelper.IAccessor<bool> _isApply;
+
+        public RnSideWalk lPre;
+        public RnSideWalk rPre;
 
         ScriptableRoadMdlData cache;
         public bool IsSuccess => throw new NotImplementedException();
@@ -287,6 +278,8 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
         public float RightSideWalkWidth { get => rightSideWalkWidth.floatValue; set => rightSideWalkWidth.floatValue = value; }
         public float RoadWidth { get => roadWidth.floatValue; set => roadWidth.floatValue = value; }
         public bool IsEditingDetailMode { get => isEditingDetailMode.boolValue; set => isEditingDetailMode.boolValue = value; }
+        public bool EnableLeftSideWalk { get => enableLeftSideWalk.boolValue; set => enableLeftSideWalk.boolValue = value; }
+        public bool EnableRightSideWalk { get => enableRightSideWalk.boolValue; set => enableRightSideWalk.boolValue = value; }
 
         public bool ChangeLaneWidth(float width)
         {
@@ -309,7 +302,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
 
             bool isChanged = false;
             var roadObj = targetObject as ScriptableRoadMdl;
-            var road = roadObj.road;
+            var roadGroup = roadObj.road;
 
             if (cache.isEditingDetailMode != IsEditingDetailMode)
             {
@@ -327,7 +320,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
                 Notify(NumLeftLane, cache.numLeftLane, nameof(NumLeftLane));
                 cache.numLeftLane = NumLeftLane;
                 isChanged = true;
-                road.SetLeftLaneCount(NumLeftLane);
+                roadGroup.SetLeftLaneCount(NumLeftLane);
 
             }
             if (cache.numRightLane != NumRightLane)
@@ -335,7 +328,7 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
                 Notify(NumRightLane, cache.numRightLane, nameof(NumRightLane));
                 cache.numRightLane = NumRightLane;
                 isChanged = true;
-                road.SetRightLaneCount(NumRightLane);
+                roadGroup.SetRightLaneCount(NumRightLane);
 
             }
             if (cache.medianWidth != MedianWidth) 
@@ -346,11 +339,11 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
 
                 if (MedianWidth == 0.0f)
                 {
-                    road.RemoveMedian();
+                    roadGroup.RemoveMedian();
                 }
                 else
                 {
-                    road.SetMedianWidth(MedianWidth, LaneWayMoveOption.MoveBothWay);
+                    roadGroup.SetMedianWidth(MedianWidth, LaneWayMoveOption.MoveBothWay);
                 }
             }
 
@@ -368,6 +361,31 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
             {
                 Notify(RightSideWalkWidth, cache.rightSideWalkWidth, nameof(RightSideWalkWidth));
                 cache.rightSideWalkWidth = RightSideWalkWidth;
+            }
+
+            if (cache.enableLeftSideWalk != EnableLeftSideWalk)
+            {
+                Notify(EnableLeftSideWalk, cache.enableLeftSideWalk, nameof(EnableLeftSideWalk));
+                cache.enableLeftSideWalk = EnableLeftSideWalk;
+                foreach (var road in roadGroup.Roads)
+                {
+                    //road.SideWalks
+                    ////road.SideWalks.Count() == ; // レーンの向きを見て　左右の判断
+                    //foreach (var lane in road.GetLeftLanes())
+                    //{
+                    //    lane
+                    //}
+                    //road.SideWalks[0].SetWidth(LeftSideWalkWidth);
+                    //road.RemoveSideWalk(SideWalkType.Left);
+                }
+                isChanged = true;
+            }
+
+            if (cache.enableRightSideWalk != EnableRightSideWalk)
+            {
+                Notify(EnableRightSideWalk, cache.enableRightSideWalk, nameof(EnableRightSideWalk));
+                cache.enableRightSideWalk = EnableRightSideWalk;
+                isChanged = true;
             }
 
 

--- a/Editor/RoadNetwork/UIDocBind/ScriptableRoadMdl.cs
+++ b/Editor/RoadNetwork/UIDocBind/ScriptableRoadMdl.cs
@@ -360,8 +360,15 @@ namespace PLATEAU.Editor.RoadNetwork.UIDocBind
                 }
                 else
                 {
-                    const float medianWidth = 10.0f;
-                    road.SetMedianWidth(medianWidth, LaneWayMoveOption.MoveBothWay);
+                    var isSuc = road.CreateMedianOrSkip();
+                    if (isSuc == false)
+                    {
+                        Debug.Log("CreateMedianOrSkip() : 作成に失敗");
+                    }
+                    editorData.ClearSubData();
+
+                    // ToDo ここで作成したMedianに対してeditorDataで所持している値を適用する
+                    //...
                 }
             }
 

--- a/Resources/PlateauUIDocument/RoadNetwork/RoadNetworkEditingRoadPanel.uxml
+++ b/Resources/PlateauUIDocument/RoadNetwork/RoadNetworkEditingRoadPanel.uxml
@@ -10,7 +10,7 @@
             </ui:Label>
         </ui:GroupBox>
         <ui:GroupBox name="WidthGroup" style="display: flex;">
-            <ui:FloatField label="中央分離帯の幅" value="42.2" binding-path="medianWidth" />
+            <ui:Toggle label="中央分離帯の有無" binding-path="enableMedianLane" />
         </ui:GroupBox>
         <ui:Toggle label="左側歩道の有無" binding-path="EnableLeftSideWalk" />
         <ui:Toggle label="右側歩道の有無" binding-path="EnableRightSideWalk" />

--- a/Resources/PlateauUIDocument/RoadNetwork/RoadNetworkEditingRoadPanel.uxml
+++ b/Resources/PlateauUIDocument/RoadNetwork/RoadNetworkEditingRoadPanel.uxml
@@ -10,11 +10,10 @@
             </ui:Label>
         </ui:GroupBox>
         <ui:GroupBox name="WidthGroup" style="display: flex;">
-            <ui:FloatField label="道路の幅" value="42.2" binding-path="roadWidth" />
             <ui:FloatField label="中央分離帯の幅" value="42.2" binding-path="medianWidth" />
-            <ui:FloatField label="左側歩道の幅" value="42.2" binding-path="leftSideWalkWidth" />
-            <ui:FloatField label="右側歩道の幅" value="42.2" binding-path="rightSideWalkWidth" />
         </ui:GroupBox>
+        <ui:Toggle label="左側歩道の有無" binding-path="EnableLeftSideWalk" />
+        <ui:Toggle label="右側歩道の有無" binding-path="EnableRightSideWalk" />
         <ui:Button text="適用" parse-escape-sequences="true" display-tooltip-when-elided="true" binding-path="_isApply" name="ApplyButton" />
         <ui:VisualElement style="flex-direction: row; justify-content: space-between; display: none;">
             <ui:Button text="前の設定" parse-escape-sequences="true" display-tooltip-when-elided="true" name="NextButton" />

--- a/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
@@ -413,6 +413,10 @@ namespace PLATEAU.RoadNetwork.Structure
             right = rWays;
         }
 
+        public bool HasMedians()
+        {
+           return Roads.Any(l => l.MedianLane != null);
+        }
 
         /// <summary>
         /// 中央分離帯の幅を設定する. 非推奨. 個別にWayを動かすことを推奨

--- a/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
@@ -389,6 +389,29 @@ namespace PLATEAU.RoadNetwork.Structure
                 l.SetMedianLane(null);
         }
 
+        /// <summary>
+        /// 中央分離帯を取得する
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        public void GetMedians(
+            out IReadOnlyCollection<RnWay> left,
+            out IReadOnlyCollection<RnWay> right)
+        {
+            var lWays = new List<RnWay>(Roads.Count);
+            var rWays = new List<RnWay>(Roads.Count);
+
+            foreach (var road in Roads)
+            {
+                var centerLeft = road.GetLeftLanes().Last();
+                var centerRight = road.GetRightLanes().First();
+                lWays.Add(centerLeft.RightWay);
+                rWays.Add(centerRight.RightWay);
+            }
+
+            left = lWays;
+            right = rWays;
+        }
 
 
         /// <summary>


### PR DESCRIPTION
﻿## 関連リンク
[本プルリク](https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/pull/316)
[途中２　このドラフト](https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/pull/337)
[途中１](https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/pull/336)

## 実装内容
中央分離帯をスライドした時に複製されるバグの修正
中央分離帯の編集機能のパラメータの調整
手動編集機能の編集用データの生成破棄タイミングの調整

## 動作確認
・中央分離帯のパラメータ、スライドした時に複製されるバグが直ったことの確認
1. 道路ネットワークを自動生成する
2. 左上のPLATEAU_DEVから道路ネットワーク編集ウィンドウを表示する
3. Refreshボタンを押す
4. 操作モードをEditRoadStructureにする
5. シーンビューでの操作を編集モードに切り替えを有効にする
6. シーンビューから道路を選択する
7. 車線数を変更してみる
8. 中央分離帯の有無を変更する
9. 適用ボタンを押す
10. シーンビュー上で中央分離帯を動かして複製されないことを確認する
11. シーンビューでの操作を編集モードに切り替えを無効に戻す

## その他
手動編集機能の編集用データの生成破棄タイミングの調整のバグあります。
このままでは処理フローが複雑になるため関連リンクの本プルリクで仕様の変更をして対応しました。
また、道路を編集した状態で別の道路を選択するとnull参照を起こす問題がありますが前述のプルリクで対応しています。