### PR TITLE
車線矢印を配置、路面標示マテリアル崩れ修正

### DIFF
--- a/Resources/ArrowModel.meta
+++ b/Resources/ArrowModel.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d61c143364ba5294c9ae2f7febb3e543
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Resources/ArrowModel/RoadMarkArrowLeft.fbx
+++ b/Resources/ArrowModel/RoadMarkArrowLeft.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:381b82e745db87b4a36e58e1bd7099c6b49c43007f23c26636f69245367328a6
+size 16332

--- a/Resources/ArrowModel/RoadMarkArrowLeft.fbx.meta
+++ b/Resources/ArrowModel/RoadMarkArrowLeft.fbx.meta
@@ -1,0 +1,109 @@
+fileFormatVersion: 2
+guid: 1042253248703e142bb9db2811f56291
+ModelImporter:
+  serializedVersion: 22200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 1
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Resources/ArrowModel/RoadMarkArrowRight.fbx
+++ b/Resources/ArrowModel/RoadMarkArrowRight.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba260484298eedc6e7d56c1ba1b3d9534724caff70473d18f943f4bf2d4cbe08
+size 16332

--- a/Resources/ArrowModel/RoadMarkArrowRight.fbx.meta
+++ b/Resources/ArrowModel/RoadMarkArrowRight.fbx.meta
@@ -1,0 +1,109 @@
+fileFormatVersion: 2
+guid: 6480c89b1dcedea49833994675a2cc86
+ModelImporter:
+  serializedVersion: 22200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 1
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Resources/ArrowModel/RoadMarkArrowStraight.fbx
+++ b/Resources/ArrowModel/RoadMarkArrowStraight.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55d42903b6aaa960c6766edfc3a227e2168728eecab12ccb3fd693faa717bee6
+size 16076

--- a/Resources/ArrowModel/RoadMarkArrowStraight.fbx.meta
+++ b/Resources/ArrowModel/RoadMarkArrowStraight.fbx.meta
@@ -1,0 +1,109 @@
+fileFormatVersion: 2
+guid: 164982a4c9d0e5845b6419f85d74a06d
+ModelImporter:
+  serializedVersion: 22200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 1
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Resources/ArrowModel/RoadMarkArrowStraightLeft.fbx
+++ b/Resources/ArrowModel/RoadMarkArrowStraightLeft.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3db8ba47a61cd9b0a02024d7ca549a401f4f6b1ee4f63894c5992574433dae8
+size 16412

--- a/Resources/ArrowModel/RoadMarkArrowStraightLeft.fbx.meta
+++ b/Resources/ArrowModel/RoadMarkArrowStraightLeft.fbx.meta
@@ -1,0 +1,109 @@
+fileFormatVersion: 2
+guid: 91d462226c1df0341aa676fb0f74afcd
+ModelImporter:
+  serializedVersion: 22200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 1
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Resources/ArrowModel/RoadMarkArrowStraightRight.fbx
+++ b/Resources/ArrowModel/RoadMarkArrowStraightRight.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b951ae4ccb54ce2c49edbcf82bfe59bab57fe61144af5508322e02f7b98033e1
+size 16412

--- a/Resources/ArrowModel/RoadMarkArrowStraightRight.fbx.meta
+++ b/Resources/ArrowModel/RoadMarkArrowStraightRight.fbx.meta
@@ -1,0 +1,109 @@
+fileFormatVersion: 2
+guid: 472abc3a3b0122849907e5440dc482e1
+ModelImporter:
+  serializedVersion: 22200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 1
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Resources/PlateauUIDocument/RoadNetwork/UIStyle.uss
+++ b/Resources/PlateauUIDocument/RoadNetwork/UIStyle.uss
@@ -426,7 +426,6 @@ Scroller #unity-drag-container {
     background-color: rgba(103, 103, 103, 0);
     border-width: 0;
     color: rgb(0, 55, 55);
-    font-weight: bold;
 }
 
 #StraightToggle .unity-base-field__label {

--- a/Runtime/RoadAdjust/RoadMarking/DirectionalArrow.meta
+++ b/Runtime/RoadAdjust/RoadMarking/DirectionalArrow.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: eda06632e774410aa3b96fb2964ef673
+timeCreated: 1732699112

