### PR TITLE
Feature/road network improve editing operation

### DIFF
--- a/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
@@ -290,7 +290,7 @@ namespace PLATEAU.Editor.RoadNetwork
                 while (lineE.MoveNext())
                 {
                     var way = lineE.Current;
-                    SnapPointsToDem(way.Points);
+                    SnapPointsToDemAndTran(way.Points);
                 }
 
 
@@ -305,32 +305,41 @@ namespace PLATEAU.Editor.RoadNetwork
             return true;
         }
 
-        public static void SnapPointsToDem(IEnumerable<RnPoint> items)
+        public static void SnapPointsToDemAndTran(IEnumerable<RnPoint> items)
         {
             Ray ray;
             const float rayDis = 1000.0f;
             foreach (var item in items)
             {
                 ray = new Ray(item.Vertex + Vector3.up * rayDis, Vector3.down * rayDis);
-                SnapPointToDem(item, ray);
+                SnapPointToObj(item, ray, "dem_", "tran_");
             }
         }
 
-        public static void SnapPointToDem(RnPoint item)
+        public static void SnapPointToDemAndTran(RnPoint item)
         {
             Ray ray;
             const float rayDis = 1000.0f;
             ray = new Ray(item.Vertex + Vector3.up * rayDis, Vector3.down * rayDis);
-            SnapPointToDem(item, ray);
+            SnapPointToObj(item, ray, "dem_", "tran_");
         }
 
