### PR TITLE
Feature/track selection

### DIFF
--- a/Editor/RoadNetwork/Graph/RGraphDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Graph/RGraphDebugEditorWindow.cs
@@ -63,6 +63,11 @@ namespace PLATEAU.Editor.RoadNetwork.Graph
                 {
                     f.RemoveInnerVertex();
                 }
+
+                if (GUILayout.Button("MergeIsolatedVertex"))
+                {
+                    f.MergeIsolatedVertex();
+                }
             }
         }
         FaceEdit faceEdit = new FaceEdit();

--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -472,6 +472,27 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                 {
                     work.DelayExec.Add(() => intersection.SeparateContinuousBorder());
                 }
+
+                if (GUILayout.Button("Create Inside Objects"))
+                {
+                    List<RnPoint> points = new List<RnPoint>(intersection.Edges.Sum(x => x.Border.Count));
+                    foreach (var pos in intersection.Edges.SelectMany(e => e.Border.Points))
+                    {
+                        if (points.Any() && points.Last() == pos)
+                            continue;
+                        points.Add(pos);
+                    }
+                    if (points.Count > 1 && points[0] == points[^1])
+                        points.RemoveAt(points.Count - 1);
+
+                    var obj = new GameObject("InsideObjects");
+                    foreach (var pos in points)
+                    {
+                        var go = new GameObject("Point");
+                        go.transform.SetParent(obj.transform);
+                        go.transform.position = pos.Vertex;
+                    }
+                }
             }
 
         }

--- a/Runtime/RoadNetwork/Factory/RoadNetworkFactory.cs
+++ b/Runtime/RoadNetwork/Factory/RoadNetworkFactory.cs
@@ -777,7 +777,7 @@ namespace PLATEAU.RoadNetwork.Factory
                 }
 
                 // 道路を分割する
-                ret.SplitLaneByWidth(RoadSize, out var failedLinks);
+                ret.SplitLaneByWidth(RoadSize, false, out var failedLinks);
                 ret.ReBuildIntersectionTracks();
 
                 // 信号制御器をデフォ値で配置する

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -992,7 +992,7 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
         /// <param name="visibleType"></param>
         private void DrawLane(RnLane lane, LaneOption op, VisibleType visibleType)
         {
-            laneOp?.Draw(work, lane, visibleType);
+            op?.Draw(work, lane, visibleType);
         }
 
         private void DrawRoad(RnRoad road, VisibleType visibleType)

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -7,10 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.Serialization;
 using UnityEngine.Splines;
-using static PLATEAU.RoadNetwork.Structure.Drawer.PLATEAURnModelDrawerDebug;
-using static PLATEAU.RoadNetwork.Util.LineCrossPointResult;
 using Object = System.Object;
 
 namespace PLATEAU.RoadNetwork.Structure.Drawer
@@ -220,6 +217,22 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
                 // toがこれを満たすトラックのみ表示
                 public VisibleType toRoadType = VisibleType.All;
 
+                [Serializable]
+                public class TurnTypeColor
+                {
+                    [field: SerializeField]
+                    public RnTurnType Type { get; set; }
+                    [field: SerializeField]
+                    public Color Color { get; set; }
+                    public TurnTypeColor(RnTurnType type, Color color)
+                    {
+                        Type = type;
+                        Color = color;
+                    }
+                }
+
+                public List<TurnTypeColor> turnTypeColor = EnumEx.GetValues<RnTurnType>().Select(x => new TurnTypeColor(x, DebugEx.GetDebugColor((int)x, RnTurnTypeEx.Count))).ToList();
+
                 protected override bool DrawImpl(DrawWork work, RnIntersection intersection)
                 {
                     var color = baseColor;
@@ -242,7 +255,7 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
 
                         if (useTurnTypeColor)
                         {
-                            color = DebugEx.GetDebugColor((int)track.TurnType, RnTurnTypeEx.Count);
+                            color = turnTypeColor.FirstOrDefault(x => x.Type == track.TurnType)?.Color ?? DebugEx.GetDebugColor((int)track.TurnType, RnTurnTypeEx.Count);
                         }
 
                         Color CheckRoad(RnWay trackBorderWay)

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -198,7 +198,6 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
             {
                 public Color baseColor = Color.yellow * 0.7f;
 
-                public bool useTurnTypeColor = false;
 
                 public Color disConnectedColor = Color.red;
 
@@ -231,7 +230,8 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
                     }
                 }
 