--- a/Runtime/RoadAdjust/RoadMarking/DirectionalArrow/DirectionalArrowComposer.cs
+++ b/Runtime/RoadAdjust/RoadMarking/DirectionalArrow/DirectionalArrowComposer.cs
@@ -1,0 +1,154 @@
+using PLATEAU.RoadAdjust.RoadNetworkToMesh;
+using PLATEAU.RoadNetwork.Structure;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PLATEAU.RoadAdjust.RoadMarking.DirectionalArrow
+{
+    /// <summary>
+    /// 路面標示として、交差点手前の矢印を生成します。
+    /// </summary>
+    internal class DirectionalArrowComposer
+    {
+        private IRrTarget target;
+        
+        public DirectionalArrowComposer(IRrTarget target)
+        {
+            this.target = target;
+        }
+
+        public List<RoadMarkingInstance> Generate()
+        {
+            var ret = new List<RoadMarkingInstance>();
+            
+            
+            foreach (var road in target.Roads())
+            {
+                var nextIntersection = road.Next as RnIntersection;
+                var prevIntersection = road.Prev as RnIntersection;
+                
+                // roadでnextとprevを見る、isReverseに応じて
+                foreach (var lane in road.MainLanes)
+                {
+                    if (lane.NextBorder != null)
+                    {
+                        var inter = lane.IsReverse ? prevIntersection : nextIntersection;
+                        var nextArrow = GenerateArrow(lane.NextBorder, inter, ArrowPosition(lane, true));
+                        ret.Add(nextArrow);
+                    }
+
+                    if (lane.PrevBorder != null)
+                    {
+                        var inter = lane.IsReverse ? nextIntersection : prevIntersection;
+                        var prevArrow = GenerateArrow(lane.PrevBorder, inter, ArrowPosition(lane, false));
+                        ret.Add(prevArrow);
+                    }
+                    
+                    
+                }
+                
+            }
+            return ret;
+        }
+
+        private RoadMarkingInstance GenerateArrow(RnWay laneBorder, RnIntersection intersection, Vector3 position)
+        {
+            if (intersection == null) return null;
+            var type = ArrowType(laneBorder, intersection);
+            var meshInstance = type.ToMeshInstance();
+            if (meshInstance == null)
+            {
+                Debug.LogError("mesh instance is null.");
+                return null;
+            }
+            
+            meshInstance.Translate(position);
+            return meshInstance;
+        }
+
+        private Vector3 ArrowPosition(RnLane lane, bool isNext)
+        {
+            var border = isNext ? lane.NextBorder : lane.PrevBorder;
+            if (border.Count == 0)
+            {
+                Debug.Log("Skipping because border count is 0.");
+                return Vector3.zero;
+            }
+
+            if(border.Count == 1)
+            {
+                return border[0];
+            }
+
+            return (border[0] + border[^1]) / 2f;
+        }
+        
+
+        private DirectionalArrowType ArrowType(RnWay laneBorder, RnIntersection intersection)
+        {
+            if (intersection == null) return DirectionalArrowType.None;
+            bool containStraight = false;
+            bool containLeft = false;
+            bool containRight = false;
+            foreach (var track in intersection.Tracks)
+            {
+                if (!track.FromBorder.IsSameLineSequence(laneBorder)) continue;
+                var turnT = track.TurnType;
+                containLeft |= turnT.IsLeft();
+                containRight |= turnT.IsRight();
+                containStraight |= turnT == RnTurnType.Straight;
+            }
+
+            if (containStraight && containLeft && containRight) return DirectionalArrowType.None;
+            if (containStraight && containLeft) return DirectionalArrowType.StraightAndLeft;
+            if (containStraight && containRight) return DirectionalArrowType.StraightAndRight;
+            if (containStraight) return DirectionalArrowType.Straight;
+            if (containRight) return DirectionalArrowType.Right;
+            if (containLeft) return DirectionalArrowType.Left;
+            
+            return DirectionalArrowType.None;
+        }
+        
+    }
+
+    internal enum DirectionalArrowType
+    {
+        None, Straight, Left, Right, StraightAndLeft, StraightAndRight
+    }
+
+    internal static class DirectionalArrowTypeExtension
+    {
+        private const string ModelFolder = "ArrowModel/";
+        public static RoadMarkingInstance ToMeshInstance(this DirectionalArrowType type)
+        {
+            if (type == DirectionalArrowType.None) return null;
+                // return new RoadMarkingInstance(Resources.Load<Mesh>(ModelFolder + "RoadMarkArrowStraight"), RoadMarkingMaterial.Yellow);;
+
+            var prefab = type switch
+            {
+                DirectionalArrowType.Straight => Resources.Load<GameObject>(ModelFolder + "RoadMarkArrowStraight"),
+                DirectionalArrowType.Left => Resources.Load<GameObject>(ModelFolder + "RoadMarkArrowLeft"),
+                DirectionalArrowType.Right => Resources.Load<GameObject>(ModelFolder + "RoadMarkArrowRight"),
+                DirectionalArrowType.StraightAndLeft => Resources.Load<GameObject>(ModelFolder + "RoadMarkArrowStraightLeft"),
+                DirectionalArrowType.StraightAndRight => Resources.Load<GameObject>(ModelFolder + "RoadMarkArrowStraightRight"),
+                _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+            };
+            if (prefab == null)
+            {
+                Debug.LogError("Prefab is not found.");
+                return null;
+            }
+
+            var meshFilter = prefab.GetComponent<MeshFilter>();
+            if (meshFilter == null)
+            {
+                Debug.LogError("mesh filter is not found.");
+                return null;
+            }
+
+            var mesh = meshFilter.sharedMesh;
+            return new RoadMarkingInstance(mesh, RoadMarkingMaterial.White);
+        }
+    }
+}

--- a/Runtime/RoadAdjust/RoadMarking/DirectionalArrow/DirectionalArrowComposer.cs.meta
+++ b/Runtime/RoadAdjust/RoadMarking/DirectionalArrow/DirectionalArrowComposer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1d1090a8dd344ccf821c107d255e6fc2
+timeCreated: 1732699137

