### PR TITLE
横断歩道を配置する機能を作成

### DIFF
--- a/Editor/RoadNetwork/EditingSystem/RoadNetworkEditSceneViewGui.cs
+++ b/Editor/RoadNetwork/EditingSystem/RoadNetworkEditSceneViewGui.cs
@@ -329,7 +329,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystem
         {
             // 道路を生成
             var roads = roadGroupEditorData.Ref.Roads;
-            new RoadReproducer().Generate(new RrTargetRoadBases(roadNetwork, roads.ToArray()));
+            new RoadReproducer().Generate(new RrTargetRoadBases(roadNetwork, roads.ToArray()), CrosswalkFrequency.All);
         }
 
         public class EditingIntersection

--- a/Editor/Window/Main/Tab/RoadGUIParts/RoadGeneratePanel.cs
+++ b/Editor/Window/Main/Tab/RoadGUIParts/RoadGeneratePanel.cs
@@ -65,46 +65,9 @@ namespace PLATEAU.Editor.Window.Main.Tab.RoadGuiParts
             GetT("Ignore_Highwaay").value = factory.IgnoreHighway;
             
 
-            
-            
-
-
             // 生成ボタンを押した時の挙動
             setupMethod = CreateSetupMethod();
             generateButton.clicked += setupMethod;
-
-            /// <summary>
-            /// 道路ネットワークを作成する
-            /// </summary>
-            /// <returns></returns>
-            // async Task CreateNetwork()
-            // {
-            //     var go = selfGameObject;
-            //     var targets = GetTargetCityObjects();
-            //     var req = factory.CreateRequest(targets, go);
-            //     await factory.CreateRnModelAsync(req);
-            // }
-
-            // List<PLATEAUCityObjectGroup> GetTargetCityObjects()
-            // {
-            //     List<TestTargetPresets> TargetPresets;
-            //     string TargetPresetName;
-            //     const bool TargetAll = true;
-            //
-            //     var ret = TargetAll
-            //         ? (IList<PLATEAUCityObjectGroup>)GameObject.FindObjectsOfType<PLATEAUCityObjectGroup>()
-            //         : TargetPresets
-            //             .FirstOrDefault(s => s.name == TargetPresetName)
-            //             ?.targets;
-            //     if (ret == null)
-            //         return new List<PLATEAUCityObjectGroup>();
-            //
-            //     return ret
-            //         .Where(c => c.transform.childCount == 0)
-            //         .Where(c => c.CityObjects.rootCityObjects.Any(a => a.CityObjectType == CityObjectType.COT_Road))
-            //         .Distinct()
-            //         .ToList();
-            // }
 
         }
 
@@ -129,6 +92,7 @@ namespace PLATEAU.Editor.Window.Main.Tab.RoadGuiParts
                 var midPointTolerrance = GetF("Remove_Mid_Point_Tolerance").value;
                 var allowEdgeAngle = GetF("Terminate_Allow_Edge_Angle").value;
                 var ignoreHighway = GetT("Ignore_Highwaay").value;
+                var crosswalkFreq = CrosswalkFreq(Get<DropdownField>("Crosswalk").index);
 
                 var tester = Object.FindObjectOfType<PLATEAURoadNetworkTester>();
                 if (tester == null)
@@ -160,7 +124,7 @@ namespace PLATEAU.Editor.Window.Main.Tab.RoadGuiParts
                 var model = tester.CreateNetwork().ContinueWithErrorCatch().Result;
                 
                 // 道路の白線、停止線、道路メッシュを生成します。
-                new RoadReproducer().Generate(new RrTargetModel(model));
+                new RoadReproducer().Generate(new RrTargetModel(model), crosswalkFreq);
 
             };
         }
@@ -180,5 +144,20 @@ namespace PLATEAU.Editor.Window.Main.Tab.RoadGuiParts
         }
 
 
+        /// <summary> 横断歩道のUIの選択肢IDをenumに変換します。 </summary>
+        private CrosswalkFrequency CrosswalkFreq(int uiChoiceIndex)
+        {
+            switch (uiChoiceIndex)
+            {
+                case 0:
+                    return CrosswalkFrequency.BigRoad;
+                case 1:
+                    return CrosswalkFrequency.All;
+                case 2:
+                    return CrosswalkFrequency.None;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
     }
 }

--- a/Resources/PlateauUIDocument/RoadNetwork/RoadNetwork_EditPanel.uxml
+++ b/Resources/PlateauUIDocument/RoadNetwork/RoadNetwork_EditPanel.uxml
@@ -1,5 +1,5 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="/Packages/com.synesthesias.plateau-unity-sdk/Resources/PlateauUIDocument/RoadNetwork/UIStyle.uss" />
+    <Style src="project://database/Packages/com.synesthesias.plateau-unity-sdk/Resources/PlateauUIDocument/RoadNetwork/UIStyle.uss?fileID=7433441132597879392&amp;guid=0d46d6988e7e1c94b84bd3971d937d56&amp;type=3#UIStyle" />
     <ui:VisualElement name="RoadNetwork_EditPanel" style="flex-grow: 0; padding-top: 8px; padding-right: 8px; padding-bottom: 8px; padding-left: 8px; border-left-color: rgb(136, 147, 146); border-right-color: rgb(136, 147, 146); border-top-color: rgb(136, 147, 146); border-bottom-color: rgb(136, 147, 146); border-top-width: 1px; border-right-width: 1px; border-bottom-width: 1px; border-left-width: 1px; border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px;">
         <ui:Label tabindex="-1" text="道路ネットワーク編集と、それをもとに道路再生成を行います" parse-escape-sequences="true" display-tooltip-when-elided="true" style="margin-top: 0; margin-right: 0; margin-bottom: 0; margin-left: 0; padding-top: 8px; padding-right: 0; padding-bottom: 8px; padding-left: 0; -unity-text-align: upper-center;" />
         <ui:VisualElement style="flex-grow: 1; align-items: center; padding-top: 6px; padding-bottom: 6px;">
