### PR TITLE
道路の線をドラッグして動かす操作において、マウスドラッグ量が小さければキャンセルするようにした。

### DIFF
--- a/Editor/RoadNetwork/EditingSystem/WaySlider.cs
+++ b/Editor/RoadNetwork/EditingSystem/WaySlider.cs
@@ -15,7 +15,10 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystem
         SlideState currentState = SlideState.Default;
         public WayCalcData WaySlideCalcCache { get; private set; }
         private bool isMouseDownHold;
+        private Vector2 mousePosDragStart;
         
+        /// <summary> 誤操作防止のため、線のドラッグ操作で動いたマウスのピクセル数がこの数未満であればドラッグをキャンセルします。 </summary>
+        private const float MinMouseDragPixels = 4f; 
         
 
         /// <summary>
@@ -34,18 +37,20 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystem
 
                 bool isSelectable = !editSceneViewGui.SplineEditorMod.IsEnabled;
                 wayEditorDataList.SetSelectable(isSelectable);
-
-                var isMouseOnViewport = true;
-                if (currentState == SlideState.Default)
+                
+                switch (currentState)
                 {
-                    WaySlideCalcCache = null;
-                    SelectWay(ray, wayEditorDataList, isMouseOnViewport);
-                }
-                else if (currentState == SlideState.SlidingWay)
-                {
-                    var dis = LineUtil.FindClosestPoint(WaySlideCalcCache.ClosestLine, ray, out var closestPointOnWay,
-                        out var closestPointOnRay);
-                    WaySlideCalcCache.Set(dis, closestPointOnWay, closestPointOnRay);
+                    case SlideState.Default:
+                        WaySlideCalcCache = null;
+                        SelectWay(ray, wayEditorDataList);
+                        break;
+                    case SlideState.SlidingWay:
+                        {
+                            var dis = LineUtil.FindClosestPoint(WaySlideCalcCache.ClosestLine, ray, out var closestPointOnWay,
+                                out var closestPointOnRay);
+                            WaySlideCalcCache.Set(dis, closestPointOnWay, closestPointOnRay);
+                            break;
+                        }
                 }
             }
 
@@ -60,30 +65,49 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystem
 
             if (isMouseDownHold)
             {
-                // Wayを押下した瞬間
-                if (currentState == SlideState.Default)
+                switch (currentState)
                 {
-                    if (WaySlideCalcCache != null)
-                    {
-                        currentState = SlideState.SlidingWay;
-                    }
-                }
-                // WayをSlide中
-                else if (currentState == SlideState.SlidingWay)
-                {
-                    if (WaySlideCalcCache != null)
-                    {
-                        slidingWay = OnSlidingWay(sceneView);
-                    }
+                    // Wayを押下した瞬間。DefaultからWaitForDragに遷移。
+                    case SlideState.Default:
+                        if (WaySlideCalcCache != null)
+                        {
+                            currentState = SlideState.WaitForDrag;
+                            mousePosDragStart = mousePos;
+                        }
+                        break;
+                    // 線のドラッグ待ち。
+                    case SlideState.WaitForDrag:
+                        if (Vector2.Distance(mousePos, mousePosDragStart) >= MinMouseDragPixels)
+                        {
+                            currentState = SlideState.SlidingWay;
+                        }
+                        break;
+                    
+                    // WayをSlide中
+                    case SlideState.SlidingWay:
+                        if (WaySlideCalcCache != null)
+                        {
+                            slidingWay = OnSlidingWay(sceneView);
+                        }
+
+                        break;
                 }
             }
-            else
+            else // マウスが押されていないとき
             {
-                // Wayのスライドの終了
-                if (currentState == SlideState.SlidingWay)
+                switch (currentState)
                 {
-                    slidingWay = OnEndSlidingWay(sceneView);
-                    isRoadChanged = true;
+                    // Wayのスライドの終了。SlidingWayからDefaultに遷移。
+                    case SlideState.SlidingWay:
+                        slidingWay = OnEndSlidingWay(sceneView);
+                        isRoadChanged = true;
+                        break;
+                    // 線はドラッグされなかった。Defaultに遷移。
+                    case SlideState.WaitForDrag:
+                        currentState = SlideState.Default;
+                        isRoadChanged = false;
+                        break;
+                        
                 }
             }
 
@@ -148,7 +172,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystem
             return slidingWay;
         }
         
-        private void SelectWay(Ray ray, WayEditorDataList wayEditorDataList, bool isMouseOnViewport)
+        private void SelectWay(Ray ray, WayEditorDataList wayEditorDataList)
         {
             if (wayEditorDataList == null)
             {
@@ -162,11 +186,6 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystem
             {
                 if (wayEditorData.IsSelectable == false)
                     continue;
-
-                if (isMouseOnViewport == false) // シーンビュー上にマウスがあるかチェック
-                {
-                    break;
-                }
 
                 if (wayEditorData.IsSelectable == false)
                 {
@@ -203,6 +222,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystem
         private enum SlideState
         {
             Default, // 通常の状態
+            WaitForDrag, // 誤操作防止のため、マウスドラッグがなければ線を動かさない。ドラッグ待ち状態。ドラッグがなければDefaultに戻り、ドラッグがあればSlidingWayに遷移。
             SlidingWay, // Wayをスライド中
         }
         


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8c3f903f-f222-4257-9af5-5b5db11b7ba5)

上の画面で、線をドラッグせずクリックしただけ、またはドラッグ量がとても小さい場合は線が動かないようにした