--- a/Runtime/RoadAdjust/RoadMarking/ILineMeshGenerator.cs
+++ b/Runtime/RoadAdjust/RoadMarking/ILineMeshGenerator.cs
@@ -11,7 +11,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
     /// </summary>
     internal interface ILineMeshGenerator
     {
-        public RoadMarkingInstance GenerateMesh(IReadOnlyList<Vector3> points);
+        public RoadMarkingInstance GenerateMeshInstance(IReadOnlyList<Vector3> points);
     }
     
     
@@ -28,7 +28,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             this.lineWidth = lineWidth;
         }
         
-        public RoadMarkingInstance GenerateMesh(IReadOnlyList<Vector3> points)
+        public RoadMarkingInstance GenerateMeshInstance(IReadOnlyList<Vector3> points)
         {
             
             if (points.Count < 2)
@@ -90,7 +90,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             this.lineWidth = lineWidth;
         }
 
-        public RoadMarkingInstance GenerateMesh(IReadOnlyList<Vector3> srcPointsArg)
+        public RoadMarkingInstance GenerateMeshInstance(IReadOnlyList<Vector3> srcPointsArg)
         {
             // 破線の基点を揃えるために、方向によっては逆順にします。
             Vector3[] srcPoints = direction ? srcPointsArg.ToArray() : srcPointsArg.Reverse().ToArray();
@@ -130,7 +130,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
                     {
                         // 実線部から空白部への切り替え時です。実線を生成し、描画キューを空にします。
                         drawQue.Enqueue(lineEndPos);
-                        var combine = gen.GenerateMesh(drawQue.ToArray()).CombineInstance;
+                        var combine = gen.GenerateMeshInstance(drawQue.ToArray()).CombineInstance;
                         combines.Add(combine);
                         drawQue.Clear();
                     }
@@ -155,7 +155,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
 
     internal class EmptyLineMeshGenerator : ILineMeshGenerator
     {
-        public RoadMarkingInstance GenerateMesh(IReadOnlyList<Vector3> points)
+        public RoadMarkingInstance GenerateMeshInstance(IReadOnlyList<Vector3> points)
         {
             return new RoadMarkingInstance(new Mesh(), RoadMarkingMaterial.White);
         }

--- a/Runtime/RoadAdjust/RoadMarking/MarkedWay/MarkedWayListComposer.cs
+++ b/Runtime/RoadAdjust/RoadMarking/MarkedWay/MarkedWayListComposer.cs
@@ -1,5 +1,4 @@
 using PLATEAU.RoadAdjust.RoadNetworkToMesh;
-using PLATEAU.RoadNetwork.Structure;
 
 namespace PLATEAU.RoadAdjust.RoadMarking
 {

--- a/Runtime/RoadAdjust/RoadMarking/MarkedWay/Parts/MCLaneLine.cs
+++ b/Runtime/RoadAdjust/RoadMarking/MarkedWay/Parts/MCLaneLine.cs
@@ -1,5 +1,4 @@
 using PLATEAU.RoadAdjust.RoadNetworkToMesh;
-using PLATEAU.RoadNetwork.Structure;
 
 namespace PLATEAU.RoadAdjust.RoadMarking
 {

--- a/Runtime/RoadAdjust/RoadMarking/MarkedWay/Parts/MCShoulderLine.cs
+++ b/Runtime/RoadAdjust/RoadMarking/MarkedWay/Parts/MCShoulderLine.cs
@@ -1,5 +1,4 @@
 using PLATEAU.RoadAdjust.RoadNetworkToMesh;
-using PLATEAU.RoadNetwork.Structure;
 
 namespace PLATEAU.RoadAdjust.RoadMarking
 {

--- a/Runtime/RoadAdjust/RoadMarking/MarkedWay/RoadMarkingInstance.cs
+++ b/Runtime/RoadAdjust/RoadMarking/MarkedWay/RoadMarkingInstance.cs
@@ -29,6 +29,26 @@ namespace PLATEAU.RoadAdjust.RoadMarking
                 transform = Matrix4x4.Translate(moveVector) * CombineInstance.transform
             };
         }
+
+        public void RotateYAxis(float angle)
+        {
+            // 度数法からラジアンに変換
+            float rad = angle * Mathf.Deg2Rad;
+        
+            // Y軸周りの回転行列を作成
+            Matrix4x4 rotationMatrix = Matrix4x4.identity;
+            float cos = Mathf.Cos(rad);
+            float sin = Mathf.Sin(rad);
+        
+            rotationMatrix.m00 = cos;
+            rotationMatrix.m02 = sin;
+            rotationMatrix.m20 = -sin;
+            rotationMatrix.m22 = cos;
+        
+            // 既存の行列に回転を適用
+            var transform = rotationMatrix * CombineInstance.transform;
+            CombineInstance = new CombineInstance { mesh = CombineInstance.mesh, transform = transform };
+        }
     }
 
     /// <summary>

--- a/Runtime/RoadAdjust/RoadMarking/MarkedWay/RoadMarkingInstance.cs
+++ b/Runtime/RoadAdjust/RoadMarking/MarkedWay/RoadMarkingInstance.cs
@@ -82,8 +82,8 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             }
         }
 