@@ -20,6 +20,7 @@
                     <ui:Toggle label="中央分離帯の有無" name="EnableMedianLane" style="font-size: 12px;" />
                     <ui:Toggle label="左側歩道の有無" name="EnableLeftSideWalk" style="font-size: 12px;" />
                     <ui:Toggle label="右側歩道の有無" name="EnableRightSideWalk" style="font-size: 12px;" />
+                    <ui:Toggle label="横断歩道を配置" value="true" name="PlaceCrosswalk" />
                 </ui:VisualElement>
             </ui:VisualElement>
             <ui:VisualElement style="flex-grow: 1; padding-top: 8px; padding-bottom: 8px; align-items: center;">

--- a/Resources/PlateauUIDocument/RoadNetwork/RoadNetwork_GeneratePanel.uxml
+++ b/Resources/PlateauUIDocument/RoadNetwork/RoadNetwork_GeneratePanel.uxml
@@ -8,6 +8,7 @@
         <ui:VisualElement name="InputGroup" style="flex-grow: 1;">
             <ui:FloatField label="車線幅(メートル )" value="42.2" name="RoadSizeField" style="align-items: center; font-size: 12px;" />
             <ui:FloatField label="歩道生成時の歩道幅" value="42.2" name="SideWalkSize" style="align-items: center; font-size: 12px;" />
+            <ui:DropdownField label="横断歩道の配置" name="Crosswalk" choices="大きい道路に配置,すべての交差点に配置,配置しない" index="0" style="font-size: 12px; -unity-text-align: middle-left;" />
             <ui:Toggle label="道路LOD3の歩道情報を利用" name="Add_Lod_Side_Walk" style="font-size: 12px;" />
             <ui:Toggle label="中央分離帯を作成" name="Check_Median" style="font-size: 12px;" />
             <ui:Toggle label="信号制御器を自動配置" name="Add_TrafficSignalLight" style="font-size: 12px;" />

--- a/Resources/PlateauUIDocument/RoadNetwork/UIStyle.uss
+++ b/Resources/PlateauUIDocument/RoadNetwork/UIStyle.uss
@@ -20,7 +20,6 @@
     border-color: rgb(136, 147, 146);
 }
 
-
 #MenuGroup .unity-radio-button > VisualElement {
     display: none;
 }
@@ -103,13 +102,9 @@
     width: 50%;
 }
 
-
 #InputGroup .unity-float-field__label {
     width: 50%;
 }
-
-
-
 
 #CategoryTitle {
     margin: 0;
@@ -481,3 +476,10 @@ Scroller #unity-drag-container {
     transition: 0.2s;
 }
 
+.unity-popup-field__input {
+    flex-grow: 1.5;
+}
+
+.unity-popup-field__label {
+    flex-grow: 1;
+}

--- a/Runtime/RoadAdjust/ICrosswalkPlacementRule.cs
+++ b/Runtime/RoadAdjust/ICrosswalkPlacementRule.cs
@@ -23,7 +23,7 @@ namespace PLATEAU.RoadAdjust
         private const int LaneCountThreshold = 2;
         
         /// <summary> 道路の長さがこの値未満の道路には設置しません </summary>
-        private const float LengthThreshold = 100f;
+        private const float LengthThreshold = 30f;
         
         public bool ShouldPlace(RnRoad road)
         {
@@ -31,15 +31,9 @@ namespace PLATEAU.RoadAdjust
             if (road.MainLanes.Count < LaneCountThreshold) return false;
             // 十分長いこと
             var lane = road.MainLanes[0];
-            var line = lane.Points.ToArray();
-            float len = 0;
-            for (int i = 1; i < line.Length; i++)
-            {
-                len += Vector3.Distance(line[i - 1].Vertex, line[i].Vertex);
-                if (len >= LengthThreshold) return true;
-            }
-            
-            return false;
+            float leftLength = lane.LeftWay?.CalcLength() ?? 0f;
+            float rightLength = lane.RightWay?.CalcLength() ?? 0f;
+            return Mathf.Max(leftLength, rightLength) >= LengthThreshold;
         }
     }
 

