### PR TITLE
fix : トラックの流出先選択時の方向ベクトルが逆だったので修正

### DIFF
--- a/Runtime/RoadNetwork/Structure/RnTracksBuilder.cs
+++ b/Runtime/RoadNetwork/Structure/RnTracksBuilder.cs
@@ -105,11 +105,11 @@ namespace PLATEAU.RoadNetwork.Structure
                                     var now = inBoundsLeft2Right[inBoundIndex];
                                     var next = inBoundsLeft2Right[inBoundIndex + 1];
 
-                                    var nowDir = RnIntersection.GetEdgeNormal2D(now);
+                                    var nowDir = -RnIntersection.GetEdgeNormal2D(now);
                                     var nowPos = RnIntersection.GetEdgeCenter2D(now);
                                     var nowAngle = Vector2.Angle(nowDir, toPos - nowPos);
 
-                                    var nextDir = RnIntersection.GetEdgeNormal2D(next);
+                                    var nextDir = -RnIntersection.GetEdgeNormal2D(next);
                                     var nextPos = RnIntersection.GetEdgeCenter2D(next);
                                     var nextAngle = Vector2.Angle(nextDir, toPos - nextPos);
 
@@ -133,7 +133,7 @@ namespace PLATEAU.RoadNetwork.Structure
         public RnTrack MakeTrack(RnIntersection intersection, RnNeighbor from, BuildTrackOption op,
             RnIntersectionEx.EdgeGroup fromEg, ThickCenterLineTables thickCenterLinTables, OutBound outBound)
         {
-            
+
             // 対象外のものは無視
             if (op.IsBuildTarget(intersection, from, outBound.To) == false)
                 return null;
@@ -227,7 +227,7 @@ namespace PLATEAU.RoadNetwork.Structure
 
             from.Border.GetLerpPoint(0.5f, out var fromPos);
             to.Border.GetLerpPoint(0.5f, out var toPos);
-            
+
             // 先に1回のカーブで繋がるトラックをチェック(そっちの方がきれいな曲線になりやすいので)
             var track = TryCreateTwoLineTrack(intersection, fromPos, fromNormal, toPos, toNormal, from, to,
                 edgeTurnType);
@@ -464,7 +464,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 To = to;
             }
         }
-        
+
         /// <summary>
         /// fromEg -> toEgに対する中心線とその各点に置ける幅のテーブル
         /// </summary>


### PR DESCRIPTION
﻿## 関連リンク

## 実装内容
トラックの角度チェックの時の方向ベクトルが逆だったので修正

## 動作確認
53393683に対して道路構造を作成し
tran_7b828f25-8963-40c7-99ed-62136619801fを確認
図のようにほぼ直進の１：１対応していればOK
![image](https://github.com/user-attachments/assets/c738aec5-2290-40b5-937a-bc1955c6c55c)


## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること


## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