-                public List<TurnTypeColor> turnTypeColor = EnumEx.GetValues<RnTurnType>().Select(x => new TurnTypeColor(x, DebugEx.GetDebugColor((int)x, RnTurnTypeEx.Count))).ToList();
+                public bool useTurnTypeColor = false;
+                public List<TurnTypeColor> turnTypeColors = EnumEx.GetValues<RnTurnType>().Select(x => new TurnTypeColor(x, DebugEx.GetDebugColor((int)x, RnTurnTypeEx.Count))).ToList();
 
                 protected override bool DrawImpl(DrawWork work, RnIntersection intersection)
                 {
@@ -255,7 +255,7 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
 
                         if (useTurnTypeColor)
                         {
-                            color = turnTypeColor.FirstOrDefault(x => x.Type == track.TurnType)?.Color ?? DebugEx.GetDebugColor((int)track.TurnType, RnTurnTypeEx.Count);
+                            color = turnTypeColors.FirstOrDefault(x => x.Type == track.TurnType)?.Color ?? DebugEx.GetDebugColor((int)track.TurnType, RnTurnTypeEx.Count);
                         }
 
                         Color CheckRoad(RnWay trackBorderWay)

--- a/Runtime/RoadNetwork/Structure/RnIntersection.cs
+++ b/Runtime/RoadNetwork/Structure/RnIntersection.cs
@@ -771,6 +771,8 @@ namespace PLATEAU.RoadNetwork.Structure
                     var toEg = borderEdgeGroups[index];
                     if (toEg.IsValid == false)
                         continue;
+                    if (toEg.OutBoundEdges.Any() == false)
+                        continue;
                     var turnType = RnTurnTypeEx.GetTurnType(-fromEg.Normal, toEg.Normal, RnModel.Plane);
                     foreach (var to in toEg.OutBoundEdges)
                     {
@@ -877,8 +879,9 @@ namespace PLATEAU.RoadNetwork.Structure
             RnTrack TryCreateTwoLineTrack()
             {
                 var plane = RnModel.Plane;
-                var fromRay = new Ray(fromPos - fromNormal * 0.1f, -fromNormal);
-                var toRay = new Ray(toPos - toNormal * 0.1f, -toNormal);
+                var offset = 0.01f;
+                var fromRay = new Ray(fromPos - fromNormal * offset, -fromNormal);
+                var toRay = new Ray(toPos - toNormal * offset, -toNormal);
 
                 // 交差しない場合は無視
                 if (fromRay.CalcIntersectionBy2D(toRay, plane, out var cp, out var _, out var _) == false)
@@ -1585,11 +1588,13 @@ namespace PLATEAU.RoadNetwork.Structure
             List<RnPoint> points = new List<RnPoint>(self.Edges.Sum(x => x.Border.Count));
             foreach (var p in self.Edges.SelectMany(e => e.Border.Points))
             {
-                if (points.Any() && (points.Last() == p || points.First() == p))
+                if (points.Any() && points.Last() == p)
                     continue;
                 points.Add(p);
             }
-            return GeoGraph2D.IsInsidePolygon(pos.Xz(), points.Select(x => x.Vertex.Xz()));
+            if (points.Count > 1 && points[0] == points[^1])
+                points.RemoveAt(points.Count - 1);
+            return GeoGraph2D.IsInsidePolygon(pos.Xz(), points.Select(x => x.Vertex.Xz()).ToList());
         }
 
 #if false

--- a/Runtime/RoadNetwork/Structure/RnIntersection.cs
+++ b/Runtime/RoadNetwork/Structure/RnIntersection.cs
@@ -754,6 +754,8 @@ namespace PLATEAU.RoadNetwork.Structure
                 if (inBoundsLeft2Right.Count == 0)
                     continue;
 
+                if (fromEg.IsValid == false)
+                    continue;
                 // fromEg -> toEgのTurnTypeとtoEgよりも左側に同じTurnTypeがいくつあるか
                 // fromEgから出ていくTrackのTurnTypeをTrack数分の配列で事前に作成
                 // 左折2レーン, 直進2レーン, 右折1レーンの場合以下のようになる
@@ -767,6 +769,8 @@ namespace PLATEAU.RoadNetwork.Structure
                 {
                     var index = (startEdgeIndex + i + 1) % borderEdgeGroups.Count;
                     var toEg = borderEdgeGroups[index];
+                    if (toEg.IsValid == false)
+                        continue;
                     var turnType = RnTurnTypeEx.GetTurnType(-fromEg.Normal, toEg.Normal, AxisPlane.Xz);
                     foreach (var to in toEg.OutBoundEdges)
                     {
@@ -814,134 +818,6 @@ namespace PLATEAU.RoadNetwork.Structure
                     }
                 }
             }
-
-            //foreach (var fromEg in borderEdgeGroups)
-            //{
-            //    var inBounds = fromEg.InBoundEdges.ToList();
-
-            //    // fromEg -> toEgのTurnTypeとtoEgよりも左側に同じTurnTypeがいくつあるか
-            //    // fromEgから出ていくTrackのTurnTypeをTrack数分の配列で事前に作成
-            //    // 左折2レーン, 直進2レーン, 右折1レーンの場合以下のようになる
-            //    // [Left, Left, Straight, Straight, Right]
-            //    List<RnTurnType> turnTypes = new();
-
-
-            //    Dictionary<RnIntersectionEx.EdgeGroup, int> turnTypeIndex = new();
-
-            //    List<(RnTurnType Type, RnNeighbor To)> groups = new();
-            //    {
-            //        List<RnNeighbor> left2Rights = inBounds.Reversed().ToList();
-            //        // fromEgから出ていくTrackのTurnTypeのテーブルをあらかじめ作成
-            //        var startIndex = borderEdgeGroups.IndexOf(fromEg);
-
-            //        var size = op.AllowSelfTrack ? borderEdgeGroups.Count : borderEdgeGroups.Count - 1;
-            //        for (var i = 0; i < size; i++)
-            //        {
-            //            var index = (startIndex + i + 1) % borderEdgeGroups.Count;
-            //            var toEg = borderEdgeGroups[index];
-            //            var turnType = RnTurnTypeEx.GetTurnType(-fromEg.Normal, toEg.Normal, AxisPlane.Xz);
-            //            turnTypeIndex[toEg] = turnTypes.Count;
-            //            turnTypes.AddRange(Enumerable.Repeat(turnType, toEg.OutBoundEdges.Count()));
-
-            //            foreach (var to in toEg.OutBoundEdges)
-            //            {
-            //                groups.Add((turnType, to));
-            //            }
-            //        }
-            //    }
-
-
-
-            //    foreach (var toEg in borderEdgeGroups)
-            //    {
-            //        // Uターンを許可しない場合
-            //        if (fromEg.Key == toEg.Key && op.AllowSelfTrack == false)
-            //            continue;
-
-            //        // 隣り合っている場合.
-            //        var (way, widthTable) = GetWidthTable(fromEg, toEg);
-            //        void AddTrack(RnNeighbor from, RnNeighbor to, RnTurnType edgeTurnType)
-            //        {
-            //            // 対象外のものは無視
-            //            if (op.IsBuildTarget(this, from, to) == false)
-            //                return;
-            //            var track = CreateTrackOrDefault(op, way, widthTable, from, to, edgeTurnType);
-            //            TryAddOrUpdateTrack(track);
-            //        }
-
-            //        var outBounds = toEg.OutBoundEdges.ToList();
-            //        // 行き先が無い場合は無視
-            //        if (outBounds.Count <= 0)
-            //            continue;
-            //        var turnTypeStartIndex = turnTypeIndex[toEg];
-            //        if (turnTypeStartIndex >= turnTypes.Count)
-            //            continue;
-            //        var turnType = turnTypes[turnTypeIndex[toEg]];
-            //        if (turnType.IsLeft())
-            //        {
-            //            // 左折の場合は左側のレーンのみ作成する
-            //            var num = Mathf.Min(inBounds.Count, outBounds.Count);
-            //            for (var i = 0; i < num; ++i)
-            //            {
-            //                AddTrack(inBounds[^(i + 1)], outBounds[i], turnType);
-            //            }
-            //            //foreach (var from in Enumerable.Range(0, num).Select(i => inBounds[^(i + 1)]))
-            //            //{
-            //            //    foreach (var to in outBounds)
-            //            //        AddTrack(from, to, turnType);
-            //            //}
-            //        }
-            //        else if (turnType.IsRight())
-            //        {
-            //            // 右折の場合は右側のレーンのみ作成する
-            //            var num = Mathf.Min(inBounds.Count, outBounds.Count);
-            //            for (var i = 0; i < num; ++i)
-            //            {
-            //                AddTrack(inBounds[i], outBounds[^(i + 1)], turnType);
-            //            }
-            //            //foreach (var from in inBounds.Take(num))
-            //            //{
-            //            //    foreach (var to in outBounds)
-            //            //        AddTrack(from, to, turnType);
-            //            //}
-            //        }
-            //        else if (turnType == RnTurnType.Straight)
-            //        {
-            //            // 直進のレーンは互いに干渉しないように1:1で作成する
-            //            // すでに別のEdgeGroupでStraightがある場合も考慮してoffsetを作る
-            //            var offset = turnTypes.Take(turnTypeStartIndex).Count(x => x == RnTurnType.Straight);
-            //            // 最低でも1車線はtoEdgeへのトラックを用意する(全くいけなくなるので)
-            //            //offset = Mathf.Min(offset, inBounds.Count - 1);
-            //            // まだ作っていない直進トラックの数
-            //            var remainInBoundNum = inBounds.Count - offset;
-            //            var num = Mathf.Min(remainInBoundNum, outBounds.Count);
-            //            for (var i = 0; i < num; ++i)
-            //            {
-            //                // 左から順に見ていく
-            //                AddTrack(inBounds[^(i + offset + 1)], outBounds[i], turnType);
-            //            }
-
-            //            // 右側にこれ以上Trackが作れない場合.
-            //            // しょうがないので一番右の直進Trackに合流させる
-            //            var rightEgTrackNum = turnTypes.Skip(turnTypeStartIndex + outBounds.Count).Count();
-            //            for (var i = num + offset; i < inBounds.Count - rightEgTrackNum; ++i)
-            //            {
-            //                AddTrack(inBounds[^(i + 1)], outBounds.Last(), turnType);
-            //            }
-            //        }
-            //        else
-            //        {
-            //            foreach (var from in inBounds)
-            //            {
-            //                foreach (var to in outBounds)
-            //                {
-            //                    AddTrack(from, to, turnType);
-            //                }
-            //            }
-            //        }
-
-            //    }
-            //}
         }
 
         /// <summary>