--- a/Runtime/RoadAdjust/ICrosswalkPlacementRule.cs
+++ b/Runtime/RoadAdjust/ICrosswalkPlacementRule.cs
@@ -1,0 +1,113 @@
+using PLATEAU.RoadAdjust.RoadNetworkToMesh;
+using PLATEAU.RoadNetwork.Structure;
+using System;
+using System.Linq;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace PLATEAU.RoadAdjust
+{
+    /// <summary>
+    /// 横断歩道を設置する条件を表すインターフェイスです。
+    /// 設置すべきときにメソッド<see cref="ShouldPlace"/>がtrueとなるようにサブクラスを実装します。
+    /// </summary>
+    public interface ICrosswalkPlacementRule
+    {
+        public bool ShouldPlace(RnRoad road);
+    }
+
+    /// <summary> 横断歩道を設置する条件であり、太く長い道路であるときにtrueを返します。 </summary>
+    public class CrosswalkPlacementRuleBigRoad : ICrosswalkPlacementRule
+    {
+        /// <summary> レーン数がこの値未満の道路には設置しません </summary>
+        private const int LaneCountThreshold = 2;
+        
+        /// <summary> 道路の長さがこの値未満の道路には設置しません </summary>
+        private const float LengthThreshold = 100f;
+        
+        public bool ShouldPlace(RnRoad road)
+        {
+            // レーン数があること
+            if (road.MainLanes.Count < LaneCountThreshold) return false;
+            // 十分長いこと
+            var lane = road.MainLanes[0];
+            var line = lane.Points.ToArray();
+            float len = 0;
+            for (int i = 1; i < line.Length; i++)
+            {
+                len += Vector3.Distance(line[i - 1].Vertex, line[i].Vertex);
+                if (len >= LengthThreshold) return true;
+            }
+            
+            return false;
+        }
+    }
+
+    /// <summary> 横断歩道を設置する条件であり、全交差点に設置します。 </summary>
+    public class CrosswalkPlacementRuleAll : ICrosswalkPlacementRule
+    {
+        public bool ShouldPlace(RnRoad _)
+        {
+            return true;
+        }
+    }
+
+    /// <summary> 横断歩道を設置しません </summary>
+    public class CrosswalkPlacementRuleNone : ICrosswalkPlacementRule
+    {
+        public bool ShouldPlace(RnRoad _)
+        {
+            return false;
+        }
+    }
+
+    /// <summary> 横断歩道を設置しません。すでに設置されている場合は削除します。 </summary>
+    public class CrosswalkPlacementRuleDelete : ICrosswalkPlacementRule
+    {
+        /// <summary> 削除を伴います </summary>
+        public bool ShouldPlace(RnRoad road)
+        {
+            var target = road.TargetTrans;
+            var targetTran = target.Count == 0 || target[0] == null ? null : target[0].transform;
+            var crosswalkA =
+                PLATEAUReproducedRoad.Find(ReproducedRoadType.Crosswalk, targetTran, ReproducedRoadDirection.Next);
+            var crosswalkB = PLATEAUReproducedRoad.Find(ReproducedRoadType.Crosswalk, targetTran, ReproducedRoadDirection.Prev);
+            if(crosswalkA != null) Object.DestroyImmediate(crosswalkA);
+            if(crosswalkB != null) Object.DestroyImmediate(crosswalkB);
+            return false;
+        }
+    }
+    
+    /// <summary> 横断歩道を置く頻度設定 </summary>
+    internal enum CrosswalkFrequency
+    {
+        /// <summary> 太くて長い道路に置く </summary>
+        BigRoad,
+        /// <summary> 全ての交差点に置く </summary>
+        All,
+        /// <summary> 置かない。すでに置かれているものは削除しない </summary>
+        None,
+        /// <summary> 置かない。すでに置かれているものは削除する。 </summary>
+        Delete
+    }
+
+    internal static class CrosswalkFrequencyExtensions
+    {
+        public static ICrosswalkPlacementRule ToPlacementRule(this CrosswalkFrequency freq)
+        {
+            switch (freq)
+            {
+                case CrosswalkFrequency.BigRoad:
+                    return new CrosswalkPlacementRuleBigRoad();
+                case CrosswalkFrequency.All:
+                    return new CrosswalkPlacementRuleAll();
+                case CrosswalkFrequency.None:
+                    return new CrosswalkPlacementRuleNone();
+                case CrosswalkFrequency.Delete:
+                    return new CrosswalkPlacementRuleDelete();
+                default:
+                    throw new ArgumentOutOfRangeException();   
+            }
+        }
+    }
+}

--- a/Runtime/RoadAdjust/ICrosswalkPlacementRule.cs.meta
+++ b/Runtime/RoadAdjust/ICrosswalkPlacementRule.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 953648f7b04d471a8a1a89971b48ecb8
+timeCreated: 1735196720

--- a/Runtime/RoadAdjust/RoadMarking/Crosswalk.meta
+++ b/Runtime/RoadAdjust/RoadMarking/Crosswalk.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 720e56ef37a14ae191bc212b9facb081
+timeCreated: 1734936877

--- a/Runtime/RoadAdjust/RoadMarking/Crosswalk/CrosswalkComposer.cs
+++ b/Runtime/RoadAdjust/RoadMarking/Crosswalk/CrosswalkComposer.cs
@@ -19,11 +19,13 @@ namespace PLATEAU.RoadAdjust.RoadMarking.Crosswalk
         private const float LineOffset = 0.1f;
         
         