-        /// <summary> 結合します。 </summary>
-        public Mesh Combine()
+        /// <summary> 結合してMeshを生成します。 </summary>
+        public Mesh Combine(out Material[] outMaterials)
         {
             // マテリアルごとに結合します。
             var mats = ((RoadMarkingMaterial[])Enum.GetValues(typeof(RoadMarkingMaterial))).Where(m => m != RoadMarkingMaterial.None);
@@ -91,6 +91,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             foreach (var mat in mats)
             {
                 var combineTargets = instances.Where(i => i.MaterialType == mat).Select(i => i.CombineInstance).ToArray();
+                if (combineTargets.Length == 0) continue;
                 var combined = new Mesh();
                 combined.indexFormat = IndexFormat.UInt32;
                 combined.CombineMeshes(combineTargets, true);
@@ -103,6 +104,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             var allCombinedMesh = new Mesh();
             allCombinedMesh.indexFormat = IndexFormat.UInt32;
             allCombinedMesh.CombineMeshes(allCombineTargets, false);
+            outMaterials = matCombined.Keys.Select(m => m.ToMaterial()).ToArray();
             return allCombinedMesh;
         }
     }

--- a/Runtime/RoadAdjust/RoadMarking/RoadMarkingGenerator.cs
+++ b/Runtime/RoadAdjust/RoadMarking/RoadMarkingGenerator.cs
@@ -1,3 +1,4 @@
+using PLATEAU.RoadAdjust.RoadMarking.DirectionalArrow;
 using PLATEAU.RoadAdjust.RoadNetworkToMesh;
 using PLATEAU.RoadNetwork.Data;
 using PLATEAU.RoadNetwork.Structure;
@@ -38,6 +39,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
                 Debug.LogError("道路ネットワークが見つかりませんでした。");
                 return;
             }
+            
 
             using var progressDisplay = new ProgressDisplayDialogue();
             progressDisplay.SetProgress("道路標示生成", 5f, "道路ネットワークをコピー中");
@@ -50,30 +52,38 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             var dstParent = RoadReproducer.GenerateDstParent();
 
             var roadBases = target.RoadBases().ToArray();
-            for(int i=0; i<roadBases.Length; i++) // 道路オブジェクトごとに結合します。
+            for (int i = 0; i < roadBases.Length; i++) // 道路オブジェクトごとに結合します。
             {
                 var rb = roadBases[i];
-                string roadName = rb.TargetTrans == null || rb.TargetTrans.Count == 0 ? "UnknownRoad" : rb.TargetTrans.First().name;
-                progressDisplay.SetProgress("道路標示生成", (float)i / roadBases.Length, $"[{i+1} / {roadBases.Length}] {roadName}");
+                string roadName = rb.TargetTrans == null || rb.TargetTrans.Count == 0
+                    ? "UnknownRoad"
+                    : rb.TargetTrans.First().name;
+                progressDisplay.SetProgress("道路標示生成", (float)i / roadBases.Length,
+                    $"[{i + 1} / {roadBases.Length}] {roadName}");
                 var innerTarget = new RrTargetRoadBases(target.Network(), new[] { rb });
-                
+
                 // 道路の線を取得します。
                 var ways = new MarkedWayListComposer().ComposeFrom(innerTarget);
-            
-            
+
+
                 ways.AddRange(new StopLineComposer().ComposeFrom(innerTarget));
-            
-                var instances = new RoadMarkingCombiner(ways.MarkedWays.Count);
+
+
+                var instances = new RoadMarkingCombiner();
                 foreach (var way in ways.MarkedWays)
                 {
                     // 道路の線をメッシュに変換します。
                     var gen = way.Type.ToLineMeshGenerator(way.IsReversed);
                     var points = way.Line.Points;
                     var instance = gen.GenerateMesh(points.ToArray());
-                
+
                     instances.Add(instance);
                 }
-            
+
+                // 交差点前の矢印を生成します。
+                var arrowComposer = new DirectionalArrowComposer(innerTarget);
+                instances.AddRange(arrowComposer.Generate());
+
                 var dstMesh = instances.Combine();
                 GenerateGameObj(dstMesh, dstParent, rb);
             }

--- a/Runtime/RoadAdjust/RoadMarking/RoadMarkingGenerator.cs
+++ b/Runtime/RoadAdjust/RoadMarking/RoadMarkingGenerator.cs
@@ -1,8 +1,8 @@
 using PLATEAU.RoadAdjust.RoadMarking.DirectionalArrow;
 using PLATEAU.RoadAdjust.RoadNetworkToMesh;
-using PLATEAU.RoadNetwork.Data;
 using PLATEAU.RoadNetwork.Structure;
 using PLATEAU.Util;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -75,7 +75,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
                     // 道路の線をメッシュに変換します。
                     var gen = way.Type.ToLineMeshGenerator(way.IsReversed);
                     var points = way.Line.Points;
-                    var instance = gen.GenerateMesh(points.ToArray());
+                    var instance = gen.GenerateMeshInstance(points.ToArray());
 
                     instances.Add(instance);
                 }
@@ -84,14 +84,14 @@ namespace PLATEAU.RoadAdjust.RoadMarking
                 var arrowComposer = new DirectionalArrowComposer(innerTarget);
                 instances.AddRange(arrowComposer.Generate());
 