-        public static void SnapPointToDem(RnPoint item, in Ray ray)
+        public static void SnapPointToObj(RnPoint item, in Ray ray, params string[] filter)
         {
             const float maxDistance = 1000.0f;
             var hits = Physics.RaycastAll(ray, maxDistance);    // 地形メッシュが埋まっていてもスナップ出来るように
             foreach (RaycastHit hit in hits)
             {
-                if (hit.collider.name.Contains("dem_"))
+                var isTarget = false;
+                foreach (var f in filter)
+                {
+                    if (hit.collider.name.Contains(f))
+                    {
+                        isTarget = true;
+                        break;
+                    }
+                }
+                if (isTarget)
                 {
                     item.Vertex = hit.point;
                     return;

--- a/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
@@ -190,7 +190,7 @@ namespace PLATEAU.Editor.RoadNetwork
 
         private const string roadNetworkEditingSystemObjName = "_RoadNetworkEditingSystemRoot";
         private GameObject roadNetworkEditingSystemObjRoot;
-        private const float SnapHightOffset = 0.1f; // ポイントスナップ時の高低差のオフセット（0だとポイント間を繋ぐ線がめり込むことがあるため）
+        private const float SnapHeightOffset = 0.1f; // ポイントスナップ時の高低差のオフセット（0だとポイント間を繋ぐ線がめり込むことがあるため）
 
         private Dictionary<RnLane, LaneEditCache> keyValuePairs = new Dictionary<RnLane, LaneEditCache>();
 
@@ -352,7 +352,7 @@ namespace PLATEAU.Editor.RoadNetwork
 
             if (isTarget)
             {
-                item.Vertex = targetPos + Vector3.up * SnapHightOffset;
+                item.Vertex = targetPos + Vector3.up * SnapHeightOffset;
                 return;
             }
 

--- a/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
@@ -317,13 +317,13 @@ namespace PLATEAU.Editor.RoadNetwork
         {
             Ray ray;
             const float rayDis = 1000.0f;
+            const float maxRayDistance = rayDis * 2.0f;
             ray = new Ray(item.Vertex + Vector3.up * rayDis, Vector3.down);
-            SnapPointToObj(item, ray, "dem_", "tran_");
+            SnapPointToObj(item, ray, maxRayDistance, "dem_", "tran_");
         }
 
-        public static void SnapPointToObj(RnPoint item, in Ray ray, params string[] filter)
+        public static void SnapPointToObj(RnPoint item, in Ray ray, float maxDistance, params string[] filter)
         {
-            const float maxDistance = 1000.0f;
             var hits = Physics.RaycastAll(ray, maxDistance);    // 地形メッシュが埋まっていてもスナップ出来るように
 
             var isTarget = false;

--- a/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
@@ -307,12 +307,9 @@ namespace PLATEAU.Editor.RoadNetwork
 
         public static void SnapPointsToDemAndTran(IEnumerable<RnPoint> items)
         {
-            Ray ray;
-            const float rayDis = 1000.0f;
             foreach (var item in items)
             {
-                ray = new Ray(item.Vertex + Vector3.up * rayDis, Vector3.down * rayDis);
-                SnapPointToObj(item, ray, "dem_", "tran_");
+                SnapPointToDemAndTran(item);
             }
         }
 
@@ -320,7 +317,7 @@ namespace PLATEAU.Editor.RoadNetwork
         {
             Ray ray;
             const float rayDis = 1000.0f;
-            ray = new Ray(item.Vertex + Vector3.up * rayDis, Vector3.down * rayDis);
+            ray = new Ray(item.Vertex + Vector3.up * rayDis, Vector3.down);
             SnapPointToObj(item, ray, "dem_", "tran_");
         }
 

--- a/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
@@ -190,7 +190,7 @@ namespace PLATEAU.Editor.RoadNetwork
 
         private const string roadNetworkEditingSystemObjName = "_RoadNetworkEditingSystemRoot";
         private GameObject roadNetworkEditingSystemObjRoot;
-
+        private const float SnapHightOffset = 0.1f; // ポイントスナップ時の高低差のオフセット（0だとポイント間を繋ぐ線がめり込むことがあるため）
 
         private Dictionary<RnLane, LaneEditCache> keyValuePairs = new Dictionary<RnLane, LaneEditCache>();
 
@@ -352,7 +352,7 @@ namespace PLATEAU.Editor.RoadNetwork
 
             if (isTarget)
             {
-                item.Vertex = targetPos;
+                item.Vertex = targetPos + Vector3.up * SnapHightOffset;
                 return;
             }
 

--- a/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkEditingSystem.cs
@@ -328,23 +328,34 @@ namespace PLATEAU.Editor.RoadNetwork
         {
             const float maxDistance = 1000.0f;
             var hits = Physics.RaycastAll(ray, maxDistance);    // 地形メッシュが埋まっていてもスナップ出来るように
+
+            var isTarget = false;
+            var closestDist = float.MaxValue;
+            Vector3 targetPos = Vector3.zero;
             foreach (RaycastHit hit in hits)
             {
-                var isTarget = false;
                 foreach (var f in filter)
                 {
                     if (hit.collider.name.Contains(f))
                     {
+                        var dis = Vector3.Distance(hit.point, ray.origin);
+                        if (dis < closestDist)
+                        {
+                            closestDist = dis;
+                            targetPos = hit.point;
+                        }
                         isTarget = true;
-                        break;
+                        continue;
                     }
                 }
-                if (isTarget)
-                {
-                    item.Vertex = hit.point;
-                    return;
-                }
             }
+
+            if (isTarget)
+            {
+                item.Vertex = targetPos;
+                return;
+            }
+
         }
 
 

--- a/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
@@ -156,7 +156,7 @@ namespace PLATEAU.Editor.RoadNetwork
             };
         }
 
-        private const float pointHndScaleFactor = 0.1f;
+        private const float pointHndScaleFactor = 0.15f;
         private const float laneHndScaleFactor = 0.4f;
         private const float linkHndScaleFactor = 0.5f;
         private const float signalLightHndScaleFactor = 0.2f;
@@ -605,44 +605,53 @@ namespace PLATEAU.Editor.RoadNetwork
                                     var size = HandleUtility.GetHandleSize(point) * pointHndScaleFactor;
 
 
-                                    if (isEditable && IsSame(DisplayHndMaskSet.PointMove))
+                                    // ctrlを押しているか
+                                    if (Event.current.control == false)
                                     {
-                                        DeployPointMoveHandle(point, state, networkOperator, size);
-                                        continue;
-                                    }
-
-                                    if (isEditable && IsSame(DisplayHndMaskSet.PointAdd))
-                                    {
-                                        var isClicked = Handles.Button(point, Quaternion.identity, size, size, RoadNetworkSplitLaneButtonHandleCap);
-                                        if (isClicked)
+                                        if (isEditable && IsSame(DisplayHndMaskSet.PointMove))
                                         {
-                                            // parent.Pointsからpointを検索してインデックスを取得
-                                            var idx = parent.Points.ToList().IndexOf(point);
-                                            if (idx == -1)
-                                                continue;
-                                            state.delayCommand += () =>
-                                            {
-                                                networkOperator.AddPoint(parent, idx, new RnPoint(point.Vertex + Vector3.up));
-                                                Debug.Log("ポイント追加ボタンが押された");
-                                            };
-                                            state.isDirtyTarget = true;
+                                            DeployPointMoveHandle(point, state, networkOperator, size);
+                                            continue;
                                         }
-                                        continue;
                                     }
-
-                                    if (isEditable && IsSame(DisplayHndMaskSet.PointRemove))
+                                    else
                                     {
-                                        var isClicked = Handles.Button(point, Quaternion.identity, size, size, RoadNetworkSplitLaneButtonHandleCap);
-                                        if (isClicked)
+                                        var currentEvent = Event.current;
                                         {
-                                            state.delayCommand += () =>
+                                            
+                                            if (currentEvent.shift == false)
                                             {
-                                                networkOperator.RemovePoint(parent, point);
-                                                Debug.Log("ポイント削除ボタンが押された");
-                                            };
-                                            state.isDirtyTarget = true;
+                                                var isClicked = Handles.Button(point, Quaternion.identity, size, size, RoadNetworkAddPointButtonHandleCap);
+                                                if (isClicked)
+                                                {
+                                                    // parent.Pointsからpointを検索してインデックスを取得
+                                                    var idx = parent.Points.ToList().IndexOf(point);
+                                                    if (idx == -1)
+                                                        continue;
+                                                    state.delayCommand += () =>
+                                                    {
+                                                        networkOperator.AddPoint(parent, idx, new RnPoint(point.Vertex + Vector3.up));
+                                                        Debug.Log("ポイント追加ボタンが押された");
+                                                    };
+                                                    state.isDirtyTarget = true;
+                                                    continue;
+                                                }
+                                            }
+                                            else
+                                            {
+                                                var isClicked = Handles.Button(point, Quaternion.identity, size, size, RoadNetworkRemovePointButtonHandleCap);
+                                                if (isClicked)
+                                                {
+                                                    state.delayCommand += () =>
+                                                    {
+                                                        networkOperator.RemovePoint(parent, point);
+                                                        Debug.Log("ポイント削除ボタンが押された");
+                                                    };
+                                                    state.isDirtyTarget = true;
+                                                    continue;
+                                                }
+                                            }
                                         }
-                                        continue;
                                     }
                                 }
                             }