-        public List<CrosswalkInstance> Compose(IRrTarget target)
+        public List<CrosswalkInstance> Compose(IRrTarget target, CrosswalkFrequency crosswalkFrequency)
         {
             var ret = new List<CrosswalkInstance>();
+            var placementRule = crosswalkFrequency.ToPlacementRule();
             foreach (var road in target.Roads())
             {
+                if (!placementRule.ShouldPlace(road)) continue;
                 if (road.Next is RnIntersection nextIntersection)
                 {
                     var nextBorder = new MWLine(road.GetMergedBorder(RnLaneBorderType.Next, null));

--- a/Runtime/RoadAdjust/RoadMarking/Crosswalk/CrosswalkComposer.cs
+++ b/Runtime/RoadAdjust/RoadMarking/Crosswalk/CrosswalkComposer.cs
@@ -1,0 +1,139 @@
+using PLATEAU.RoadAdjust.RoadNetworkToMesh;
+using PLATEAU.RoadNetwork;
+using PLATEAU.RoadNetwork.Structure;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace PLATEAU.RoadAdjust.RoadMarking.Crosswalk
+{
+    internal class CrosswalkComposer
+    {
+        /// <summary> 横断歩道を停止線から何メートル奥に設置するか </summary>
+        private const float PositionOffset = 3.5f;
+        /// <summary> 横断歩道の幅 </summary>
+        private const float CrosslineWidth = 4f;
+        /// <summary> 横断歩道の破線の実線部と空白部のインターバル </summary>
+        private const float CrosslineDashInterval = 0.45f;
+        /// <summary> 横断歩道の端点を歩道から最低何メートル離すか </summary>
+        private const float LineOffset = 0.1f;
+        
+        
+        public List<CrosswalkInstance> Compose(IRrTarget target)
+        {
+            var ret = new List<CrosswalkInstance>();
+            foreach (var road in target.Roads())
+            {
+                if (road.Next is RnIntersection nextIntersection)
+                {
+                    var nextBorder = new MWLine(road.GetMergedBorder(RnLaneBorderType.Next, null));
+                    var crosswalk = GenerateCrosswalk(nextBorder, nextIntersection, road, ReproducedRoadDirection.Next);
+                    if(crosswalk != null) ret.Add(crosswalk);
+                }
+
+                if (road.Prev is RnIntersection prevIntersection)
+                {
+                    var prevBorder = new MWLine(road.GetMergedBorder(RnLaneBorderType.Prev, null));
+                    var crosswalk = GenerateCrosswalk(prevBorder, prevIntersection, road, ReproducedRoadDirection.Prev);
+                    if(crosswalk != null) ret.Add(crosswalk);
+                }
+            }
+            
+            return ret;
+        }
+
+        /// <summary>
+        /// <paramref name="intersection"/>の<paramref name="border"/>側に交差点を1つ生成します。
+        /// 生成できない場合はnullを返します。
+        /// </summary>
+        private CrosswalkInstance GenerateCrosswalk(MWLine border, RnIntersection intersection, RnRoadBase srcRoad, ReproducedRoadDirection direction)
+        {
+            // 横断歩道を結ぶべき場所として、歩道と歩道を結んだ線を求めます。
+            var linePositions = ShiftStopLine(border, intersection, PositionOffset);
+            if (linePositions == null) return null;
+            var lineWay = new RnWay(new RnLineString(linePositions.Select(p => new RnPoint(p))));
+
+            // 横断歩道を車道の中心に配置するための計算です。
+            float lineLen = Vector3.Distance(linePositions[0], linePositions[^1]);
+            float lineLenMinusOffset = lineLen - LineOffset * 2f;
+            int dashCount = Mathf.FloorToInt(lineLenMinusOffset / CrosslineDashInterval); // 破線の単位がいくつ入るか
+            if (dashCount % 2 == 0) dashCount--; // 破線が空白部で終わる場合、末尾の空白を除く
+            if (dashCount <= 0) return null;
+            float crosswalkLen = CrosslineDashInterval * dashCount + 0.01f;
+            float crosswalkOffset = (lineLen - crosswalkLen) / 2;
+            var crosswalkPositions = new[]
+            {
+                lineWay.PositionAtDistance(crosswalkOffset, false),
+                lineWay.PositionAtDistance(crosswalkOffset, true)
+            };
+            // 横断歩道を1本の破線として生成します。
+            var crosswalk = new DashedLineMeshGenerator(RoadMarkingMaterial.White, true, CrosslineWidth, CrosslineDashInterval).GenerateMeshInstance(crosswalkPositions);
+            return new CrosswalkInstance(crosswalk, srcRoad, direction);
+        }
+
+
+        /// <summary>
+        /// 停止線を<paramref name="positionOffset"/>メートルだけ奥に動かした線を返します。
+        /// 戻り値は2点となります。
+        /// </summary>
+        private Vector3[] ShiftStopLine(MWLine border, RnIntersection intersection, float positionOffset)
+        {
+            if (border.Count <= 1) return null;
+            const float Threshold = 0.1f;
+            var stop1 = border[0];
+            var stop2 = border[^1];
+            // 交差点で道路と接していない外形のうち、該当道路と接する線がどこかを探します
+            Vector3 shift1 = stop1;
+            Vector3 shift2 = stop2;
+            bool shift1Found = false;
+            bool shift2Found = false;
+            foreach (var edge in intersection.Edges.Where(n => n.Road == null))
+            {
+                var e = edge.Border;
+                var e1 = edge.Border[0];
+                var e2 = edge.Border[^1];
+                if (Vector3.Distance(e1, stop1) < Threshold)
+                {
+                    shift1 = e.PositionAtDistance(positionOffset, false);
+                    shift1Found = true;
+                }
+                else if (Vector3.Distance(e1, stop2) < Threshold)
+                {
+                    shift2 = e.PositionAtDistance(positionOffset, false);
+                    shift2Found = true;
+                }
+                else if (Vector3.Distance(e2, stop1) < Threshold)
+                {
+                    shift1 = e.PositionAtDistance(positionOffset, true);
+                    shift1Found = true;
+                }
+                else if (Vector3.Distance(e2, stop2) < Threshold)
+                {
+                    shift2 = e.PositionAtDistance(positionOffset, true);
+                    shift2Found = true;
+                }
+            }
+
+            if (!shift1Found || !shift2Found)
+            {
+                return null;
+            }
+            return new[] { shift1, shift2 };
+        }
+
+        /// <summary> 横断歩道のメッシュ情報と付随する情報を保持します。 </summary>
+        internal class CrosswalkInstance
+        {
+            public RoadMarkingInstance RoadMarkingInstance { get; private set; }
+            public RnRoadBase SrcRoad { get; private set; }
+            public ReproducedRoadDirection Direction { get; private set; }
+
+            public CrosswalkInstance(RoadMarkingInstance roadMarkingInstance, RnRoadBase srcRoad, ReproducedRoadDirection direction)
+            {
+                RoadMarkingInstance = roadMarkingInstance;
+                SrcRoad = srcRoad;
+                Direction = direction;
+            }
+        }
+    }
+}

--- a/Runtime/RoadAdjust/RoadMarking/Crosswalk/CrosswalkComposer.cs.meta
+++ b/Runtime/RoadAdjust/RoadMarking/Crosswalk/CrosswalkComposer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 45e78a1c4b584f48bfaeb8de9c6d4fd8
+timeCreated: 1734937177

--- a/Runtime/RoadAdjust/RoadMarking/DirectionalArrow/DirectionalArrowComposer.cs
+++ b/Runtime/RoadAdjust/RoadMarking/DirectionalArrow/DirectionalArrowComposer.cs
@@ -22,7 +22,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking.DirectionalArrow
             this.target = target;
         }
 
-        public List<RoadMarkingInstance> Generate()
+        public List<RoadMarkingInstance> Compose()
         {
             var ret = new List<RoadMarkingInstance>();
             
@@ -83,27 +83,10 @@ namespace PLATEAU.RoadAdjust.RoadMarking.DirectionalArrow
                 Debug.Log("Skipping because center way count is 0.");
                 return Vector3.zero;
             }
-            float len = 0;
-            int index = isNext ? center.Count - 1 : 0;
-            var pos = center.GetPoint(index);
-            while(len < ArrowPositionOffset) // オフセットの分だけ線上を動かします。
-            {
-                index += isNext ? -1 : 1;
-                if (index < 0 || index >= center.Count) break;
-                var nextPos = center.GetPoint(index);
-                float lenDiff = Vector3.Distance(nextPos, pos);
-                if (len + lenDiff >= ArrowPositionOffset)
-                {
-                    float t = (len + lenDiff - ArrowPositionOffset) / lenDiff; // オーバーした割合
-                    return Vector3.Lerp(pos, nextPos, 1 - t);
-                }
 
-                pos = nextPos;
-                len += lenDiff;
-            }
-
-            return pos;
+            return center.PositionAtDistance(ArrowPositionOffset, isNext);
         }
+        
         
 
         /// <summary>

--- a/Runtime/RoadAdjust/RoadMarking/ILineMeshGenerator.cs
+++ b/Runtime/RoadAdjust/RoadMarking/ILineMeshGenerator.cs
@@ -77,17 +77,17 @@ namespace PLATEAU.RoadAdjust.RoadMarking
     /// </summary>
     internal class DashedLineMeshGenerator : ILineMeshGenerator
     {
-        /// <summary> 破線内の1つの線の長さ </summary>
-        private const float DashLength = 5f;
-        private bool direction;
-        private RoadMarkingMaterial materialType;
-        private float lineWidth;
+        private readonly bool direction;
+        private readonly RoadMarkingMaterial materialType;
+        private readonly float lineWidth;
+        private readonly float dashLength;
 
-        public DashedLineMeshGenerator(RoadMarkingMaterial materialType, bool direction, float lineWidth)
+        public DashedLineMeshGenerator(RoadMarkingMaterial materialType, bool direction, float lineWidth, float dashLength)
         {
             this.materialType = materialType;
             this.direction = direction;
             this.lineWidth = lineWidth;
+            this.dashLength = dashLength;
         }
 
         public RoadMarkingInstance GenerateMeshInstance(IReadOnlyList<Vector3> srcPointsArg)
@@ -116,9 +116,9 @@ namespace PLATEAU.RoadAdjust.RoadMarking
                 float lenDiff = Vector3.Distance(srcPoints[i], srcPoints[i - 1]);
                 if (lenDiff <= 0.0000001) continue;
                 lenImComplete += lenDiff;
-                while (lenImComplete > DashLength) // 2点の間に、DashLengthが複数入る場合に対応するためのwhileです。
+                while (lenImComplete > dashLength) // 2点の間に、dashLengthが複数入る場合に対応するためのwhileです。
                 {
-                    float lenLineEnd = lenLineStart + DashLength;
+                    float lenLineEnd = lenLineStart + dashLength;
                     float t = (lenLineEnd - lengths[i - 1]) / lenDiff;
                     var lineEndPos = Vector3.Lerp(srcPoints[i - 1], srcPoints[i], t);
                     if (isBlank)
@@ -137,7 +137,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
 
                     isBlank = !isBlank;
                     lenLineStart = lenLineEnd;
-                    lenImComplete -= DashLength;
+                    lenImComplete -= dashLength;
                 }
 
                 if (!isBlank)

--- a/Runtime/RoadAdjust/RoadMarking/MarkedWay/MarkedWay.cs
+++ b/Runtime/RoadAdjust/RoadMarking/MarkedWay/MarkedWay.cs
@@ -103,6 +103,9 @@ namespace PLATEAU.RoadAdjust.RoadMarking
 
         /// <summary> 法令で定められた、停止線の線の太さです。 </summary>
         private const float StopLineWidth = 0.45f;
+
+        /// <summary> 法令で定められた、車線の破線の空白と実線部のインターバルです。 </summary>
+        private const float DashLength = 5f;
         
         public static ILineMeshGenerator ToLineMeshGenerator(this MarkedWayType type, bool direction)
         {
@@ -111,11 +114,11 @@ namespace PLATEAU.RoadAdjust.RoadMarking
                 case MarkedWayType.CenterLineOver6MWidth:
                     return new SolidLineMeshGenerator(RoadMarkingMaterial.White, CarLaneLineWidth);
                 case MarkedWayType.CenterLineUnder6MWidth:
-                    return new DashedLineMeshGenerator(RoadMarkingMaterial.White, direction, CarLaneLineWidth);
+                    return new DashedLineMeshGenerator(RoadMarkingMaterial.White, direction, CarLaneLineWidth, DashLength);
                 case MarkedWayType.CenterLineNearIntersection:
                     return new SolidLineMeshGenerator(RoadMarkingMaterial.Yellow, CarLaneLineWidth);
                 case MarkedWayType.LaneLine:
-                    return new DashedLineMeshGenerator(RoadMarkingMaterial.White, direction, CarLaneLineWidth);
+                    return new DashedLineMeshGenerator(RoadMarkingMaterial.White, direction, CarLaneLineWidth, DashLength);
                 case MarkedWayType.ShoulderLine:
                     return new SolidLineMeshGenerator(RoadMarkingMaterial.White, CarLaneLineWidth);
                 case MarkedWayType.StopLine:

--- a/Runtime/RoadAdjust/RoadMarking/RoadMarkingGenerator.cs
+++ b/Runtime/RoadAdjust/RoadMarking/RoadMarkingGenerator.cs
@@ -13,12 +13,13 @@ namespace PLATEAU.RoadAdjust.RoadMarking
     /// <summary>
     /// 道路ネットワークをもとに、車線の線となるメッシュを生成します。
     /// </summary>
-    public class RoadMarkingGenerator
+    internal class RoadMarkingGenerator
     {
         private readonly IRrTarget targetBeforeCopy;
+        private CrosswalkFrequency crosswalkFrequency;
         
         
-        public RoadMarkingGenerator(IRrTarget target)
+        public RoadMarkingGenerator(IRrTarget target, CrosswalkFrequency crosswalkFrequency)
         {
             
             if (target != null)
@@ -29,7 +30,8 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             {
                 Debug.LogError("target road network is null.");
             }
-            
+
+            this.crosswalkFrequency = crosswalkFrequency;
         }
 
         /// <summary> 路面標示をメッシュとして生成します。 </summary>
@@ -80,7 +82,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             }
             
             // 交差点を生成します。
-            var crosswalkInstances = new CrosswalkComposer().Compose(target);
+            var crosswalkInstances = new CrosswalkComposer().Compose(target, crosswalkFrequency);
             foreach (var crosswalk in crosswalkInstances)
             {
                 var crosswalkCombiner = new RoadMarkingCombiner();

--- a/Runtime/RoadAdjust/RoadMarking/RoadMarkingGenerator.cs
+++ b/Runtime/RoadAdjust/RoadMarking/RoadMarkingGenerator.cs
@@ -1,3 +1,4 @@
+using PLATEAU.RoadAdjust.RoadMarking.Crosswalk;
 using PLATEAU.RoadAdjust.RoadMarking.DirectionalArrow;
 using PLATEAU.RoadAdjust.RoadNetworkToMesh;
 using PLATEAU.RoadNetwork.Structure;
@@ -52,7 +53,9 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             var dstParent = RoadReproducer.GenerateDstParent();
 
             var roadBases = target.RoadBases().ToArray();
-            for (int i = 0; i < roadBases.Length; i++) // 道路オブジェクトごとに結合します。
+            
+            // 路面標示のうち、道路ごとに結合するものをこの道路forループの中に書きます。
+            for (int i = 0; i < roadBases.Length; i++)
             {
                 var rb = roadBases[i];
                 string roadName = rb.TargetTrans == null || rb.TargetTrans.Count == 0
@@ -62,49 +65,77 @@ namespace PLATEAU.RoadAdjust.RoadMarking
                     $"[{i + 1} / {roadBases.Length}] {roadName}");
                 var innerTarget = new RrTargetRoadBases(target.Network(), new[] { rb });
 
-                // 道路の線を取得します。
-                var ways = new MarkedWayListComposer().ComposeFrom(innerTarget);
-
-
-                ways.AddRange(new StopLineComposer().ComposeFrom(innerTarget));
-
-
-                var instances = new RoadMarkingCombiner();
-                foreach (var way in ways.MarkedWays)
-                {
-                    // 道路の線をメッシュに変換します。
-                    var gen = way.Type.ToLineMeshGenerator(way.IsReversed);
-                    var points = way.Line.Points;
-                    var instance = gen.GenerateMeshInstance(points.ToArray());
-
-                    instances.Add(instance);
-                }
+                var combiner = new RoadMarkingCombiner();
+                
+                // 白線を生成します。
+                combiner.AddRange(GenerateRoadLines(innerTarget)); 
+                
 
                 // 交差点前の矢印を生成します。
                 var arrowComposer = new DirectionalArrowComposer(innerTarget);
-                instances.AddRange(arrowComposer.Generate());
+                combiner.AddRange(arrowComposer.Compose());
 
-                var dstMesh = instances.Combine(out var materials);
-                GenerateGameObj(dstMesh, dstParent, rb, materials);
+                var dstMesh = combiner.Combine(out var materials);
+                GenerateGameObj(dstMesh, materials, dstParent, rb, ReproducedRoadType.LaneLineAndArrow, ReproducedRoadDirection.None);
             }
+            
+            // 交差点を生成します。
+            var crosswalkInstances = new CrosswalkComposer().Compose(target);
+            foreach (var crosswalk in crosswalkInstances)
+            {
+                var crosswalkCombiner = new RoadMarkingCombiner();
+                crosswalkCombiner.Add(crosswalk.RoadMarkingInstance);
+                var crosswalkMesh = crosswalkCombiner.Combine(out var crosswalkMats);
+                GenerateGameObj(crosswalkMesh, crosswalkMats, dstParent, crosswalk.SrcRoad, ReproducedRoadType.Crosswalk, crosswalk.Direction);
+            }
+            
         }
 
+        private IEnumerable<RoadMarkingInstance> GenerateRoadLines(IRrTarget innerTarget)
+        {
+            // 道路の白線を位置を計算します。
+            var ways = new MarkedWayListComposer().ComposeFrom(innerTarget);
+
+
+            ways.AddRange(new StopLineComposer().ComposeFrom(innerTarget));
+            
+            foreach (var way in ways.MarkedWays)
+            {
+                // 道路の白線の位置からメッシュインスタンスに変換します。
+                var gen = way.Type.ToLineMeshGenerator(way.IsReversed);
+                var points = way.Line.Points;
+                var instance = gen.GenerateMeshInstance(points.ToArray());
+
+                yield return instance;
+            }
+        }
         
 
-        private void GenerateGameObj(Mesh mesh, Transform dstParent, RnRoadBase srcRoad, Material[] materials)
+        /// <summary>
+        /// 道路標示をゲームオブジェクトとして配置します。
+        /// 引数の最初の2つを除くものをキーとし、シーン上に同じキーのものがあればそれを置き換えます。なければ新規作成します。
+        /// </summary>
+        private void GenerateGameObj(Mesh mesh, Material[] materials, Transform dstParent, RnRoadBase srcRoad,
+            ReproducedRoadType reproducedType, ReproducedRoadDirection direction)
         {
-            var targetRoads = srcRoad.TargetTrans;
+            var targetRoads = srcRoad?.TargetTrans;
             var targetRoad = targetRoads == null || targetRoads.Count == 0 ? null : targetRoads.First();
             var targetName = targetRoad == null ? "UnknownRoad" : targetRoad.name;
-            string dstName = $"RoadMarking-{targetName}";
+            string dstName = $"{reproducedType.ToGameObjName()}-{targetName}";
+            if(direction != ReproducedRoadDirection.None)
+            {
+                dstName += $"-{direction}";
+            }
             GameObject dstObj = null;
             if (targetRoad != null)
             {
-                dstObj = PLATEAUReproducedRoad.Find(ReproducedRoadType.RoadMarking, targetRoad.transform);
+                // シーンに同じものがあれば、それを置き換えます。
+                dstObj = PLATEAUReproducedRoad.Find(reproducedType, targetRoad.transform, direction);
             }
 
             if (dstObj == null)
             {
+                // シーンに同じものがなければ新規作成します。
                 dstObj = new GameObject(dstName);
             }
             
@@ -121,7 +152,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             dstObj.transform.parent = dstParent;
             mesh.name = dstName;
             var comp = dstObj.GetOrAddComponent<PLATEAUReproducedRoad>();
-            comp.Init(ReproducedRoadType.RoadMarking, targetRoad == null ? null : targetRoad.transform);
+            comp.Init(reproducedType, targetRoad == null ? null : targetRoad.transform, direction);
         }
     }
 }

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/PLATEAUReproducedRoad.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/PLATEAUReproducedRoad.cs
@@ -1,4 +1,5 @@
 using PLATEAU.RoadNetwork.Structure;