@@ -1383,8 +1259,11 @@ namespace PLATEAU.RoadNetwork.Structure
             // 左側
             public EdgeGroup LeftSide { get; set; }
 
+            // 有効なエッジかどうか
+            public bool IsValid => Edges.Count > 0 && Edges.All(x => x.Border.IsValidOrDefault());
+
             // 法線方向
-            public Vector3 Normal => Edges.First().Border.GetEdgeNormal(0).normalized;
+            public Vector3 Normal => Edges.First(x => x.Border.IsValidOrDefault()).Border.GetEdgeNormal(0).normalized;
         };
 
         /// <summary>

--- a/Runtime/RoadNetwork/Structure/RnIntersection.cs
+++ b/Runtime/RoadNetwork/Structure/RnIntersection.cs
@@ -473,7 +473,7 @@ namespace PLATEAU.RoadNetwork.Structure
         public bool TryAddOrUpdateTrack(RnNeighbor from, RnNeighbor to)
         {
             const float tangentLength = 10f;
-            var turnType = RnTurnTypeEx.GetTurnType(-from.Border.GetEdgeNormal(0).normalized, to.Border.GetEdgeNormal(0).normalized, AxisPlane.Xz);
+            var turnType = RnTurnTypeEx.GetTurnType(-from.Border.GetEdgeNormal(0).normalized, to.Border.GetEdgeNormal(0).normalized, RnModel.Plane);
 
             var track = CreateTrack(from, to, turnType);
             return TryAddOrUpdateTrack(track);
@@ -771,7 +771,7 @@ namespace PLATEAU.RoadNetwork.Structure
                     var toEg = borderEdgeGroups[index];
                     if (toEg.IsValid == false)
                         continue;
-                    var turnType = RnTurnTypeEx.GetTurnType(-fromEg.Normal, toEg.Normal, AxisPlane.Xz);
+                    var turnType = RnTurnTypeEx.GetTurnType(-fromEg.Normal, toEg.Normal, RnModel.Plane);
                     foreach (var to in toEg.OutBoundEdges)
                     {
                         outBoundsLeft2Rights.Add((turnType, toEg, to));
@@ -876,7 +876,7 @@ namespace PLATEAU.RoadNetwork.Structure
 
             RnTrack TryCreateTwoLineTrack()
             {
-                var plane = AxisPlane.Xz;
+                var plane = RnModel.Plane;
                 var fromRay = new Ray(fromPos - fromNormal * 0.1f, -fromNormal);
                 var toRay = new Ray(toPos - toNormal * 0.1f, -toNormal);
 
@@ -1074,7 +1074,7 @@ namespace PLATEAU.RoadNetwork.Structure
             }
 
             // 時計回りになるように整列
-            if (GeoGraph2D.IsClockwise(edges.Select(e => e.Border[0].ToVector2(AxisPlane.Xz))) == false)
+            if (GeoGraph2D.IsClockwise(edges.Select(e => e.Border[0].ToVector2(RnModel.Plane))) == false)
             {
                 foreach (var e in edges)
                     e.Border.Reverse(true);

--- a/Runtime/RoadNetwork/Structure/RnIntersection.cs
+++ b/Runtime/RoadNetwork/Structure/RnIntersection.cs
@@ -855,7 +855,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 // 直進でつながったとしても角度つくようだとダメ
                 // #TODO : マジックナンバー
                 var ang = Vector2.Angle(-fromNormal.Xz(), segment.Direction.Xz());
-                if (ang > 30)
+                if (ang > 15)
                     return null;
 
                 var oneLineCrossPoints =

--- a/Runtime/RoadNetwork/Structure/RnLane.cs
+++ b/Runtime/RoadNetwork/Structure/RnLane.cs
@@ -735,6 +735,44 @@ namespace PLATEAU.RoadNetwork.Structure
             return Mathf.Min(self.CalcNextBorderWidth(), self.CalcPrevBorderWidth());
         }
 
+        /// <summary>
+        /// このレーンのうち最も狭くなる場所の幅を返す.頂点ごとに計算するため割と重い
+        /// 左右のレーンが不正の場合は0を返す
+        /// </summary>
+        /// <param name="self"></param>
+        /// <returns></returns>
+        public static float CalcMinWidth(this RnLane self)
+        {
+            if (self == null)
+                return 0f;
+            if (self.LeftWay.IsValidOrDefault() == false)
+                return 0f;
+            if (self.RightWay.IsValidOrDefault() == false)
+                return 0f;
+
+            var minW = float.MaxValue;
+            foreach (var v in self.LeftWay)
+            {
+                self.RightWay.GetNearestPoint(v, out var _, out var _, out var distance);
+                minW = Mathf.Min(minW, distance);
+            }
+
+            foreach (var v in self.RightWay)
+            {
+                self.LeftWay.GetNearestPoint(v, out var _, out var _, out var distance);
+                minW = Mathf.Min(minW, distance);
+            }
+
+            return minW;
+        }
+
+
+        /// <summary>
+        /// Laneの幅を設定する. 頂点ごとに計算するため割と重い
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="getWidth"></param>
+        /// <param name="moveLeft"></param>
         private static bool TrySetWidth(this RnLane self, Func<int, float, float> getWidth, bool moveLeft)
         {
             if (self.HasBothBorder == false)
@@ -761,7 +799,6 @@ namespace PLATEAU.RoadNetwork.Structure
                     return (nextPos, t2);
                 }
 
-                var lastWayIndex = fixWayIndex;
                 var (pos, t) = GetFixSeg(fixWayIndex);
 
                 if (t < 0f || t > 1f)

--- a/Runtime/RoadNetwork/Structure/RnLane.cs
+++ b/Runtime/RoadNetwork/Structure/RnLane.cs
@@ -658,7 +658,7 @@ namespace PLATEAU.RoadNetwork.Structure
             var rights =
                 self.RightWay.Vertices.ToList();
             AddPoint(Vector3.Lerp(lefts[0], rights[0], p2));
-            var segments = GeoGraphEx.GetInnerLerpSegments(lefts, rights, AxisPlane.Xz, p2);
+            var segments = GeoGraphEx.GetInnerLerpSegments(lefts, rights, RnModel.Plane, p2);
             foreach (var s in segments)
             {
                 AddPoint(s);
@@ -780,7 +780,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 Debug.Log($"[TrySetWidth] Lane {self.DebugMyId} HasBothBorder == false");
                 return false;
             }
-            var plane = AxisPlane.Xz;
+            var plane = RnModel.Plane;
             // 動かさない
             var fixWay = moveLeft ? self.RightWay : self.LeftWay;
             var moveWay = moveLeft ? self.LeftWay : self.RightWay;
@@ -1051,7 +1051,7 @@ namespace PLATEAU.RoadNetwork.Structure
                         else
                             AddPoint(prevBorder.Points.First());
 
-                        var segments = GeoGraphEx.GetInnerLerpSegments(targetLane.LeftWay.Vertices.ToList(), targetLane.RightWay.Vertices.ToList(), AxisPlane.Xz, rate);
+                        var segments = GeoGraphEx.GetInnerLerpSegments(targetLane.LeftWay.Vertices.ToList(), targetLane.RightWay.Vertices.ToList(), RnModel.Plane, rate);
                         foreach (var s in segments)
                         {
                             AddPoint(new RnPoint(s));

--- a/Runtime/RoadNetwork/Structure/RnLane.cs
+++ b/Runtime/RoadNetwork/Structure/RnLane.cs
@@ -522,6 +522,9 @@ namespace PLATEAU.RoadNetwork.Structure
             if (border.GetPoint(0) == RightWay.GetPoint(0))
                 return RnLaneBorderDir.Right2Left;
 
+            if (border.IsValid == false)
+                return null;
+
             var d = border.GetPoint(1).Vertex - border.GetPoint(0).Vertex;
             // #NOTE : Laneが複雑な形状をしているときのためPrevはPrev側, NextBorderだとNext側を見る
             var index = type == RnLaneBorderType.Prev ? 0 : -1;

--- a/Runtime/RoadNetwork/Structure/RnLineString.cs
+++ b/Runtime/RoadNetwork/Structure/RnLineString.cs
@@ -460,7 +460,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <param name="line"></param>
         /// <param name="axis"></param>
         /// <returns></returns>
-        public static IEnumerable<(Vector3 v, float index)> GetIntersectionBy2D(this RnLineString self, LineSegment3D line, AxisPlane axis = AxisPlane.Xz)
+        public static IEnumerable<(Vector3 v, float index)> GetIntersectionBy2D(this RnLineString self, LineSegment3D line, AxisPlane axis = RnModel.Plane)
         {
             foreach (var item in self.GetEdges().Select((edge, i) => new { edge, i }))
             {
@@ -481,7 +481,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <param name="axis"></param>
         /// <returns></returns>
         public static IEnumerable<(Vector3 v, float index)> GetIntersectionBy2D(this RnLineString self, Ray ray,
-            AxisPlane axis = AxisPlane.Xz)
+            AxisPlane axis = RnModel.Plane)
         {
             foreach (var item in self.GetEdges().Select((edge, i) => new { edge, i }))
             {
@@ -500,7 +500,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <param name="res"></param>
         /// <param name="axis"></param>
         /// <returns></returns>
-        public static bool TryGetNearestIntersectionBy2D(this RnLineString self, Ray ray, out (Vector3 v, float index) res, AxisPlane axis = AxisPlane.Xz)
+        public static bool TryGetNearestIntersectionBy2D(this RnLineString self, Ray ray, out (Vector3 v, float index) res, AxisPlane axis = RnModel.Plane)
         {
             var ret = self.GetIntersectionBy2D(ray, axis).ToList();
             if (ret.Any() == false)
@@ -694,7 +694,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <param name="other"></param>
         /// <param name="plane"></param>
         /// <returns></returns>
-        public static float GetDistance2D(this RnLineString self, RnLineString other, AxisPlane plane = AxisPlane.Xz)
+        public static float GetDistance2D(this RnLineString self, RnLineString other, AxisPlane plane = RnModel.Plane)
         {
             var ret = float.MaxValue;
             foreach (var e1 in self.GetEdges2D())

--- a/Runtime/RoadNetwork/Structure/RnLineString.cs
+++ b/Runtime/RoadNetwork/Structure/RnLineString.cs
@@ -435,7 +435,7 @@ namespace PLATEAU.RoadNetwork.Structure
 
     public static class RnLineStringEx
     {
-        public static IEnumerable<LineSegment2D> GetEdges2D(this RnLineString self, AxisPlane axis = AxisPlane.Xz)
+        public static IEnumerable<LineSegment2D> GetEdges2D(this RnLineString self, AxisPlane axis = RnModel.Plane)
         {
             foreach (var e in GeoGraphEx.GetEdges(self.Points.Select(x => x.Vertex.ToVector2(axis)), false))
                 yield return new LineSegment2D(e.Item1, e.Item2);

--- a/Runtime/RoadNetwork/Structure/RnModel.cs
+++ b/Runtime/RoadNetwork/Structure/RnModel.cs
@@ -519,8 +519,13 @@ namespace PLATEAU.RoadNetwork.Structure
             }
         }
 
-
-        public void SplitLaneByWidth(float roadWidth, out List<ulong> failedRoads)
+        /// <summary>
+        /// roadWidthの道路幅を基準にレーンを分割する
+        /// </summary>
+        /// <param name="roadWidth"></param>
+        /// <param name="rebuildTrack">レーン分割後に関連する交差点のトラックを再生成する</param>
+        /// <param name="failedRoads"></param>
+        public void SplitLaneByWidth(float roadWidth, bool rebuildTrack, out List<ulong> failedRoads)
         {
             failedRoads = new List<ulong>();
             var visitedRoads = new HashSet<RnRoad>();
@@ -550,7 +555,8 @@ namespace PLATEAU.RoadNetwork.Structure
                         {
                             var width = roadGroup.Roads.Select(r => r.GetLanes(dir).Sum(l => l.CalcWidth())).Min();
                             var num = (int)(width / roadWidth);
-                            roadGroup.SetLaneCount(dir, num);
+                            // 
+                            roadGroup.SetLaneCount(dir, num, rebuildTrack);
                         }
                     }
                     // 
@@ -563,7 +569,7 @@ namespace PLATEAU.RoadNetwork.Structure
 
                         var leftLaneCount = (num + 1) / 2;
                         var rightLaneCount = num - leftLaneCount;
-                        roadGroup.SetLaneCount(leftLaneCount, rightLaneCount);
+                        roadGroup.SetLaneCount(leftLaneCount, rightLaneCount, rebuildTrack);
                     }
 
                 }

--- a/Runtime/RoadNetwork/Structure/RnModel.cs
+++ b/Runtime/RoadNetwork/Structure/RnModel.cs
@@ -15,6 +15,8 @@ namespace PLATEAU.RoadNetwork.Structure
     {
         public const float Epsilon = float.Epsilon;
 
+        public const AxisPlane Plane = AxisPlane.Xz;
+
         //----------------------------------
         // start: フィールド
         //----------------------------------
@@ -629,7 +631,7 @@ namespace PLATEAU.RoadNetwork.Structure
         public static RoadCutResult CanSliceRoadHorizontalAndConvert2Intersection(this RnModel self, RnRoad road,
             LineSegment3D lineSegment1, LineSegment3D lineSegment2)
         {
-            if (lineSegment1.TrySegmentIntersectionBy2D(lineSegment2, AxisPlane.Xz, -1f, out var _))
+            if (lineSegment1.TrySegmentIntersectionBy2D(lineSegment2, RnModel.Plane, -1f, out var _))
                 return RoadCutResult.CrossCutLine;
 
             var check1 = self.CanSliceRoadHorizontal(road, lineSegment1, out var inters1);
@@ -869,7 +871,7 @@ namespace PLATEAU.RoadNetwork.Structure
             if (check != RoadCutResult.Success)
                 return new SliceRoadHorizontalResult { Result = check };
 
-            var lineSegment2D = lineSegment.To2D(AxisPlane.Xz);
+            var lineSegment2D = lineSegment.To2D(RnModel.Plane);
 
             // key   : 元のLineString
             // value : 分割後のselfのprev/next側のLineString
@@ -1145,7 +1147,7 @@ namespace PLATEAU.RoadNetwork.Structure
             if (check != RoadCutResult.Success)
                 return new SliceIntersectionResult { Result = check };
 
-            var lineSegment2D = lineSegment.To2D(AxisPlane.Xz);
+            var lineSegment2D = lineSegment.To2D(RnModel.Plane);
 
             // key   : 元のLineString
             // value : 分割後のselfのprev/next側のLineString

--- a/Runtime/RoadNetwork/Structure/RnRoad.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoad.cs
@@ -977,7 +977,7 @@ namespace PLATEAU.RoadNetwork.Structure
             {
                 throw new ArgumentException($"TryGetAdjustBorderSegment. Invalid border type ${borderType}");
             }
-            var plane = AxisPlane.Xz;
+            var plane = RnModel.Plane;
             var leftSeg2D = leftSeg.To2D(plane);
             var rightSeg2D = rightSeg.To2D(plane);
             // leftWay/rightWayの最後の直線の2等分線に対して直角な線

--- a/Runtime/RoadNetwork/Structure/RnWay.cs
+++ b/Runtime/RoadNetwork/Structure/RnWay.cs
@@ -671,6 +671,8 @@ namespace PLATEAU.RoadNetwork.Structure
         {
             self.GetNearestPoint(v, out nearest, out var pointIndex, out distance);
 
+            if (self.IsValidOrDefault() == false)
+                return false;
             var st = Mathf.Clamp((int)pointIndex, 0, self.Count - 2);
             var en = Mathf.Clamp(Mathf.CeilToInt(pointIndex - 1), 0, self.Count - 2);
 

--- a/Runtime/RoadNetwork/Structure/RnWay.cs
+++ b/Runtime/RoadNetwork/Structure/RnWay.cs
@@ -864,7 +864,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <param name="other"></param>
         /// <param name="plane"></param>
         /// <returns></returns>
-        public static float GetDistance2D(this RnWay self, RnWay other, AxisPlane plane = AxisPlane.Xz)
+        public static float GetDistance2D(this RnWay self, RnWay other, AxisPlane plane = RnModel.Plane)
         {
             return self?.LineString?.GetDistance2D(other?.LineString, plane) ?? float.MaxValue;
         }

--- a/Runtime/RoadNetwork/Tester/PLATEAUGeoGraphTesterLineString.cs
+++ b/Runtime/RoadNetwork/Tester/PLATEAUGeoGraphTesterLineString.cs
@@ -44,6 +44,29 @@ namespace PLATEAU.RoadNetwork.Tester
         }
         [FormerlySerializedAs("lineStringIntersectionTest")] public RoadSliceTestParam roadIntersectionTest = new RoadSliceTestParam();
 
+
+        [Serializable]
+        public class InsideTestParam
+        {
+            public bool enable = false;
+            public GameObject target;
+        }
+        public InsideTestParam insideTest = new InsideTestParam();
+
+        void InsideTest(InsideTestParam p)
+        {
+            if (p.enable == false)
+                return;
+            var target = p.target;
+            if (!target)
+                return;
+            var vertices = GetVertices();
+            var isInside = GeoGraph2D.IsInsidePolygon(target.transform.position.GetTangent(axis), vertices);
+            DebugEx.DrawString($"{isInside}", target.transform.position);
+        }
+
+
+
         private IEnumerable<Transform> GetChildren(Transform self)
         {
             for (var i = 0; i < self.childCount; i++)
@@ -205,6 +228,7 @@ namespace PLATEAU.RoadNetwork.Tester
             EdgeBorderTest(edgeBorderTest);
             TurnTypeTest(turnTypeTest);
             RoadSliceTest(roadIntersectionTest);
+            InsideTest(insideTest);
         }
 
     }

--- a/Runtime/RoadNetwork/Util/RnEx.cs
+++ b/Runtime/RoadNetwork/Util/RnEx.cs
@@ -182,14 +182,14 @@ namespace PLATEAU.RoadNetwork.Util
             }
 
             AddPoint(start);
-            var segments = GeoGraphEx.GetInnerLerpSegments(leftVertices, rightVertices, AxisPlane.Xz, t);
+            var segments = GeoGraphEx.GetInnerLerpSegments(leftVertices, rightVertices, RnModel.Plane, t);
             // 1つ目の点はボーダーと重複するのでスキップ
             // #TODO : 実際はボーダーよりも外側にあるのはすべてスキップすべき
             foreach (var s in segments.Skip(1))
                 AddPoint(new RnPoint(s));
             AddPoint(end);
             // 自己交差があれば削除する
-            var plane = AxisPlane.Xz;
+            var plane = RnModel.Plane;
             GeoGraph2D.RemoveSelfCrossing(line.Points
                 , t => t.Vertex.GetTangent(plane)
                 , (p1, p2, p3, p4, inter, f1, f2) => new RnPoint(Vector3.Lerp(p1, p2, f1)));
@@ -216,7 +216,7 @@ namespace PLATEAU.RoadNetwork.Util
             {
                 var elem = new LineCrossPointResult.TargetLineInfo { LineString = way };
 
-                foreach (var r in way.GetIntersectionBy2D(lineSegment, AxisPlane.Xz))
+                foreach (var r in way.GetIntersectionBy2D(lineSegment, RnModel.Plane))
                 {
                     elem.Intersections.Add((r.index, r.v));
                 }

--- a/Runtime/RoadNetwork/Util/RnEx.cs
+++ b/Runtime/RoadNetwork/Util/RnEx.cs
@@ -167,6 +167,12 @@ namespace PLATEAU.RoadNetwork.Util
         /// <returns></returns>
         public static RnLineString CreateInnerLerpLineString(IReadOnlyList<Vector3> leftVertices, IReadOnlyList<Vector3> rightVertices, RnPoint start, RnPoint end, RnWay startBorder, RnWay endBorder, float t, float pointSkipDistance = 1e-3f)
         {
+            // 左右がどちらも直線もしくは点以下の場合 -> start/endを直接つなぐ
+            if (leftVertices.Count <= 2 && rightVertices.Count <= 2)
+            {
+                return new RnLineString(new List<RnPoint> { start, end });
+            }
+
             var line = new RnLineString();
             void AddPoint(RnPoint p)
             {

--- a/Runtime/Util/GeoGraph/GeoGraph2d.cs
+++ b/Runtime/Util/GeoGraph/GeoGraph2d.cs
@@ -1876,6 +1876,32 @@ namespace PLATEAU.Util.GeoGraph
             ret.Add(ret.Last() + 1);
             return ret;
         }
+
+        /// <summary>
+        /// pointがverticesで構成される多角形の内部にあるかどうかを返す
+        /// </summary>
+        /// <param name="point"></param>
+        /// <param name="vertices"></param>
+        /// <returns></returns>
+        public static bool IsInsidePolygon(Vector2 point, IEnumerable<Vector2> vertices)
+        {
+            var edges = GeoGraphEx.GetEdges(vertices, false).Select(v => new LineSegment2D(v.Item1, v.Item2)).ToList();
+            var ray = new Ray2D(point, Vector2.right);
+            var count = 0;
+            // Crossing Number algorithmで判定する
+            // https://www.nttpc.co.jp/technology/number_algorithm.html
+            foreach (var e in edges)
+            {
+                if (LineUtil.HalfLineSegmentIntersection(
+                        ray, e.Start, e.End, out var inter, out float t1,
+                        out float t2) && t1 > 0f && t2 is > 0f and < 1f)
+                {
+                    count++;
+                }
+            }
+            return count % 2 == 1;
+        }
+
 #if false
         public static Dictionary<Vector2, List<Tuple<Vector2, Vector2>>> ComputeIntersections(IEnumerable<Tuple<Vector2, Vector2>> originalSegments)
         {

--- a/Runtime/Util/GeoGraph/LineUtil.cs
+++ b/Runtime/Util/GeoGraph/LineUtil.cs
@@ -536,6 +536,11 @@ namespace PLATEAU.Util.GeoGraph
 
             var length = GetLineSegmentLength(vertices) * p;
             var len = 0f;
+            midPoint = Vector3.zero;
+            if (vertices.Count == 0)
+                return -1;
+
+            midPoint = vertices[0];
             for (var i = 0; i < vertices.Count - 1; ++i)
             {
                 var p0 = vertices[i];
@@ -550,7 +555,6 @@ namespace PLATEAU.Util.GeoGraph
                 }
             }
 
-            midPoint = Vector3.zero;
             return -1;
         }
 

--- a/Runtime/Util/RayEx.cs
+++ b/Runtime/Util/RayEx.cs
@@ -55,7 +55,7 @@ namespace PLATEAU.Util
             {
                 var d2 = new Vector2(ray.direction.GetTangent(plane).magnitude, ray.direction.GetNormal(plane)).normalized;
                 var x = (inter2 - ray.origin.GetTangent(plane)).magnitude;
-                var y = d2.y * x;
+                var y = d2.y * x + ray.origin.GetNormal(plane);
                 t = x * Mathf.Sqrt(1 + d2.y * d2.y);
                 return y;
             }


### PR DESCRIPTION
﻿## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->

## 実装内容
## トラック生成時の判断変更
### 直線でつなぐか2直線でつなぐかの判断変更
大抵は、2直線(1回だけ曲がる)状況が多いので先に2直線でつなぐかチェックするように変更.
その際, 交点が交差点の内部にあるかを判断する処理を追加.
また、1直線でつなぐかどうかの判定をターンタイプがStraightかどうかで判断していたが,  タイプ的にはStraightでも直線でつなぐとかなり角度がつくケースが存在するので, 進入角度と直線の角度で見るように
### 右左折含めてすべてのレーンで可能な限り合流ケースを除くように
退出レーンの方が多い場合は、一番左/右のレーンが複数担当し, それ以外は行き先を一つに絞るようにした。
ただし、退出レーンの方が少ない時はしょうがないので最右の退出レーンに複数レーンが進入するようになっている。

### 動作確認方法
道路構造を作成する
デバッグ描画の設定で, Intersection Op -> Show Track -> Draw Spline -> From Road Typeを「Scene Selected」にすると, 現在選択している「道路」（交差点ではない)から侵入するレーンだけが表示されるようになる。
この機能を使って、いろいろな交差点のトラックを確認し, 他のレーンをぶつかるような道路が無いか確認する
![image](https://github.com/user-attachments/assets/f0832f05-a9b6-47b1-b822-fb37d0126c30)


#### 妥協点
構造によっては稀に交差する状況は起こりえるのであくまで軽減
* 直進だが斜めに直進しており、その結果右隣の道路の右折とかぶるような状況などはどうしても起こるので許容している

## LOD1の道路に歩道を作成するときに, 最低限の道路の幅を渡しそれ以下になるようだったらスキップする処理追加
道路の幅がこれ以下の時はスキップするように
ただし、交差点は輪郭線と接続している道路の幅で判断するようしている
![image](https://github.com/user-attachments/assets/c8b825f2-ac2a-4599-b97d-5c1a30635b20)

### 動作確認
53393694で確認
こちらに対して道路構造を作成し
tran_f60afa38-dfa7-45ee-8d0b-e492617d9e63あたりの細いLOD1の道路に対して歩道が作成されないことを確認。

## グラフ構造生成時に1辺しかつながっていないような頂点は強制的にマージするように

最小地物に分解されたメッシュに対して、頂点結合を行った結果、以下のように多角形をなしていないような頂点が現れることがあるので, これを結合する処理を追加
o----o
|        |
|        |
o----o -----o
### 動作確認
これは、ちょっと見た目で確認できる場所が難しいのでコードの確認と、生成された道路構造に対して歩道が崩れたりしていないかで確認するしかないかと...


## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