@@ -1277,6 +1286,38 @@ namespace PLATEAU.Editor.RoadNetwork
                     Handles.DrawWireDisc(position, Vector3.up, size * linkHndScaleFactor);
                     Handles.DrawWireCube(position + Vector3.forward * 0.07f, new Vector3(size, size * pointHndScaleFactor, size * 0.15f));
                     Handles.DrawWireCube(position + Vector3.back * 0.07f, new Vector3(size, size * pointHndScaleFactor, size * 0.15f));
+                    break;
+            }
+        }
+
+        static void RoadNetworkAddPointButtonHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
+        {
+            switch (eventType)
+            {
+                case EventType.MouseMove:
+                case EventType.Layout:
+                    Handles.CubeHandleCap(controlID, position, rotation, size, eventType);
+
+                    break;
+                case EventType.Repaint:
+                    Handles.DrawWireDisc(position, Vector3.up, size * linkHndScaleFactor);
+                    Handles.DrawWireCube(position, new Vector3(size, size * pointHndScaleFactor, size * 0.15f));
+                    Handles.DrawWireCube(position, new Vector3(size * 0.15f, size * pointHndScaleFactor, size));
+                    break;
+            }
+        }
+        static void RoadNetworkRemovePointButtonHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
+        {
+            switch (eventType)
+            {
+                case EventType.MouseMove:
+                case EventType.Layout:
+                    Handles.CubeHandleCap(controlID, position, rotation, size, eventType);
+
+                    break;
+                case EventType.Repaint:
+                    Handles.DrawWireDisc(position, Vector3.up, size * linkHndScaleFactor);
+                    Handles.DrawWireCube(position, new Vector3(size, size * pointHndScaleFactor, size * 0.15f));
                     break;
             }
         }