+using System;
 using UnityEngine;
 
 namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
@@ -10,20 +11,22 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
     {
         public ReproducedRoadType roadType;
         public Transform sourceRoad;
+        public ReproducedRoadDirection roadDirection;
 
-        public void Init(ReproducedRoadType roadTypeArg, Transform sourceRoadArg)
+        public void Init(ReproducedRoadType roadTypeArg, Transform sourceRoadArg, ReproducedRoadDirection roadDirectionArg)
         {
             roadType = roadTypeArg;
             sourceRoad = sourceRoadArg;
+            roadDirection = roadDirectionArg;
         }
 
         /// <summary> 値が合致するものをシーンから探します。なければnullを返します。 </summary>
-        public static GameObject Find(ReproducedRoadType roadTypeArg, Transform sourceRoadArg)
+        public static GameObject Find(ReproducedRoadType roadTypeArg, Transform sourceRoadArg, ReproducedRoadDirection roadDirectionArg)
         {
             var comps = FindObjectsOfType<PLATEAUReproducedRoad>(false);
             foreach (var c in comps)
             {
-                bool match = c.roadType == roadTypeArg && c.sourceRoad == sourceRoadArg;
+                bool match = c.roadType == roadTypeArg && c.sourceRoad == sourceRoadArg && c.roadDirection == roadDirectionArg;
                 if (match)
                 {
                     return c.gameObject;
@@ -34,9 +37,35 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
         }
     }
 
-    public enum ReproducedRoadType
+    /// <summary> 道路の両端に配置される道路標示（横断歩道）において、道路のどちら側に配置されたかを示します。どちらでもない道路標示はNoneとなります。 </summary>
+    public enum ReproducedRoadDirection
     {
+        None, Prev, Next
+    }
+
+    /// <summary> 道路ネットワークから何を生成したかです </summary>
+    public enum ReproducedRoadType
+    { 
         RoadMesh,
-        RoadMarking
+        LaneLineAndArrow,
+        Crosswalk
+    }
+    
+    public static class ReproducedRoadTypeExtension
+    {
+        public static string ToGameObjName(this ReproducedRoadType type)
+        {
+            switch (type)
+            {
+                case ReproducedRoadType.RoadMesh:
+                    return "Road";
+                case ReproducedRoadType.LaneLineAndArrow:
+                    return "LaneArrow";
+                case ReproducedRoadType.Crosswalk:
+                    return "Crosswalk";
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
     }
 }

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/RoadNetworkToMesh.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/RoadNetworkToMesh.cs
@@ -166,16 +166,20 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
 
         }
 
+        /// <summary>
+        /// シーン中にゲームオブジェクトとして配置します。
+        /// 同じものがシーンにあれば置き換え、なければ生成します。
+        /// </summary>
         private GameObject GenerateDstGameObj(Transform dstParent, GameObject[] srcObjs)
         {
             var srcObj = srcObjs.Length == 0 ? null : srcObjs[0];
             string srcObjName = srcObj == null ? "RoadUnknown" : $"{srcObj.name}";
-            string dstObjName = $"Generated-{srcObjName}";
+            string dstObjName = $"{ReproducedRoadType.RoadMesh.ToGameObjName()}-{srcObjName}";
 
             GameObject dstObj = null;
             if (srcObj != null)
             {
-                dstObj = PLATEAUReproducedRoad.Find(ReproducedRoadType.RoadMesh, srcObj.transform);
+                dstObj = PLATEAUReproducedRoad.Find(ReproducedRoadType.RoadMesh, srcObj.transform, ReproducedRoadDirection.None);
             }
 
             if (dstObj == null)
@@ -184,7 +188,7 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
             }
             dstObj.transform.SetParent(dstParent);
             var comp = dstObj.GetOrAddComponent<PLATEAUReproducedRoad>();
-            comp.Init(ReproducedRoadType.RoadMesh, srcObj == null ? null : srcObj.transform);
+            comp.Init(ReproducedRoadType.RoadMesh, srcObj == null ? null : srcObj.transform, ReproducedRoadDirection.None);
             return dstObj;
         }
         

--- a/Runtime/RoadAdjust/RoadReproducer.cs
+++ b/Runtime/RoadAdjust/RoadReproducer.cs
@@ -14,17 +14,17 @@ namespace PLATEAU.RoadAdjust
     /// </summary>
     internal class RoadReproducer
     {
-        public void Generate(IRrTarget target)
+        public void Generate(IRrTarget target, CrosswalkFrequency crosswalkFrequency)
         {
             // 道路ネットワークから道路メッシュを生成
             var rnm = new RoadNetworkToMesh.RoadNetworkToMesh(target, RnmLineSeparateType.Combine);
             rnm.Generate();
-            
+
             // 道路標示を生成
-            var rm = new RoadMarking.RoadMarkingGenerator(target);
+            var rm = new RoadMarking.RoadMarkingGenerator(target, crosswalkFrequency);
             rm.Generate();
         }
-        
+
         public static Transform GenerateDstParent()
         {
             var dstParent = SceneManager.GetActiveScene()
@@ -38,4 +38,6 @@ namespace PLATEAU.RoadAdjust
             return dstParent.transform;
         }
     }
+    
+
 }

