### PR TITLE
Fix/road network graph edge

### DIFF
--- a/Editor/RoadNetwork/Graph/RGraphDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Graph/RGraphDebugEditorWindow.cs
@@ -64,9 +64,9 @@ namespace PLATEAU.Editor.RoadNetwork.Graph
                     f.RemoveInnerVertex();
                 }
 
-                if (GUILayout.Button("MergeIsolatedVertex"))
+                if (GUILayout.Button("RemoveIsolatedEdge"))
                 {
-                    f.MergeIsolatedVertex();
+                    f.RemoveIsolatedEdge();
                 }
             }
         }
@@ -197,6 +197,11 @@ namespace PLATEAU.Editor.RoadNetwork.Graph
                 if (GUILayout.Button("Vertex Reduction"))
                 {
                     graph.VertexReduction(mergeCellSize, mergeCellLength, removeMidPointTolerance);
+                }
+
+                if (GUILayout.Button("MergeIsolatedVertices"))
+                {
+                    graph.RemoveIsolatedEdgeFromFace();
                 }
 
                 if (GUILayout.Button("Edge Reduction"))

--- a/Runtime/RoadNetwork/CityObject/SubDividedCityObject.cs
+++ b/Runtime/RoadNetwork/CityObject/SubDividedCityObject.cs
@@ -189,7 +189,9 @@ namespace PLATEAU.RoadNetwork.CityObject
                 foreach (var item in vertexMap)
                     newVertices[item.Value] = item.Key;
 
-                DebugEx.Log($"Vertex size {Vertices.Count} -> {newVertices.Count}, Remove triangle = {removeTriangleNum}");
+                // 削除されたときにログを出す
+                if (removeTriangleNum > 0)
+                    DebugEx.Log($"Vertex size {Vertices.Count} -> {newVertices.Count}, Remove triangle = {removeTriangleNum}");
                 Vertices = newVertices;
             }
 

--- a/Runtime/RoadNetwork/Graph/RGraph.cs
+++ b/Runtime/RoadNetwork/Graph/RGraph.cs
@@ -373,6 +373,9 @@ namespace PLATEAU.RoadNetwork.Graph
         /// <returns></returns>
         public IEnumerable<REdge> GetNeighborEdges()
         {
+            // 同じeが複数回返ることは無いはず
+            // 返る場合V0とV1が同じ辺を共有しているがそれはthis以外は存在無いはずなので
+            // (全く同じ辺は２つは無い前提)
             if (V0 != null)
             {
                 foreach (var e in V0.Edges)

--- a/Runtime/Util/GeoGraph/LineSegment3D.cs
+++ b/Runtime/Util/GeoGraph/LineSegment3D.cs
@@ -111,6 +111,18 @@ namespace PLATEAU.Util.GeoGraph
             distanceFromStart = Mathf.Clamp(distanceFromStart, 0f, self.Magnitude);
             return self.Start + distanceFromStart * self.Direction;
         }
+
+        /// <summary>
+        /// selfとvの距離を返す
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="v"></param>
+        /// <returns></returns>
+        public static float GetDistance(this LineSegment3D self, Vector3 v)
+        {
+            return (v - self.GetNearestPoint(v)).magnitude;
+        }
+
         delegate bool Intersection2D(LineSegment2D a, LineSegment2D b, out Vector3 aInter, out Vector3 bInter, out float at, out float ab);
         private static bool TryIntersectionBy2D(this LineSegment3D self, LineSegment3D other, AxisPlane plane, Intersection2D func, float normalTolerance,
             out Vector3 intersection, out float t1, out float t2)


### PR DESCRIPTION
﻿## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->

## グラフ構造の最適化の際のエンバグ修正
以下のプルリクで行った辺につながっている頂点のマージ処理。
これを行ってしまうと元の形状が崩れる状況があったので修正.
https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/pull/376
![image](https://github.com/user-attachments/assets/d2a8d928-b16a-4be4-a15f-e0e269840053)
頂点をマージするのではなく、あくまでFace(面)から対象の辺を削除するだけにとどめ, 最終的に面にも所属しない辺を削除するように変更


### 動作確認
メッシュコード53393680の
tran_99078f8a-34a3-404a-8a7f-d9115d1d932e
tran_60739cfa-8848-4c1b-921c-f7ea67dd3450
の接続辺が崩れることがあったが以下のように割ときれいな形状を保てるようになれば成功
![image](https://github.com/user-attachments/assets/4fbbd45c-62af-4986-b427-cfad3d6f24aa)

## デバッグ描画で同じ道路の別車線から出るトラックの距離が近すぎるときにテキストで表示するデバッグ機能
道路構造のデバッグ描画クラスのInspectorのIntersection Op -> Show Track -> Draw Spline -> Need Spline Distanceを0より大きい値にすると、距離がそれ以下の場所に赤いラインとテキストで表示する(重いので注意)
![image](https://github.com/user-attachments/assets/872ae8ad-bbc7-42fb-8aff-f9fce5f6e68f)
![image](https://github.com/user-attachments/assets/93395e42-af7f-45bd-bfea-2980c83c0b60)


## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