-                var dstMesh = instances.Combine();
-                GenerateGameObj(dstMesh, dstParent, rb);
+                var dstMesh = instances.Combine(out var materials);
+                GenerateGameObj(dstMesh, dstParent, rb, materials);
             }
         }
 
         
 
-        private void GenerateGameObj(Mesh mesh, Transform dstParent, RnRoadBase srcRoad)
+        private void GenerateGameObj(Mesh mesh, Transform dstParent, RnRoadBase srcRoad, Material[] materials)
         {
             var targetRoads = srcRoad.TargetTrans;
             var targetRoad = targetRoads == null || targetRoads.Count == 0 ? null : targetRoads.First();
@@ -116,7 +116,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             var meshFilter = dstObj.GetOrAddComponent<MeshFilter>();
             meshFilter.mesh = mesh;
             var meshRenderer = dstObj.GetOrAddComponent<MeshRenderer>();
-            meshRenderer.sharedMaterials = RoadMarkingMaterialExtension.Materials();
+            meshRenderer.sharedMaterials = materials;
             meshRenderer.shadowCastingMode = ShadowCastingMode.Off; // 道路と重なっているので影は不要
             dstObj.transform.parent = dstParent;
             mesh.name = dstName;

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/Contour/RnmTessSubMesh.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/Contour/RnmTessSubMesh.cs
@@ -1,5 +1,4 @@
 using LibTessDotNet;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/RoadNetworkToMesh.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/RoadNetworkToMesh.cs
@@ -15,6 +15,10 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 #endif
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
 {
     /// <summary>

--- a/Runtime/RoadNetwork/Factory/RoadNetworkFactory.cs
+++ b/Runtime/RoadNetwork/Factory/RoadNetworkFactory.cs
@@ -539,9 +539,9 @@ namespace PLATEAU.RoadNetwork.Factory
                     if (lane == null)
                         return;
                     var prev = Lines.Where(l => l.IsBorder && l.Way != null)
-                        .FirstOrDefault(l => lane.PrevBorder?.IsSameLine(l.Way) ?? false);
+                        .FirstOrDefault(l => lane.PrevBorder?.IsSameLineReference(l.Way) ?? false);
                     var next = Lines.Where(l => l.IsBorder && l.Way != null)
-                        .FirstOrDefault(l => lane.NextBorder?.IsSameLine(l.Way) ?? false);
+                        .FirstOrDefault(l => lane.NextBorder?.IsSameLineReference(l.Way) ?? false);
 
                     var prevRoad = prev?.Neighbor?.Node;
                     var nextRoad = next?.Neighbor?.Node;
@@ -714,7 +714,7 @@ namespace PLATEAU.RoadNetwork.Factory
                                     // #TODO : 自動生成の段階で分かれているケースが存在するならは点や法線方向で判定するように変える
                                     if (way == null)
                                         laneType = RnSideWalkLaneType.Undefined;
-                                    else if (insideWay.IsSameLine(way))
+                                    else if (insideWay.IsSameLineReference(way))
                                         laneType = RnSideWalkLaneType.LeftLane;
                                     else
                                         laneType = RnSideWalkLaneType.RightLane;

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -706,7 +706,7 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
                         work.Self.DrawDashedArrows(centerWay, color: showCenterWay.color.PutA(GetLaneAlpha(lane)));
                 }
 
-                if (lane.NextBorder != null && lane.PrevBorder != null && lane.NextBorder.IsSameLine(lane.PrevBorder))
+                if (lane.NextBorder != null && lane.PrevBorder != null && lane.NextBorder.IsSameLineReference(lane.PrevBorder))
                 {
                     DebugEx.DrawString($"Invalid Border Lane ", lane.GetCentralVertex());
                 }

--- a/Runtime/RoadNetwork/Structure/RnIntersection.cs
+++ b/Runtime/RoadNetwork/Structure/RnIntersection.cs
@@ -83,7 +83,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <returns></returns>
         public bool ContainsBorder(RnWay way)
         {
-            return FromBorder.IsSameLine(way) || ToBorder.IsSameLine(way);
+            return FromBorder.IsSameLineReference(way) || ToBorder.IsSameLineReference(way);
         }
     }
 

--- a/Runtime/RoadNetwork/Structure/RnIntersection.cs
+++ b/Runtime/RoadNetwork/Structure/RnIntersection.cs
@@ -63,7 +63,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <returns></returns>
         public bool IsSameInOut(RnWay from, RnWay to)
         {
-            return FromBorder.IsSameLine(from) && ToBorder.IsSameLine(to);
+            return FromBorder.IsSameLineReference(from) && ToBorder.IsSameLineReference(to);
         }
 
         /// <summary>
@@ -193,7 +193,7 @@ namespace PLATEAU.RoadNetwork.Structure
 
                 if (Road is RnRoad road)
                 {
-                    if (road.MedianLane != null && road.MedianLane.AllBorders.Any(b => b.IsSameLine(Border)))
+                    if (road.MedianLane != null && road.MedianLane.AllBorders.Any(b => b.IsSameLineReference(Border)))
                         return true;
                 }
 
