### PR TITLE
update : RGraphの歩道のアウトサイド判定を修正. 別のCityObjectの歩道以外との境界線はアウトサイド判定に

### DIFF
--- a/Runtime/RoadNetwork/Graph/RGraphEx.cs
+++ b/Runtime/RoadNetwork/Graph/RGraphEx.cs
@@ -957,7 +957,7 @@ namespace PLATEAU.RoadNetwork.Graph
             var outsideIndex = ways.FindIndex(w => w.type == 0);
             if (outsideIndex < 0)
             {
-                Debug.LogWarning("outside edge not found");
+                Debug.LogWarning($"outside edge not found {(self.CityObjectGroup ? self.CityObjectGroup.name : "null")}");
                 return false;
             }
 

--- a/Runtime/RoadNetwork/Graph/RGraphEx.cs
+++ b/Runtime/RoadNetwork/Graph/RGraphEx.cs
@@ -901,15 +901,22 @@ namespace PLATEAU.RoadNetwork.Graph
             // 0 : 外側の辺, 1:内側の辺, 2:境界線
             static int Edge2WayType(REdge e)
             {
-                // 歩道にしか所属しない場合は外側の辺
+                // 自身の歩道にしか所属しない場合は外側の辺
                 if (e.Faces.Count == 1)
                     return 0;
 
+                // 以下複数のFaceと所属する場合
+
                 var t = e.GetAllFaceTypeMaskOrDefault();
-                // 複数の歩道に所属している場合は境界線
+                // 複数の歩道に所属している場合は歩道との境界線
                 if (t.HasAnyFlag(RRoadTypeMask.SideWalk))
                     return 2;
-                // 歩道以外に所属している場合は内側の辺
+
+                // 歩道との境界線ではない and 他のtranメッシュとの境界線は外側の辺
+                if (e.Faces.GroupBy(f => f.CityObjectGroup).Count() > 1)
+                    return 0;
+
+                // 自身のtranメッシュの歩道以外に所属している場合は内側の辺
                 return 1;
             }
             var vertices = self.ComputeOutlineVertices();


### PR DESCRIPTION
﻿## 関連リンク
https://synesthesias.atlassian.net/browse/PLTSDK3-311

## 実装内容
歩道の左右どっちも道路とつながっている場合に自分の所属するメッシュじゃない方の境界線は外側判定に


## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
道路構造を作成する.
53393641_tran_6697_op.gmlのtran_8c5804f6-d69d-44b7-9add-343c8b78f290で確認。
図のように歩道の両サイドが道路とつながっている場合でも、自分のメッシュと違う側は外側判定となっているか確認
![image](https://github.com/user-attachments/assets/25b95b5b-8863-49a1-81ba-23e255a4c76d)


## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