--- a/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
@@ -675,7 +675,7 @@ namespace PLATEAU.Editor.RoadNetwork
             {
                 var mousePos = Event.current.mousePosition;
                 var ray = HandleUtility.GUIPointToWorldRay(mousePos);
-                RoadNetworkEditingSystem.SnapPointToDem(point, ray);
+                RoadNetworkEditingSystem.SnapPointToObj(point, ray, "dem_", "tran_");
                 //var res = networkOperator.MovePoint(point, vertPos);
                 state.isDirtyTarget = true;
                 //Debug.Assert(res.IsSuccess);

--- a/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
@@ -565,7 +565,7 @@ namespace PLATEAU.Editor.RoadNetwork
                             }
                         }
 
-                        foreach (var lane in road.MainLanes)
+                        foreach (var lane in road.AllLanes)
                         {
                             if (state.isDirtyTarget)
                             {

--- a/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
@@ -687,7 +687,8 @@ namespace PLATEAU.Editor.RoadNetwork
             {
                 var mousePos = Event.current.mousePosition;
                 var ray = HandleUtility.GUIPointToWorldRay(mousePos);
-                RoadNetworkEditingSystem.SnapPointToObj(point, ray, "dem_", "tran_");
+                const float maxRayDistance = 1000.0f;
+                RoadNetworkEditingSystem.SnapPointToObj(point, ray, maxRayDistance, "dem_", "tran_");
                 //var res = networkOperator.MovePoint(point, vertPos);
                 state.isDirtyTarget = true;
                 //Debug.Assert(res.IsSuccess);
@@ -1238,7 +1239,7 @@ namespace PLATEAU.Editor.RoadNetwork
 
         }
 
-        static void RoadNetworkLinkHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
+        private static void RoadNetworkLinkHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
         {
             switch (eventType)
             {
@@ -1259,7 +1260,7 @@ namespace PLATEAU.Editor.RoadNetwork
 
         }
 
-        static void RoadNetworkLaneHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
+        private static void RoadNetworkLaneHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
         {
             switch (eventType)
             {
@@ -1276,7 +1277,7 @@ namespace PLATEAU.Editor.RoadNetwork
 
         }
 
-        static void RoadNetworkSplitLaneButtonHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
+        private static void RoadNetworkSplitLaneButtonHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
         {
             switch (eventType)
             {
@@ -1293,7 +1294,7 @@ namespace PLATEAU.Editor.RoadNetwork
             }
         }
 
-        static void RoadNetworkAddPointButtonHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
+        private static void RoadNetworkAddPointButtonHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
         {
             switch (eventType)
             {
@@ -1309,7 +1310,7 @@ namespace PLATEAU.Editor.RoadNetwork
                     break;
             }
         }
-        static void RoadNetworkRemovePointButtonHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
+        private static void RoadNetworkRemovePointButtonHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
         {
             switch (eventType)
             {
@@ -1325,7 +1326,7 @@ namespace PLATEAU.Editor.RoadNetwork
             }
         }
 
-        static void RoadNetworkRemoveLaneButtonHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
+        private static void RoadNetworkRemoveLaneButtonHandleCap(int controlID, Vector3 position, Quaternion rotation, float size, EventType eventType)
         {
             switch (eventType)
             {

--- a/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
+++ b/Editor/RoadNetwork/RoadNetworkSceneGUISystem.cs
@@ -618,9 +618,10 @@ namespace PLATEAU.Editor.RoadNetwork
                                     {
                                         var currentEvent = Event.current;
                                         {
-                                            
+                                            // ポイントの追加
                                             if (currentEvent.shift == false)
                                             {
+                                                // ポイントの追加ボタンの表示
                                                 var isClicked = Handles.Button(point, Quaternion.identity, size, size, RoadNetworkAddPointButtonHandleCap);
                                                 if (isClicked)
                                                 {
@@ -637,8 +638,10 @@ namespace PLATEAU.Editor.RoadNetwork
                                                     continue;
                                                 }
                                             }
+                                            // ポイントの削除
                                             else
                                             {
+                                                // ポイントの削除ボタンの表示
                                                 var isClicked = Handles.Button(point, Quaternion.identity, size, size, RoadNetworkRemovePointButtonHandleCap);
                                                 if (isClicked)
                                                 {


### PR DESCRIPTION
﻿## 関連リンク
[Jira](https://synesthesias.atlassian.net/browse/PLTSDK3-267?atlOrigin=eyJpIjoiMjVkNWVlOGU0NWM2NGY5MTk2Mjc4YmFjODc1MTgyZDMiLCJwIjoiaiJ9)

## 実装内容
ショートカットでポイントの追加、削除が出来るように実装。
ポイントのスナップ機能の調整（tran対応、オフセット、手前優先）
歩道もポイントの編集対象に追加

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
・準備
1. tran_ef843b43-0e50-45c3-ac8d-1c8b77accab4　と周囲の交差点が入るぐらいにカメラを動かす
![tran_ef843b43-0e50-45c3-ac8d-1c8b77accab4](https://github.com/user-attachments/assets/d8fd01f7-fc7f-44db-9fc4-3d2493c733d0)

2. 道路ネットワークを自動生成する
3. 左上のPLATEAU_DEVから道路ネットワーク編集ウィンドウを表示する
4. Refreshボタンを押す
5. 操作モードをEditRoadStructureにする
6. シーンビューでの操作を編集モードに切り替えを有効にする
7. シーンビューから橋に配置された道路アイコンを選択する
8. 詳細編集モードを有効にする

・機能の確認項目
- [x] 歩道のポイント（球体のハンドル）を移動させることが出来る
- [x] tran_にスナップされている
- [x] Ctrlキーを押すと追加アイコンが表示されクリックすると追加される
- [x] Ctrl+Sfhitキーで削除アイコンが表示されクリックすると削除される

## その他
### 本来の仕様について
・交差点と共有しているのポイントの追加や削除、移動は出来ないようにする
他のブランチに影響するので[別タスク](https://synesthesias.atlassian.net/browse/PLTSDK3-268?atlOrigin=eyJpIjoiNjMzNmE2NzNiNWUwNDQyNjg3YjM1ODIyNDliZTdmZjgiLCJwIjoiaiJ9)として作成済み。

・ポイントの追加はwayを選択してその地点にポイントを追加する
最低限の機能を組み込むことを優先して[別タスク](https://synesthesias.atlassian.net/browse/PLTSDK3-339?atlOrigin=eyJpIjoiMDYwOGU2NDA4MWM0NDhjZGFhMzJjNWEyMjQ5YjY5MzMiLCJwIjoiaiJ9)として作成済み。
