### PR TITLE
update : 道路構造のシリアライズ処理の高速化

### DIFF
--- a/Editor/RoadNetwork/CodeGen.meta
+++ b/Editor/RoadNetwork/CodeGen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e1a3fa301b7f554ea95966ed5fb7ff1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/RoadNetwork/CodeGen/RnDataSerializeCodeGen.cs
+++ b/Editor/RoadNetwork/CodeGen/RnDataSerializeCodeGen.cs
@@ -1,0 +1,425 @@
+﻿using PLATEAU.CityInfo;
+using PLATEAU.RoadNetwork.Data;
+using PLATEAU.RoadNetwork.Structure;
+using PLATEAU.Util;
+using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace PLATEAU.Editor.RoadNetwork.CodeGen
+{
+    public class RnDataSerializeCodeGen
+    {
+        /// <summary>
+        /// ID化するために集めるタイプリスト
+        /// </summary>
+        public static List<Type> CollectDataTypes { get; } = new List<Type>
+        {
+            typeof(TrafficSignalLightController),
+            typeof(TrafficSignalLight),
+            typeof(TrafficSignalControllerPattern),
+            typeof(TrafficSignalControllerPhase),
+            typeof(RnPoint),
+            typeof(RnLineString),
+            typeof(RnLane),
+            typeof(RnRoadBase),
+            typeof(RnWay),
+            typeof(RnSideWalk),
+        };
+
+        /// <summary>
+        /// シリアライズ情報
+        /// </summary>
+        private class SerializeInfo
+        {
+            /// <summary>
+            /// フィールド情報
+            /// </summary>
+            public List<FieldInfo> Fields { get; } = new List<FieldInfo>();
+        }
+
+        private class Work
+        {
+            /// <summary>
+            /// 探索済み
+            /// </summary>
+            public HashSet<Type> Visited { get; } = new();
+
+            /// <summary>
+            /// Keyが存在する場合. 自分自身もしくはフィールドにCollect対象のデータを持っている
+            /// key   : シリアライズの探索対象のタイプ
+            /// value : そのフィールド情報
+            /// </summary>
+            public Dictionary<Type, SerializeInfo> SerializeInfos { get; } = new Dictionary<Type, SerializeInfo>();
+
+            /// <summary>
+            /// 検索対象のタイプ
+            /// </summary>
+            public HashSet<Type> CollectTargetTypes { get; } = new();
+
+            /// <summary>
+            /// key   : Type
+            /// value : keyの子クラス
+            /// ただし、同じAssemblyの物のみ
+            /// </summary>
+            public Dictionary<Type, HashSet<Type>> ChildTypes { get; } = new Dictionary<Type, HashSet<Type>>();
+
+            /// <summary>
+            /// チェック不要のタイプ. (この要素が対象外であることが保証されている
+            /// </summary>
+            public string TargetNameSpace { get; set; }
+
+            public bool IsTarget(Type type)
+            {
+                return CollectTargetTypes.Contains(type);
+            }
+
+            /// <summary>
+            /// 探索を無視していいタイプ
+            /// </summary>
+            /// <param name="type"></param>
+            /// <returns></returns>
+            public bool IsIgnore(Type type)
+            {
+                if (string.IsNullOrEmpty(TargetNameSpace) == false
+                    && (type.Namespace?.StartsWith(TargetNameSpace) ?? false) == false)
+                {
+                    return true;
+                }
+
+                // 単純型は対象外
+                if (TypeUtil.IsSimpleType(type))
+                    return true;
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Genericをすべて外した型を返す.
+        /// List&lt;&lt;T&gt;List&gt;のような型の場合、Tの型を取得する.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        private static Type RemoveGenericType(Type type)
+        {
+            var t = type.GenericTypeArguments?.FirstOrDefault();
+            if (t == null)
+                return type;
+            return RemoveGenericType(t);
+        }
+
+        /// <summary>
+        /// typeのフィールドを再帰的に探索してSerializeInfoを作成しworkに書き込む
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="flags"></param>
+        /// <param name="work"></param>
+        /// <returns></returns>
+        private static bool CollectSerializeInfos(Type type, BindingFlags flags, Work work)
+        {
+            // 完全対象外チェック
+            if (work.IsIgnore(type))
+                return false;
+
+            // すでに探索済みなら無視
+            if (work.Visited.Contains(type))
+                return work.SerializeInfos.ContainsKey(type);
+
+            work.Visited.Add(type);
+            // 自分自身が対象の場合はSerializeInfoにも入れる
+            if (work.IsTarget(type))
+                work.SerializeInfos.TryAdd(type, new SerializeInfo());
+
+            var fieldInfos = type.GetFields(flags);
+            foreach (var fieldInfo in fieldInfos)
+            {
+                // 自身のフィールドでない場合は無視
+                if (fieldInfo.DeclaringType != type)
+                    continue;
+
+                var fieldType = RemoveGenericType(fieldInfo.FieldType);
+
+                // 対象外チェック
+                if (work.IsIgnore(fieldType))
+                    continue;
+
+                var found = CollectSerializeInfos(fieldType, flags, work);
+                // 子クラスに対してもチェックを行う
+                if (work.ChildTypes.TryGetValue(fieldType, out var childTypes))
+                {
+                    foreach (var ct in childTypes)
+                    {
+                        if (CollectSerializeInfos(ct, flags, work))
+                            found = true;
+                    }
+                }
+
+                // 再起したメンバーを持っている場合. の親でチェック中の場合はfalseが返るが
+                if (found)
+                {
+                    work.SerializeInfos.TryAdd(type, new SerializeInfo());
+                    work.SerializeInfos[type].Fields.Add(fieldInfo);
+                }
+            }
+
+            return work.SerializeInfos.ContainsKey(type);
+        }
+
+        /// <summary>
+        /// インデント周りを考慮したStringBuilder
+        /// </summary>
+        private class CodeBuilder
+        {
+            readonly StringBuilder sb = new StringBuilder();
+            private int indent = 0;
+
+            private string Tab => new string('\t', indent);
+
+            public class TabLine : IDisposable
+            {
+                private readonly CodeBuilder codeBuilder;
+
+                public TabLine(CodeBuilder codeBuilder)
+                {
+                    this.codeBuilder = codeBuilder;
+                    codeBuilder.indent++;
+                }
+
+                public void Dispose()
+                {
+                    codeBuilder.indent--;
+                    codeBuilder.AppendLine("}");
+                }
+            }
+
+            public void AppendLine(string line)
+            {
+                sb.AppendLine($"{Tab}{line}");
+            }
+
+            public TabLine Nest(string line)
+            {
+                AppendLine(line + "{");
+                return new TabLine(this);
+            }
+
+            public override string ToString()
+            {
+                return sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Genericな型に対して良い感じの型名を返す
+        /// https://stackoverflow.com/questions/1533115/get-generictype-name-in-good-format-using-reflection-on-c-sharp
+        /// </summary>
+        /// <param name="t"></param>
+        /// <returns></returns>
+        private static string GetWellFormedFullName(Type t)
+        {
+            if (!t.IsGenericType)
+                return t.Name;
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append(t.Name.Substring(0, t.Name.LastIndexOf("`", StringComparison.Ordinal)));
+            sb.Append(t.GetGenericArguments().Aggregate("<",
+                (aggregate, type) => aggregate + (aggregate == "<" ? "" : ",") + GetWellFormedFullName(type)));
+            sb.Append(">");
+
+            return sb.ToString();
+        }
+        /// <summary>
+        /// typeに関して
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="path"></param>
+        private static void Generate(Type type, string path)
+        {
+            var work = new Work { TargetNameSpace = type.Namespace, };
+
+            foreach (var t in type.Assembly.DefinedTypes)
+            {
+                foreach (var baseType in t.GetBaseTypes())
+                {
+                    if (!work.ChildTypes.ContainsKey(baseType))
+                        work.ChildTypes[baseType] = new HashSet<Type>();
+                    work.ChildTypes[baseType].Add(t);
+                }
+            }
+
+            foreach (var t in CollectDataTypes)
+            {
+                work.CollectTargetTypes.Add(t);
+                if (work.ChildTypes.TryGetValue(t, out var childTypes))
+                {
+                    foreach (var ct in childTypes)
+                    {
+                        work.CollectTargetTypes.Add(ct);
+                    }
+                }
+            }
+
+            work.SerializeInfos.TryAdd(type, new SerializeInfo());
+            CollectSerializeInfos(type, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, work);
+
+            bool IsCodeGenTarget(Type type)
+            {
+                if (type == null)
+                    return false;
+                if (work.SerializeInfos.TryGetValue(type, out var si) && si.Fields.Count > 0)
+                    return true;
+                return type.BaseType != null && IsCodeGenTarget(type.BaseType);
+            }
+
+            var sb = new CodeBuilder();
+
+            sb.AppendLine("// GENERATED CODE");
+            sb.AppendLine("using System.Collections.Generic;");
+            sb.AppendLine("using System.Reflection;");
+            var serializeWorkClassName = $"Collect{type.Name}Work";
+            using (sb.Nest($"namespace {type.Namespace}"))
+            {
+                using (sb.Nest($"internal class {serializeWorkClassName}"))
+                {
+                    string FieldName(Type t) => $"{t.Name}s";
+
+                    sb.AppendLine("public HashSet<object> Visited {get;} = new();");
+
+                    foreach (var x in CollectDataTypes)
+                    {
+                        sb.AppendLine($"public HashSet<{x.Name}> {FieldName(x)} {{ get; }} = new ();");
+                    }
+
+                    foreach (var x in CollectDataTypes)
+                    {
+                        sb.AppendLine($"public bool TryAdd({x.Name} x) {{ return {FieldName(x)}.Add(x); }}");
+                    }
+                }
+            }
+
+            // privateフィールドに対してReflectionで取得するかどうか
+            // #NOTE : 今後partialではなくSerializer単体でデータ収集できるようにするためのもの
+            //       : 現状はoverride対応が面倒なのでpartialでやっている
+            bool useReflection = false;
+            // ここからはSerializeInfoを元にコード生成
+            // namespaceごとに分ける
+            foreach (var group in work.SerializeInfos.GroupBy(x => x.Key.Namespace))
+            {
+                using var ns = sb.Nest($"namespace {group.Key}");
+                foreach (var (key, val) in group.OrderBy(x => x.Key.Name))
+                {
+                    if (IsCodeGenTarget(key) == false)
+                        continue;
+                    using (sb.Nest($"partial class {key.Name}"))
+                    {
+                        var isTop = IsCodeGenTarget(key.BaseType) == false;
+
+                        Dictionary<string, FieldInfo> privateFields = new();
+                        sb.AppendLine($"// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する");
+                        using (sb.Nest($"internal {(isTop ? "virtual " : "override")} bool Collect({serializeWorkClassName} collectWork)"))
+                        {
+                            // 親がいる場合はVisitedチェックは親に任せる(暴発防止)
+                            if (IsCodeGenTarget(key.BaseType))
+                            {
+                                sb.AppendLine($"if(base.Collect(collectWork) == false) return false;");
+                            }
+                            else
+                            {
+                                sb.AppendLine($"if(collectWork.Visited.Add(this)== false) return false;");
+                            }
+
+                            foreach (var fieldInfo in val.Fields)
+                            {
+                                var originFieldName = fieldInfo.Name;
+
+                                // 
+                                if (fieldInfo.IsPrivate)
+                                {
+                                    // プロパティの場合はそっちに名前変更
+                                    var m = TypeUtil.BackingFieldNameRegex.Match(originFieldName);
+                                    if (m.Success)
+                                    {
+                                        originFieldName = m.Groups[1].Value;
+                                    }
+
+                                    if (useReflection)
+                                    {
+                                        var fieldInfoName = $"{originFieldName}FieldInfo";
+                                        privateFields.Add(fieldInfoName, fieldInfo);
+                                        sb.AppendLine(
+                                            $"var {originFieldName}Tmp = {fieldInfoName}.GetValue(this) as {GetWellFormedFullName(fieldInfo.FieldType)};");
+                                    }
+                                    else
+                                    {
+                                        sb.AppendLine($"var {originFieldName}Tmp = {originFieldName};");
+                                    }
+                                }
+                                else
+                                {
+                                    sb.AppendLine($"var {originFieldName}Tmp = {originFieldName};");
+                                }
+
+                                var fieldName = $"{originFieldName}Tmp";
+                                var rawFieldType = RemoveGenericType(fieldInfo.FieldType);
+
+
+                                void AddCollectWork(string name)
+                                {
+                                    using var _ = sb.Nest($"if({name} != null)");
+                                    if (work.IsTarget(rawFieldType))
+                                    {
+                                        using var a = sb.Nest($"if(collectWork.TryAdd({name}))");
+                                        if (IsCodeGenTarget(rawFieldType))
+                                            sb.AppendLine($"{name}.Collect(collectWork);");
+                                    }
+                                    else
+                                    {
+
+                                        if (IsCodeGenTarget(rawFieldType))
+                                            sb.AppendLine($"{name}.Collect(collectWork);");
+                                    }
+                                }
+
+                                if (rawFieldType != fieldInfo.FieldType)
+                                {
+                                    // #TODO : 2重リスト対応
+                                    using (sb.Nest($"foreach(var v in {fieldName} ?? new ())"))
+                                    {
+                                        AddCollectWork("v");
+                                    }
+                                }
+                                else
+                                {
+                                    AddCollectWork(fieldName);
+                                }
+                            }
+                            sb.AppendLine("return true;");
+                        }
+
+                        foreach (var (fieldName, fieldInfo) in privateFields)
+                        {
+                            sb.AppendLine($"private static readonly FieldInfo {fieldName} = typeof({key.Name}).GetField(\"{fieldInfo.Name}\", BindingFlags.Instance | BindingFlags.NonPublic);");
+                        }
+                    }
+                }
+            }
+
+            File.WriteAllText(path, sb.ToString());
+        }
+
+        /// <summary>
+        /// RnModelに対してシリアライズ用のデータ抽出を行うコードを生成する.
+        /// </summary>
+        /// <param name="path"></param>
+        public static void GenerateRnDataCollectCode(string path)
+        {
+            Generate(typeof(RnModel), path);
+        }
+    }
+}

--- a/Editor/RoadNetwork/CodeGen/RnDataSerializeCodeGen.cs.meta
+++ b/Editor/RoadNetwork/CodeGen/RnDataSerializeCodeGen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f51c582821ba424a876c4cc74527d24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/RoadNetwork/Structure/RnIntersection.cs
+++ b/Runtime/RoadNetwork/Structure/RnIntersection.cs
@@ -15,7 +15,7 @@ using UnityEngine.Splines;
 namespace PLATEAU.RoadNetwork.Structure
 {
     [Serializable]
-    public class RnTrack : ARnParts<RnTrack>
+    public partial class RnTrack : ARnParts<RnTrack>
     {
         //----------------------------------
         // start: フィールド
@@ -168,7 +168,7 @@ namespace PLATEAU.RoadNetwork.Structure
     }
 
     [Serializable]
-    public class RnNeighbor : ARnParts<RnNeighbor>
+    public partial class RnNeighbor : ARnParts<RnNeighbor>
     {
         //----------------------------------
         // start: フィールド
@@ -278,7 +278,7 @@ namespace PLATEAU.RoadNetwork.Structure
     /// 交差点
     /// </summary>
     [Serializable]
-    public class RnIntersection : RnRoadBase
+    public partial class RnIntersection : RnRoadBase
     {
         //----------------------------------
         // start: フィールド

--- a/Runtime/RoadNetwork/Structure/RnLane.cs
+++ b/Runtime/RoadNetwork/Structure/RnLane.cs
@@ -75,7 +75,7 @@ namespace PLATEAU.RoadNetwork.Structure
         MoveBothWay
     }
 
-    public class RnLane : ARnParts<RnLane>
+    public partial class RnLane : ARnParts<RnLane>
     {
         //----------------------------------
         // start: フィールド

--- a/Runtime/RoadNetwork/Structure/RnLineString.cs
+++ b/Runtime/RoadNetwork/Structure/RnLineString.cs
@@ -12,7 +12,7 @@ namespace PLATEAU.RoadNetwork.Structure
     /// 線分群クラス. 頂点のリストを持つ
     /// </summary>
     [Serializable]
-    public class RnLineString : ARnParts<RnLineString>, IReadOnlyList<Vector3>
+    public partial class RnLineString : ARnParts<RnLineString>, IReadOnlyList<Vector3>
     {
         //----------------------------------
         // start: フィールド
@@ -36,7 +36,7 @@ namespace PLATEAU.RoadNetwork.Structure
         {
             Points = new RnPoint[initialSize].ToList();
         }
-        
+
 
         public RnLineString(IEnumerable<RnPoint> points)
         {

--- a/Runtime/RoadNetwork/Structure/RnModel.cs
+++ b/Runtime/RoadNetwork/Structure/RnModel.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 namespace PLATEAU.RoadNetwork.Structure
 {
     // #NOTE : Editorが重いのでSerialize対象にしない
-    public class RnModel
+    public partial class RnModel
     {
         public const float Epsilon = float.Epsilon;
 

--- a/Runtime/RoadNetwork/Structure/RnModel.generated.cs
+++ b/Runtime/RoadNetwork/Structure/RnModel.generated.cs
@@ -1,0 +1,403 @@
+// GENERATED CODE
+using System.Collections.Generic;
+using System.Reflection;
+namespace PLATEAU.RoadNetwork.Structure{
+	internal class CollectRnModelWork{
+		public HashSet<object> Visited {get;} = new();
+		public HashSet<TrafficSignalLightController> TrafficSignalLightControllers { get; } = new ();
+		public HashSet<TrafficSignalLight> TrafficSignalLights { get; } = new ();
+		public HashSet<TrafficSignalControllerPattern> TrafficSignalControllerPatterns { get; } = new ();
+		public HashSet<TrafficSignalControllerPhase> TrafficSignalControllerPhases { get; } = new ();
+		public HashSet<RnPoint> RnPoints { get; } = new ();
+		public HashSet<RnLineString> RnLineStrings { get; } = new ();
+		public HashSet<RnLane> RnLanes { get; } = new ();
+		public HashSet<RnRoadBase> RnRoadBases { get; } = new ();
+		public HashSet<RnWay> RnWays { get; } = new ();
+		public HashSet<RnSideWalk> RnSideWalks { get; } = new ();
+		public bool TryAdd(TrafficSignalLightController x) { return TrafficSignalLightControllers.Add(x); }
+		public bool TryAdd(TrafficSignalLight x) { return TrafficSignalLights.Add(x); }
+		public bool TryAdd(TrafficSignalControllerPattern x) { return TrafficSignalControllerPatterns.Add(x); }
+		public bool TryAdd(TrafficSignalControllerPhase x) { return TrafficSignalControllerPhases.Add(x); }
+		public bool TryAdd(RnPoint x) { return RnPoints.Add(x); }
+		public bool TryAdd(RnLineString x) { return RnLineStrings.Add(x); }
+		public bool TryAdd(RnLane x) { return RnLanes.Add(x); }
+		public bool TryAdd(RnRoadBase x) { return RnRoadBases.Add(x); }
+		public bool TryAdd(RnWay x) { return RnWays.Add(x); }
+		public bool TryAdd(RnSideWalk x) { return RnSideWalks.Add(x); }
+	}
+}
+namespace PLATEAU.RoadNetwork.Structure{
+	partial class RnIntersection{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal override bool Collect(CollectRnModelWork collectWork){
+			if(base.Collect(collectWork) == false) return false;
+			var edgesTmp = edges;
+			foreach(var v in edgesTmp ?? new ()){
+				if(v != null){
+					v.Collect(collectWork);
+				}
+			}
+			var SignalControllerTmp = SignalController;
+			if(SignalControllerTmp != null){
+				if(collectWork.TryAdd(SignalControllerTmp)){
+					SignalControllerTmp.Collect(collectWork);
+				}
+			}
+			var tracksTmp = tracks;
+			foreach(var v in tracksTmp ?? new ()){
+				if(v != null){
+					v.Collect(collectWork);
+				}
+			}
+			return true;
+		}
+	}
+	partial class RnLane{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal virtual  bool Collect(CollectRnModelWork collectWork){
+			if(collectWork.Visited.Add(this)== false) return false;
+			var ParentTmp = Parent;
+			if(ParentTmp != null){
+				if(collectWork.TryAdd(ParentTmp)){
+					ParentTmp.Collect(collectWork);
+				}
+			}
+			var PrevBorderTmp = PrevBorder;
+			if(PrevBorderTmp != null){
+				if(collectWork.TryAdd(PrevBorderTmp)){
+					PrevBorderTmp.Collect(collectWork);
+				}
+			}
+			var NextBorderTmp = NextBorder;
+			if(NextBorderTmp != null){
+				if(collectWork.TryAdd(NextBorderTmp)){
+					NextBorderTmp.Collect(collectWork);
+				}
+			}
+			var LeftWayTmp = LeftWay;
+			if(LeftWayTmp != null){
+				if(collectWork.TryAdd(LeftWayTmp)){
+					LeftWayTmp.Collect(collectWork);
+				}
+			}
+			var RightWayTmp = RightWay;
+			if(RightWayTmp != null){
+				if(collectWork.TryAdd(RightWayTmp)){
+					RightWayTmp.Collect(collectWork);
+				}
+			}
+			var centerWayTmp = centerWay;
+			if(centerWayTmp != null){
+				if(collectWork.TryAdd(centerWayTmp)){
+					centerWayTmp.Collect(collectWork);
+				}
+			}
+			return true;
+		}
+	}
+	partial class RnLineString{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal virtual  bool Collect(CollectRnModelWork collectWork){
+			if(collectWork.Visited.Add(this)== false) return false;
+			var PointsTmp = Points;
+			foreach(var v in PointsTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+					}
+				}
+			}
+			return true;
+		}
+	}
+	partial class RnModel{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal virtual  bool Collect(CollectRnModelWork collectWork){
+			if(collectWork.Visited.Add(this)== false) return false;
+			var roadsTmp = roads;
+			foreach(var v in roadsTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+						v.Collect(collectWork);
+					}
+				}
+			}
+			var intersectionsTmp = intersections;
+			foreach(var v in intersectionsTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+						v.Collect(collectWork);
+					}
+				}
+			}
+			var sideWalksTmp = sideWalks;
+			foreach(var v in sideWalksTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+						v.Collect(collectWork);
+					}
+				}
+			}
+			return true;
+		}
+	}
+	partial class RnNeighbor{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal virtual  bool Collect(CollectRnModelWork collectWork){
+			if(collectWork.Visited.Add(this)== false) return false;
+			var BorderTmp = Border;
+			if(BorderTmp != null){
+				if(collectWork.TryAdd(BorderTmp)){
+					BorderTmp.Collect(collectWork);
+				}
+			}
+			var RoadTmp = Road;
+			if(RoadTmp != null){
+				if(collectWork.TryAdd(RoadTmp)){
+					RoadTmp.Collect(collectWork);
+				}
+			}
+			return true;
+		}
+	}
+	partial class RnRoad{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal override bool Collect(CollectRnModelWork collectWork){
+			if(base.Collect(collectWork) == false) return false;
+			var NextTmp = Next;
+			if(NextTmp != null){
+				if(collectWork.TryAdd(NextTmp)){
+					NextTmp.Collect(collectWork);
+				}
+			}
+			var PrevTmp = Prev;
+			if(PrevTmp != null){
+				if(collectWork.TryAdd(PrevTmp)){
+					PrevTmp.Collect(collectWork);
+				}
+			}
+			var mainLanesTmp = mainLanes;
+			foreach(var v in mainLanesTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+						v.Collect(collectWork);
+					}
+				}
+			}
+			var medianLaneTmp = medianLane;
+			if(medianLaneTmp != null){
+				if(collectWork.TryAdd(medianLaneTmp)){
+					medianLaneTmp.Collect(collectWork);
+				}
+			}
+			return true;
+		}
+	}
+	partial class RnRoadBase{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal virtual  bool Collect(CollectRnModelWork collectWork){
+			if(collectWork.Visited.Add(this)== false) return false;
+			var ParentModelTmp = ParentModel;
+			if(ParentModelTmp != null){
+				ParentModelTmp.Collect(collectWork);
+			}
+			var sideWalksTmp = sideWalks;
+			foreach(var v in sideWalksTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+						v.Collect(collectWork);
+					}
+				}
+			}
+			return true;
+		}
+	}
+	partial class RnSideWalk{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal virtual  bool Collect(CollectRnModelWork collectWork){
+			if(collectWork.Visited.Add(this)== false) return false;
+			var parentRoadTmp = parentRoad;
+			if(parentRoadTmp != null){
+				if(collectWork.TryAdd(parentRoadTmp)){
+					parentRoadTmp.Collect(collectWork);
+				}
+			}
+			var outsideWayTmp = outsideWay;
+			if(outsideWayTmp != null){
+				if(collectWork.TryAdd(outsideWayTmp)){
+					outsideWayTmp.Collect(collectWork);
+				}
+			}
+			var insideWayTmp = insideWay;
+			if(insideWayTmp != null){
+				if(collectWork.TryAdd(insideWayTmp)){
+					insideWayTmp.Collect(collectWork);
+				}
+			}
+			var startEdgeWayTmp = startEdgeWay;
+			if(startEdgeWayTmp != null){
+				if(collectWork.TryAdd(startEdgeWayTmp)){
+					startEdgeWayTmp.Collect(collectWork);
+				}
+			}
+			var endEdgeWayTmp = endEdgeWay;
+			if(endEdgeWayTmp != null){
+				if(collectWork.TryAdd(endEdgeWayTmp)){
+					endEdgeWayTmp.Collect(collectWork);
+				}
+			}
+			return true;
+		}
+	}
+	partial class RnTrack{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal virtual  bool Collect(CollectRnModelWork collectWork){
+			if(collectWork.Visited.Add(this)== false) return false;
+			var FromBorderTmp = FromBorder;
+			if(FromBorderTmp != null){
+				if(collectWork.TryAdd(FromBorderTmp)){
+					FromBorderTmp.Collect(collectWork);
+				}
+			}
+			var ToBorderTmp = ToBorder;
+			if(ToBorderTmp != null){
+				if(collectWork.TryAdd(ToBorderTmp)){
+					ToBorderTmp.Collect(collectWork);
+				}
+			}
+			return true;
+		}
+	}
+	partial class RnWay{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal virtual  bool Collect(CollectRnModelWork collectWork){
+			if(collectWork.Visited.Add(this)== false) return false;
+			var LineStringTmp = LineString;
+			if(LineStringTmp != null){
+				if(collectWork.TryAdd(LineStringTmp)){
+					LineStringTmp.Collect(collectWork);
+				}
+			}
+			return true;
+		}
+	}
+	partial class TrafficSignalControllerPattern{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal virtual  bool Collect(CollectRnModelWork collectWork){
+			if(collectWork.Visited.Add(this)== false) return false;
+			var ParentTmp = Parent;
+			if(ParentTmp != null){
+				if(collectWork.TryAdd(ParentTmp)){
+					ParentTmp.Collect(collectWork);
+				}
+			}
+			var PhasesTmp = Phases;
+			foreach(var v in PhasesTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+						v.Collect(collectWork);
+					}
+				}
+			}
+			var OffsetTrafficLightTmp = OffsetTrafficLight;
+			if(OffsetTrafficLightTmp != null){
+				if(collectWork.TryAdd(OffsetTrafficLightTmp)){
+					OffsetTrafficLightTmp.Collect(collectWork);
+				}
+			}
+			return true;
+		}
+	}
+	partial class TrafficSignalControllerPhase{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal virtual  bool Collect(CollectRnModelWork collectWork){
+			if(collectWork.Visited.Add(this)== false) return false;
+			var ParentTmp = Parent;
+			if(ParentTmp != null){
+				if(collectWork.TryAdd(ParentTmp)){
+					ParentTmp.Collect(collectWork);
+				}
+			}
+			var BlueRoadPairsTmp = BlueRoadPairs;
+			foreach(var v in BlueRoadPairsTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+						v.Collect(collectWork);
+					}
+				}
+			}
+			var YellowRoadPairsTmp = YellowRoadPairs;
+			foreach(var v in YellowRoadPairsTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+						v.Collect(collectWork);
+					}
+				}
+			}
+			var RedRoadPairsTmp = RedRoadPairs;
+			foreach(var v in RedRoadPairsTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+						v.Collect(collectWork);
+					}
+				}
+			}
+			return true;
+		}
+	}
+	partial class TrafficSignalLight{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal virtual  bool Collect(CollectRnModelWork collectWork){
+			if(collectWork.Visited.Add(this)== false) return false;
+			var ParentTmp = Parent;
+			if(ParentTmp != null){
+				if(collectWork.TryAdd(ParentTmp)){
+					ParentTmp.Collect(collectWork);
+				}
+			}
+			var RoadTmp = Road;
+			if(RoadTmp != null){
+				if(collectWork.TryAdd(RoadTmp)){
+					RoadTmp.Collect(collectWork);
+				}
+			}
+			var NeighborTmp = Neighbor;
+			foreach(var v in NeighborTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+						v.Collect(collectWork);
+					}
+				}
+			}
+			return true;
+		}
+	}
+	partial class TrafficSignalLightController{
+		// データシリアライズ用. メンバ変数から対象オブジェクトを抽出する
+		internal virtual  bool Collect(CollectRnModelWork collectWork){
+			if(collectWork.Visited.Add(this)== false) return false;
+			var ParentTmp = Parent;
+			if(ParentTmp != null){
+				if(collectWork.TryAdd(ParentTmp)){
+					ParentTmp.Collect(collectWork);
+				}
+			}
+			var TrafficLightsTmp = TrafficLights;
+			foreach(var v in TrafficLightsTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+						v.Collect(collectWork);
+					}
+				}
+			}
+			var SignalPatternsTmp = SignalPatterns;
+			foreach(var v in SignalPatternsTmp ?? new ()){
+				if(v != null){
+					if(collectWork.TryAdd(v)){
+						v.Collect(collectWork);
+					}
+				}
+			}
+			return true;
+		}
+	}
+}

