### PR TITLE
Feature/road network track selection 2

### DIFF
--- a/Runtime/RoadNetwork/RnDef.cs
+++ b/Runtime/RoadNetwork/RnDef.cs
@@ -1,4 +1,6 @@
-﻿namespace PLATEAU.RoadNetwork
+﻿using PLATEAU.Util.GeoGraph;
+
+namespace PLATEAU.RoadNetwork
 {
 
     // 左右を表すenum
@@ -25,5 +27,13 @@
         {
             return dir == RnDir.Left ? RnDir.Right : RnDir.Left;
         }
+    }
+
+    /// <summary>
+    /// 共通定義情報
+    /// </summary>
+    internal static class RnDef
+    {
+        public const AxisPlane Plane = AxisPlane.Xz;
     }
 }

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.Serialization;
 using UnityEngine.Splines;
 using Object = System.Object;
 
@@ -346,6 +347,9 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
             // 接続先の無いレーンを表示する
             public bool showNoTrackBorder = false;
 
+            // 輪郭線の法線を表示する
+            public bool showEdgeNormal = false;
+
             protected override IEnumerable<Drawer<RnIntersection>> GetChildDrawers()
             {
                 yield return showTrack;
@@ -396,6 +400,16 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
                     {
                         DrawEdge(showNonBorderEdge);
                     }
+                    if (showEdgeNormal)
+                    {
+                        var normal = RnIntersection.GetEdgeNormal(n);
+                        var center = RnIntersection.GetEdgeCenter(n);
+                        work.Self.DrawLine(center, center - 50 * normal);
+                    }
+
+                    if (work.Self.showPartsType.HasFlag(RnPartsTypeMask.Neighbor))
+                        DebugEx.DrawString($"{n.GetDebugLabelOrDefault()}", RnIntersection.GetEdgeCenter(n));
+
                 }
 
                 if (showNoTrackBorder)

--- a/Runtime/RoadNetwork/Structure/RnModel.cs
+++ b/Runtime/RoadNetwork/Structure/RnModel.cs
@@ -15,7 +15,7 @@ namespace PLATEAU.RoadNetwork.Structure
     {
         public const float Epsilon = float.Epsilon;
 
-        public const AxisPlane Plane = AxisPlane.Xz;
+        internal const AxisPlane Plane = RnDef.Plane;
 
         //----------------------------------
         // start: フィールド

--- a/Runtime/Util/GeoGraph/GeoGraph2d.cs
+++ b/Runtime/Util/GeoGraph/GeoGraph2d.cs
@@ -41,7 +41,7 @@ namespace PLATEAU.Util.GeoGraph
         /// <returns></returns>
         public static List<T> ComputeConvexVolume<T>(IEnumerable<T> vertices, Func<T, Vector3> toVec3, AxisPlane plane, float sameLineTolerance = 0f)
         {
-            Vector3 ToVec2(T a) => toVec3(a).GetTangent(plane);
+            Vector2 ToVec2(T a) => toVec3(a).GetTangent(plane);
             // リストの最後の辺が時計回りになっているかを確認
             bool IsLastClockwise(List<T> list)
             {


### PR DESCRIPTION
﻿## 関連リンク


## 実装内容
### デバッグエディタで交差点のエッジ情報を表示
デバッグエディタなので動作確認は特に必要ないです。
![image](https://github.com/user-attachments/assets/3398409b-5b3b-4142-8654-2beec155a2c7)

### 交差点のエッジの法線方向が必ず外側を向くように
RnIntersection.Align/AlignNormal

### 交差点のトラック生成時に直進のトラックに対して, 流入点と流出点の対応関係を流入角度を見るように
今までは一番左のレーン優先でとっていたがそれだと, 隣のレーンと重なることが多かったので修正

## 動作確認
メッシュコード : 53393683
交差点 : tran_7b828f25-8963-40c7-99ed-62136619801f

道路構造を作成しデバッグ表示で、
ここで、別のレーンのトラックが隣のレーンのトラックと重ならないかチェック
![image](https://github.com/user-attachments/assets/60c6a0ba-9636-4c9d-81f1-c516370420ae)

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること


## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