@@ -212,9 +212,9 @@ namespace PLATEAU.RoadNetwork.Structure
             if (Road is RnRoad road)
             {
                 var ret = RnFlowTypeMask.Empty;
-                if (road.GetConnectedLanes(Border).Any(l => l.IsMedianLane == false && l.NextBorder.IsSameLine(Border)))
+                if (road.GetConnectedLanes(Border).Any(l => l.IsMedianLane == false && l.NextBorder.IsSameLineReference(Border)))
                     ret |= RnFlowTypeMask.Inbound;
-                if (road.GetConnectedLanes(Border).Any(l => l.IsMedianLane == false && l.PrevBorder.IsSameLine(Border)))
+                if (road.GetConnectedLanes(Border).Any(l => l.IsMedianLane == false && l.PrevBorder.IsSameLineReference(Border)))
                     ret |= RnFlowTypeMask.Outbound;
                 return ret;
             }
@@ -257,7 +257,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 foreach (var lane in road.MainLanes)
                 {
                     // Borderと同じ線上にあるレーンを返す
-                    if (lane.AllBorders.Any(b => b.IsSameLine(Border)))
+                    if (lane.AllBorders.Any(b => b.IsSameLineReference(Border)))
                         yield return lane;
                 }
             }
@@ -391,7 +391,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <param name="afterRoad"></param>
         public void ReplaceEdgeLink(RnWay border, RnRoadBase afterRoad)
         {
-            foreach (var e in edges.Where(e => e.Border.IsSameLine(border)))
+            foreach (var e in edges.Where(e => e.Border.IsSameLineReference(border)))
                 e.Road = afterRoad;
         }
 
@@ -437,7 +437,7 @@ namespace PLATEAU.RoadNetwork.Structure
         {
             // trackの入口/出口がこの交差点のものかチェックする
             if (!edges.Any(e =>
-                    e.Border.IsSameLine(track.FromBorder) || !edges.Any(e => e.Border.IsSameLine(track.ToBorder))))
+                    e.Border.IsSameLineReference(track.FromBorder) || !edges.Any(e => e.Border.IsSameLineReference(track.ToBorder))))
             {
                 DebugEx.LogError("交差点に含まれないトラックが追加されようとしています");
                 return false;
@@ -509,7 +509,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <param name="lane"></param>
         public void RemoveEdge(RnRoad road, RnLane lane)
         {
-            RemoveEdges(x => x.Road == road && ((lane.PrevBorder?.IsSameLine(x.Border) ?? false) || (lane.NextBorder?.IsSameLine(x.Border) ?? false)));
+            RemoveEdges(x => x.Road == road && ((lane.PrevBorder?.IsSameLineReference(x.Border) ?? false) || (lane.NextBorder?.IsSameLineReference(x.Border) ?? false)));
         }
 
         /// <summary>
@@ -1166,7 +1166,7 @@ namespace PLATEAU.RoadNetwork.Structure
             if (self == null || borderWay == null)
                 return Enumerable.Empty<RnNeighbor>();
 
-            return self.Edges.Where(e => e.Border?.IsSameLine(borderWay) ?? false);
+            return self.Edges.Where(e => e.Border?.IsSameLineReference(borderWay) ?? false);
         }
 
         /// <summary>

--- a/Runtime/RoadNetwork/Structure/RnLane.cs
+++ b/Runtime/RoadNetwork/Structure/RnLane.cs
@@ -252,6 +252,7 @@ namespace PLATEAU.RoadNetwork.Structure
             }
             catch
             {
+                Debug.LogError("Could not create center way.");
                 return null;
             }
         }
@@ -281,7 +282,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 {
                     foreach (var lane in road.AllLanes)
                     {
-                        if (lane.AllBorders.Any(b => b.IsSameLine(border)))
+                        if (lane.AllBorders.Any(b => b.IsSameLineReference(border)))
                             yield return lane;
                     }
                 }
@@ -296,7 +297,7 @@ namespace PLATEAU.RoadNetwork.Structure
 
             foreach (var n in Parent.GetNeighborRoads())
             {
-                if (n.GetBorders().Any(b => border.IsSameLine(b.EdgeWay)))
+                if (n.GetBorders().Any(b => border.IsSameLineReference(b.EdgeWay)))
                     yield return n;
             }
         }

--- a/Runtime/RoadNetwork/Structure/RnLineString.cs
+++ b/Runtime/RoadNetwork/Structure/RnLineString.cs
@@ -36,6 +36,7 @@ namespace PLATEAU.RoadNetwork.Structure
         {
             Points = new RnPoint[initialSize].ToList();
         }
+        
 
         public RnLineString(IEnumerable<RnPoint> points)
         {
@@ -429,7 +430,17 @@ namespace PLATEAU.RoadNetwork.Structure
             if (x.Count != y.Count)
                 return false;
 
-            return x.Points.SequenceEqual(y.Points);
+            for (int i = 0; i < x.Count; i++)
+            {
+                var xi = x[i];
+                var yi = y[i];
+                const float Threshold = 0.001f;
+                if (Math.Abs(xi.x - yi.x) > Threshold) return false;
+                if (Math.Abs(xi.y - yi.y) > Threshold) return false;
+                if (Math.Abs(xi.z - yi.z) > Threshold) return false;
+            }
+
+            return true;
         }
     }
 