--- a/Runtime/RoadNetwork/Structure/RnModel.generated.cs.meta
+++ b/Runtime/RoadNetwork/Structure/RnModel.generated.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83adea152ba4894468b9f250e5f28c8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/RoadNetwork/Structure/RnPoint.cs
+++ b/Runtime/RoadNetwork/Structure/RnPoint.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace PLATEAU.RoadNetwork.Structure
 {
     [Serializable]
-    public class RnPoint : ARnParts<RnPoint>
+    public partial class RnPoint : ARnParts<RnPoint>
     {
         [field: SerializeField] public Vector3 Vertex { get; set; }
 

--- a/Runtime/RoadNetwork/Structure/RnRoad.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoad.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 
 namespace PLATEAU.RoadNetwork.Structure
 {
-    public class RnRoad : RnRoadBase
+    public partial class RnRoad : RnRoadBase
     {
         //----------------------------------
         // start: フィールド

--- a/Runtime/RoadNetwork/Structure/RnRoadBase.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoadBase.cs
@@ -10,7 +10,7 @@ namespace PLATEAU.RoadNetwork.Structure
     /// Serialize時にnewする必要があるのでabstractにはできない
     /// </summary>
     [Serializable]
-    public class RnRoadBase : ARnParts<RnRoadBase>
+    public partial class RnRoadBase : ARnParts<RnRoadBase>
     {
         //----------------------------------
         // start: フィールド

--- a/Runtime/RoadNetwork/Structure/RnSideWalk.cs
+++ b/Runtime/RoadNetwork/Structure/RnSideWalk.cs
@@ -30,7 +30,7 @@ namespace PLATEAU.RoadNetwork.Structure
         RightLane,
     }
 
-    public class RnSideWalk : ARnParts<RnSideWalk>
+    public partial class RnSideWalk : ARnParts<RnSideWalk>
     {
         //----------------------------------
         // start: フィールド

--- a/Runtime/RoadNetwork/Structure/RnWay.cs
+++ b/Runtime/RoadNetwork/Structure/RnWay.cs
@@ -57,7 +57,7 @@ namespace PLATEAU.RoadNetwork.Structure
     /// 同じ線分だけど向きが逆ということが多々あるのでメモリ削減 & 比較を楽にするため
     /// </summary>
     [Serializable]
-    public class RnWay : ARnParts<RnWay>, IReadOnlyList<Vector3>
+    public partial class RnWay : ARnParts<RnWay>, IReadOnlyList<Vector3>
     {
         //----------------------------------
         // start: フィールド
@@ -148,7 +148,7 @@ namespace PLATEAU.RoadNetwork.Structure
             IsReversed = isReversed;
             IsReverseNormal = isReverseNormal;
         }
-        
+
         public RnWay(RnWay other)
         {
             LineString = other.LineString.Clone(true);
@@ -488,7 +488,7 @@ namespace PLATEAU.RoadNetwork.Structure
             if (other == null)
                 return false;
             return LineString == other.LineString;
-            
+
         }
 
         /// <summary>
@@ -864,7 +864,7 @@ namespace PLATEAU.RoadNetwork.Structure
         {
             return self?.LineString?.GetDistance2D(other?.LineString, plane) ?? float.MaxValue;
         }
-        
+
         /// <summary>
         /// 線の端から<paramref name="distance"/>メートル辿ったときの位置を返します。
         /// <paramref name="endSide"/>がtrueの場合、線を逆（配列のend側）から辿ります。
@@ -874,7 +874,7 @@ namespace PLATEAU.RoadNetwork.Structure
             float len = 0;
             int index = endSide ? way.Count - 1 : 0;
             var pos = way.GetPoint(index);
-            while(len < distance) // オフセットの分だけ線上を動かします。
+            while (len < distance) // オフセットの分だけ線上を動かします。
             {
                 index += endSide ? -1 : 1;
                 if (index < 0 || index >= way.Count) break;

--- a/Runtime/RoadNetwork/Structure/TrafficRegulationInfo.cs
+++ b/Runtime/RoadNetwork/Structure/TrafficRegulationInfo.cs
@@ -19,14 +19,14 @@ namespace PLATEAU.RoadNetwork.Structure
     /// 信号制御器
     /// </summary>
     [Serializable]
-    public class TrafficSignalLightController : ARnParts<TrafficSignalLightController>
+    public partial class TrafficSignalLightController : ARnParts<TrafficSignalLightController>
     {
 
         public static bool CreateDefault(RnIntersection intersection)
         {
             Assert.IsNotNull(intersection);
             // 信号制御器の作成、信号機の作成
-            var trafficController = 
+            var trafficController =
                 new TrafficSignalLightController("SignalController" + intersection.DebugMyId, intersection, intersection.GetCenterPoint());
 
             // 信号制御器の登録
@@ -198,7 +198,7 @@ namespace PLATEAU.RoadNetwork.Structure
     /// 信号灯器
     /// 注意　配置されている道路に交差点も設定出来るため注意
     /// </summary>
-    public class TrafficSignalLight : ARnParts<TrafficSignalLight>
+    public partial class TrafficSignalLight : ARnParts<TrafficSignalLight>
     {
         /// <summary>
         /// デシリアライズ用
@@ -308,7 +308,7 @@ namespace PLATEAU.RoadNetwork.Structure
     /// 信号制御のパターン
     /// 開始時刻、制御パターンID、フェーズのリスト、信号灯のオフセットを持つ
     /// </summary>
-    public class TrafficSignalControllerPattern : ARnParts<TrafficSignalControllerPattern>
+    public partial class TrafficSignalControllerPattern : ARnParts<TrafficSignalControllerPattern>
     {
         /// <summary>
         /// デシリアライズ用
@@ -330,7 +330,7 @@ namespace PLATEAU.RoadNetwork.Structure
     /// 信号制御のフェーズ
     /// 信号制御のパターンに含まれる要素
     /// </summary>
-    public class TrafficSignalControllerPhase : ARnParts<TrafficSignalControllerPhase>
+    public partial class TrafficSignalControllerPhase : ARnParts<TrafficSignalControllerPhase>
     {
         /// <summary>
         /// デシリアライズ用

--- a/Runtime/Util/TypeUtil.cs
+++ b/Runtime/Util/TypeUtil.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace PLATEAU.Util
 {
@@ -66,7 +67,7 @@ namespace PLATEAU.Util
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
-        private static bool IsSimpleType(this Type type)
+        public static bool IsSimpleType(Type type)
         {
             return type.IsPrimitive || type.IsEnum || type == typeof(string);
         }
@@ -98,7 +99,7 @@ namespace PLATEAU.Util
                 yield return new Tuple<FieldInfo, object>(memberInfo, obj);
             }
             // プリミティブ型は子を持たないので打ち切る
-            else if (type.IsSimpleType())
+            else if (IsSimpleType(type))
             {
                 yield break;
             }
@@ -114,7 +115,6 @@ namespace PLATEAU.Util
             // それ以外の
             else
             {
-
                 var fieldInfos = type.GetFields(flags);
                 foreach (var fieldInfo in fieldInfos)
                 {
@@ -157,6 +157,11 @@ namespace PLATEAU.Util
         {
             return GetPropertyBackingField(propertyInfo?.DeclaringType, propertyInfo);
         }
+
+        /// <summary>
+        /// BackingFieldの名前からプロパティ名を取得する
+        /// </summary>
+        public static readonly Regex BackingFieldNameRegex = new Regex(@"^<(.+)>k__BackingField$");
 
         /// <summary>
         /// 親タイプをすべて取得


### PR DESCRIPTION
﻿## 関連リンク
https://synesthesias.atlassian.net/browse/PLTSDK3-298

## 実装内容
道路構造のシリアライズ処理の高速化
RnDataへ変換するために一度、リフレクションを使いRnModelの全フィールドを再帰的に検索かけていたが、これが異常に重い
Reflectionが重い & Typeごとに検索かけていたので, RnPointの抽出とRnLineStringの抽出で線形に時間が増える。
それを、自動生成したコードを使うようにすることでReflectionを無くす & 対象フィールドを一度に検索することで高速化を行った。
そのため、実際に高速化されたのはシリアライズ前のデータ収集処理のみ。

生成されたコード
  RnModel.generated.cs

コード生成コード
RnDataSerializeCodeGen.cs


## 動作確認
道路構造を生成したうえで、シリアライズ化を行い. 実行時間のテスト & デシリアライズしてデータが壊れていないか軽くチェック.

また、以下の手順で、RnStructureModelのデバッグエディタウィンドウを開き、Option -> Collect Checkを実行すると
Reflectionで取得したデータと、今回の自動生成されたデータの整合性チェックを行うので、エラーログが出ないか確認する.
(Collect Check Successが出たら成功)
整合性チェックのテストコードはRnModelDebugEditorWindow.cs

![image](https://github.com/user-attachments/assets/3944ad57-25a6-4c9b-adc2-75cf6d1b30af)
![image](https://github.com/user-attachments/assets/e93d9089-d223-4a35-a905-3ff4ee7b4aaa)

![image](https://github.com/user-attachments/assets/74a86903-604b-43ef-aba0-3b879d766b84)

## 妥協点
private変数を抽出するために, 各クラスをpartialで定義することに.
本来であればコレクタコード単体で完結するのが理想で、private変数だけReflectionでとってくるのが正しいが, overrideでぱっと書きたかったので妥協。

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## その他
今後, 新しくDataStorageにId化して書き込みたいものがある場合は、コード生成が必要になります。
