### PR TITLE
交差点の途中トラックのy座標が0になるバグ修正

### DIFF
--- a/Runtime/Util/RayEx.cs
+++ b/Runtime/Util/RayEx.cs
@@ -55,7 +55,7 @@ namespace PLATEAU.Util
             {
                 var d2 = new Vector2(ray.direction.GetTangent(plane).magnitude, ray.direction.GetNormal(plane)).normalized;
                 var x = (inter2 - ray.origin.GetTangent(plane)).magnitude;
-                var y = d2.y * x;
+                var y = d2.y * x + ray.origin.GetNormal(plane);
                 t = x * Mathf.Sqrt(1 + d2.y * d2.y);
                 return y;
             }


### PR DESCRIPTION
﻿## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->

## 実装内容
Rayを2D射影における交点を出したときに、2本のRayの中間地点を求めるときにoriginを考慮していないバグの修正

## 確認方法
* 道路構造を作成する
* トラックの状態を確認する
  * 中間地点が不自然に下に潜り込んでいないか確認する。
![image](https://github.com/user-attachments/assets/deb13b88-279c-4c04-8fb5-35dcc7963d78)


## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