--- a/Runtime/RoadAdjust/RoadReproducer.cs
+++ b/Runtime/RoadAdjust/RoadReproducer.cs
@@ -16,9 +16,11 @@ namespace PLATEAU.RoadAdjust
     {
         public void Generate(IRrTarget target)
         {
+            // 道路ネットワークから道路メッシュを生成
             var rnm = new RoadNetworkToMesh.RoadNetworkToMesh(target, RnmLineSeparateType.Combine);
             rnm.Generate();
             
+            // 道路標示を生成
             var rm = new RoadMarking.RoadMarkingGenerator(target);
             rm.Generate();
         }

--- a/Runtime/RoadNetwork/Structure/RnWay.cs
+++ b/Runtime/RoadNetwork/Structure/RnWay.cs
@@ -891,5 +891,33 @@ namespace PLATEAU.RoadNetwork.Structure
         {
             return self?.LineString?.GetDistance2D(other?.LineString, plane) ?? float.MaxValue;
         }
+        
+        /// <summary>
+        /// 線の端から<paramref name="distance"/>メートル辿ったときの位置を返します。
+        /// <paramref name="endSide"/>がtrueの場合、線を逆（配列のend側）から辿ります。
+        /// </summary>
+        public static Vector3 PositionAtDistance(this RnWay way, float distance, bool endSide)
+        {
+            float len = 0;
+            int index = endSide ? way.Count - 1 : 0;
+            var pos = way.GetPoint(index);
+            while(len < distance) // オフセットの分だけ線上を動かします。
+            {
+                index += endSide ? -1 : 1;
+                if (index < 0 || index >= way.Count) break;
+                var nextPos = way.GetPoint(index);
+                float lenDiff = Vector3.Distance(nextPos, pos);
+                if (len + lenDiff >= distance)
+                {
+                    float t = (len + lenDiff - distance) / lenDiff; // オーバーした割合
+                    return Vector3.Lerp(pos, nextPos, 1 - t);
+                }
+
+                pos = nextPos;
+                len += lenDiff;
+            }
+
+            return pos;
+        }
     }
 }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/4ed79df5-3a32-4da5-b129-0efa9c06583b)

- 道路調整→生成タブから道路ネットワーク生成したとき、横断歩道が配置されます。
- 横断歩道の配置方法を上図の3択から選ぶことができます。

![image](https://github.com/user-attachments/assets/b73f4105-6fc8-44cd-b9cc-96203b414cfb)

- 道路調整タブ→編集タブ→編集モードをONにする→道路を選択→チェックボックス「横断歩道を配置」を切り替える→編集内容を確定で、道路の横断歩道を切り替えることができます。