--- a/Runtime/RoadNetwork/Structure/RnModel.cs
+++ b/Runtime/RoadNetwork/Structure/RnModel.cs
@@ -367,7 +367,7 @@ namespace PLATEAU.RoadNetwork.Structure
                         continue;
 
                     var otherNeighbor =
-                        other.Neighbors.FirstOrDefault(n => n.Border.IsSameLine(neighbor.Border) && n.Road == inter);
+                        other.Neighbors.FirstOrDefault(n => n.Border.IsSameLineReference(neighbor.Border) && n.Road == inter);
                     if (otherNeighbor == null)
                         continue;
 

--- a/Runtime/RoadNetwork/Structure/RnRoad.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoad.cs
@@ -874,7 +874,7 @@ namespace PLATEAU.RoadNetwork.Structure
             foreach (var lane in self.MainLanes)
             {
                 // Borderと同じ線上にあるレーンを返す
-                if (lane.AllBorders.Any(b => b.IsSameLine(border)))
+                if (lane.AllBorders.Any(b => b.IsSameLineReference(border)))
                     yield return lane;
             }
         }
@@ -1153,25 +1153,25 @@ namespace PLATEAU.RoadNetwork.Structure
                     }
 
                     // start - startで重なっている場合
-                    if (dstSw.StartEdgeWay?.IsSameLine(srcSw.StartEdgeWay) ?? false)
+                    if (dstSw.StartEdgeWay?.IsSameLineReference(srcSw.StartEdgeWay) ?? false)
                     {
                         MergeSideWalk(true, RnWayEx.AppendFront2LineString);
                         dstSw.SetStartEdgeWay(srcSw.EndEdgeWay);
                     }
                     // start - endで重なっている場合
-                    else if (dstSw.StartEdgeWay?.IsSameLine(srcSw.EndEdgeWay) ?? false)
+                    else if (dstSw.StartEdgeWay?.IsSameLineReference(srcSw.EndEdgeWay) ?? false)
                     {
                         MergeSideWalk(false, RnWayEx.AppendFront2LineString);
                         dstSw.SetStartEdgeWay(srcSw.StartEdgeWay);
                     }
                     // end - endで重なっている場合
-                    else if (dstSw.EndEdgeWay?.IsSameLine(srcSw.EndEdgeWay) ?? false)
+                    else if (dstSw.EndEdgeWay?.IsSameLineReference(srcSw.EndEdgeWay) ?? false)
                     {
                         MergeSideWalk(true, RnWayEx.AppendBack2LineString);
                         dstSw.SetEndEdgeWay(srcSw.StartEdgeWay);
                     }
                     // end - startで重なっている場合
-                    else if (dstSw.EndEdgeWay?.IsSameLine(srcSw.StartEdgeWay) ?? false)
+                    else if (dstSw.EndEdgeWay?.IsSameLineReference(srcSw.StartEdgeWay) ?? false)
                     {
                         MergeSideWalk(false, RnWayEx.AppendBack2LineString);
                         dstSw.SetEndEdgeWay(srcSw.EndEdgeWay);
@@ -1250,7 +1250,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 {
                     foreach (var w in sw.AllWays)
                     {
-                        if (neighborRoad.SideWalks.Any(x => x.AllWays.Any(y => y.IsSameLine(w))))
+                        if (neighborRoad.SideWalks.Any(x => x.AllWays.Any(y => y.IsSameLineReference(w))))
                         {
                             checkBorderPoints.Add(w[0]);
                             checkBorderPoints.Add(w[^1]);

--- a/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
@@ -1046,7 +1046,7 @@ namespace PLATEAU.RoadNetwork.Structure
                     // 親の方向と一致している場合はprevLane -> nextLaneの方向になっているかチェックする
                     if (prevLane.IsReverse == false)
                     {
-                        if (nowLane.PrevBorder.IsSameLine(prevLane.NextBorder) == false)
+                        if (nowLane.PrevBorder.IsSameLineReference(prevLane.NextBorder) == false)
                         {
                             DebugEx.LogError($"invalid Direction Lane[{j}] ${prevRoad.GetTargetTransName()} -> ${nowRoad.GetTargetTransName()}");
                             return false;
@@ -1055,7 +1055,7 @@ namespace PLATEAU.RoadNetwork.Structure
                     // 親の方向と逆の場合はnextLane -> prevLaneの方向になっているかチェックする
                     else
                     {
-                        if (prevLane.PrevBorder.IsSameLine(nowLane.NextBorder) == false)
+                        if (prevLane.PrevBorder.IsSameLineReference(nowLane.NextBorder) == false)
                         {
                             DebugEx.LogError($"invalid Direction Lane[{j}] ${prevRoad.GetTargetTransName()} -> ${nowRoad.GetTargetTransName()}");
                             return false;
@@ -1206,25 +1206,25 @@ namespace PLATEAU.RoadNetwork.Structure
                         }
 
                         // start - startで重なっている場合
-                        if (dstSw.StartEdgeWay?.IsSameLine(srcSw.StartEdgeWay) ?? false)
+                        if (dstSw.StartEdgeWay?.IsSameLineReference(srcSw.StartEdgeWay) ?? false)
                         {
                             Merge(true, RnWayEx.AppendFront2LineString);
                             dstSw.SetStartEdgeWay(srcSw.EndEdgeWay);
                         }
                         // start - endで重なっている場合
-                        else if (dstSw.StartEdgeWay?.IsSameLine(srcSw.EndEdgeWay) ?? false)
+                        else if (dstSw.StartEdgeWay?.IsSameLineReference(srcSw.EndEdgeWay) ?? false)
                         {
                             Merge(false, RnWayEx.AppendFront2LineString);
                             dstSw.SetStartEdgeWay(srcSw.StartEdgeWay);
                         }
                         // end - endで重なっている場合
-                        else if (dstSw.EndEdgeWay?.IsSameLine(srcSw.EndEdgeWay) ?? false)
+                        else if (dstSw.EndEdgeWay?.IsSameLineReference(srcSw.EndEdgeWay) ?? false)
                         {
                             Merge(true, RnWayEx.AppendBack2LineString);
                             dstSw.SetEndEdgeWay(srcSw.StartEdgeWay);
                         }
                         // end - startで重なっている場合
-                        else if (dstSw.EndEdgeWay?.IsSameLine(srcSw.StartEdgeWay) ?? false)
+                        else if (dstSw.EndEdgeWay?.IsSameLineReference(srcSw.StartEdgeWay) ?? false)
                         {
                             Merge(false, RnWayEx.AppendBack2LineString);
                             dstSw.SetEndEdgeWay(srcSw.EndEdgeWay);

--- a/Runtime/RoadNetwork/Structure/RnSideWalk.cs
+++ b/Runtime/RoadNetwork/Structure/RnSideWalk.cs
@@ -305,7 +305,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <returns></returns>
         public static bool IsNeighboring(this RnSideWalk self, RnSideWalk other)
         {
-            return self.AllWays.Any(x => other.AllWays.Any(b => x.IsSameLine(b)));
+            return self.AllWays.Any(x => other.AllWays.Any(b => x.IsSameLineReference(b)));
         }
 
 

--- a/Runtime/RoadNetwork/Structure/RnWay.cs
+++ b/Runtime/RoadNetwork/Structure/RnWay.cs
@@ -65,7 +65,7 @@ namespace PLATEAU.RoadNetwork.Structure
 
             if (SameLineIsEqual)
             {
-                return x.IsSameLine(y);
+                return x.IsSameLineReference(y);
             }
 
             return x.IsReversed == y.IsReversed && x.IsReverseNormal == y.IsReverseNormal && Equals(x.LineString, y.LineString);
@@ -174,6 +174,13 @@ namespace PLATEAU.RoadNetwork.Structure
             LineString = lineString;
             IsReversed = isReversed;
             IsReverseNormal = isReverseNormal;
+        }
+        
+        public RnWay(RnWay other)
+        {
+            LineString = other.LineString.Clone(true);
+            IsReversed = other.IsReversed;
+            IsReverseNormal = other.IsReverseNormal;
         }
 
         public RnWay(RnWay src, bool cloneVertex = true)
@@ -501,18 +508,34 @@ namespace PLATEAU.RoadNetwork.Structure
         }
 
         /// <summary>
-        /// 同じ線分かどうか
+        /// 同じ線分かどうか（参照を比較）
         /// </summary>
-        /// <param name="other"></param>
-        /// <param name="onlyReferenceEqual"></param>
-        /// <returns></returns>
-        public bool IsSameLine(RnWay other, bool onlyReferenceEqual = true)
+        public bool IsSameLineReference(RnWay other)
         {
             if (other == null)
                 return false;
-            if (onlyReferenceEqual)
-                return LineString == other.LineString;
-            return RnLineString.Equals(LineString, other.LineString);
+            return LineString == other.LineString;
+            
+        }
+
+        /// <summary>
+        /// 同じ線分かどうか（点配列の内容を比較）
+        /// </summary>
+        public bool IsSameLineSequence(RnWay other)
+        {
+            if (other == null) return false;
+            if (Count != other.Count) return false;
+            for (int i = 0; i < Count; i++)
+            {
+                var p1 = GetPoint(i).Vertex;
+                var p2 = other.GetPoint(i).Vertex;
+                const float Threshold = 0.001f;
+                if (Math.Abs(p1.x - p2.x) > Threshold) return false;
+                if (Math.Abs(p1.y - p2.y) > Threshold) return false;
+                if (Math.Abs(p1.z - p2.z) > Threshold) return false;
+            }
+
+            return true;
         }
     }
 
@@ -606,7 +629,7 @@ namespace PLATEAU.RoadNetwork.Structure
             if (back == null)
                 return;
             // 自己挿入は禁止
-            if (self.IsSameLine(back))
+            if (self.IsSameLineReference(back))
                 return;
             if (self.IsReversed)
             {
@@ -631,7 +654,7 @@ namespace PLATEAU.RoadNetwork.Structure
             if (front == null)
                 return;
             // 自己挿入は禁止
-            if (self.IsSameLine(front))
+            if (self.IsSameLineReference(front))
                 return;
             if (self.IsReversed)
             {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6a84f446-635e-4df4-8eae-911951c55b42)

- 上図のとおり、「生成」ボタンを押すと車線の矢印が出てきます
- 路面標示のマテリアルについて、Unityを保存して開き直すと黄色と白色のマテリアルが入れ替わることがある問題を修正しました