### PR TITLE
道路編集で、元ゲームオブジェクトがない状態でも動作するようにした

### DIFF
--- a/Editor/RoadNetwork/AddSystem/RoadNetworkAddSystem.cs
+++ b/Editor/RoadNetwork/AddSystem/RoadNetworkAddSystem.cs
@@ -22,7 +22,8 @@ namespace PLATEAU.Editor.RoadNetwork
             RoadAddSystem.OnRoadAdded = (roadGroup) =>
             {
                 // 道路モデル再生成
-                bool crosswalkExists = PLATEAUReproducedRoad.Find(ReproducedRoadType.Crosswalk, roadGroup.Roads[0].TargetTrans[0].transform, ReproducedRoadDirection.Next);
+                var road = new RoadReproduceSource(roadGroup.Roads[0]);
+                bool crosswalkExists = PLATEAUReproducedRoad.Find(ReproducedRoadType.Crosswalk, road, ReproducedRoadDirection.Next);
                 new RoadReproducer().Generate(new RrTargetRoadBases(Context.RoadNetwork, roadGroup.Roads), crosswalkExists ? CrosswalkFrequency.All : CrosswalkFrequency.Delete);
 
                 // スケルトン更新

--- a/Editor/Window/Main/Tab/RoadGUIParts/RoadEditPanel.cs
+++ b/Editor/Window/Main/Tab/RoadGUIParts/RoadEditPanel.cs
@@ -178,9 +178,8 @@ namespace PLATEAU.Editor.Window.Main.Tab.RoadGuiParts
                 rootVisualElement.Bind(selectedRoad);
                 
                 // 現在の交差点の有無をチェックボックスに反映させます
-                var roads = roadGroupEditorData.Ref.Roads.FirstOrDefault()?.TargetTrans;
-                var roadTrans = roads == null || roads.Count == 0 || roads[0] == null ? null : roads[0].transform;
-                bool doCrosswalkExist = PLATEAUReproducedRoad.Find(ReproducedRoadType.Crosswalk, roadTrans, ReproducedRoadDirection.Next);
+                var roads = new RoadReproduceSource(roadGroupEditorData.Ref.Roads.FirstOrDefault());
+                bool doCrosswalkExist = PLATEAUReproducedRoad.Find(ReproducedRoadType.Crosswalk, roads, ReproducedRoadDirection.Next);
                 placeCrosswalkToggle.value = doCrosswalkExist;
                 prevPlaceCrosswalkToggle = doCrosswalkExist;
             }

--- a/Runtime/RoadAdjust/ICrosswalkPlacementRule.cs
+++ b/Runtime/RoadAdjust/ICrosswalkPlacementRule.cs
@@ -61,11 +61,10 @@ namespace PLATEAU.RoadAdjust
         /// <summary> 削除を伴います </summary>
         public bool ShouldPlace(RnRoad road)
         {
-            var target = road.TargetTrans;
-            var targetTran = target.Count == 0 || target[0] == null ? null : target[0].transform;
+            var target = new RoadReproduceSource(road);
             var crosswalkA =
-                PLATEAUReproducedRoad.Find(ReproducedRoadType.Crosswalk, targetTran, ReproducedRoadDirection.Next);
-            var crosswalkB = PLATEAUReproducedRoad.Find(ReproducedRoadType.Crosswalk, targetTran, ReproducedRoadDirection.Prev);
+                PLATEAUReproducedRoad.Find(ReproducedRoadType.Crosswalk, target, ReproducedRoadDirection.Next);
+            var crosswalkB = PLATEAUReproducedRoad.Find(ReproducedRoadType.Crosswalk, target, ReproducedRoadDirection.Prev);
             if(crosswalkA != null) Object.DestroyImmediate(crosswalkA);
             if(crosswalkB != null) Object.DestroyImmediate(crosswalkB);
             return false;

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/Contour/RnmContourMesh.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/Contour/RnmContourMesh.cs
@@ -13,19 +13,19 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
     internal class RnmContourMesh : IEnumerable<RnmContour>
     {
         [SerializeField] private List<RnmContour> contours = new();
-        [SerializeField] private GameObject[] sourceObjects;
+        [SerializeField] private RoadReproduceSource[] sourceObjects;
 
-        public GameObject[] SourceObjects => sourceObjects;
+        public RoadReproduceSource[] SourceObjects => sourceObjects;
 
-        public RnmContourMesh(IEnumerable<GameObject> sourceObjects) { this.sourceObjects = sourceObjects.ToArray(); }
+        public RnmContourMesh(IEnumerable<RoadReproduceSource> sourceObjects) { this.sourceObjects = sourceObjects.ToArray(); }
 
-        public RnmContourMesh(IEnumerable<GameObject> sourceObjects, IEnumerable<RnmContour> contours)
+        public RnmContourMesh(IEnumerable<RoadReproduceSource> sourceObjects, IEnumerable<RnmContour> contours)
             : this(sourceObjects)
         {
             this.contours = contours.ToList();
         }
 
-        public RnmContourMesh(IEnumerable<GameObject> sourceObjects, RnmContour contour)
+        public RnmContourMesh(IEnumerable<RoadReproduceSource> sourceObjects, RnmContour contour)
             : this(sourceObjects)
         {
             this.contours = new List<RnmContour> { contour };

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmContourGeneratorCarLane.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmContourGeneratorCarLane.cs
@@ -17,7 +17,7 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
             foreach (var road in target.Roads())
             {
                 var contours = GenerateCarLane(road);
-                var targetObjs = road.TargetTrans.Select(cog => cog.gameObject);
+                var targetObjs = new[]{new RoadReproduceSource(road)};
                 var contourMeshes = new RnmContourMeshList
                 (
                     contours.Select(c => new RnmContourMesh(targetObjs, c))

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmContourGeneratorIntersectionCombine.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmContourGeneratorIntersectionCombine.cs
@@ -12,7 +12,7 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
             var cMeshes = new RnmContourMeshList();
             foreach (var inter in target.Intersections())
             {
-                var targetObjs =  inter.TargetTrans.Where(t => t!=null).Select(t => t.gameObject);
+                var targetObjs = new[] { new RoadReproduceSource(inter) };
                 var contours = new RnmContourGeneratorIntersectionSeparate().GenerateContours(inter);
                 var cMesh = new RnmContourMesh(targetObjs, contours);
                 cMeshes.Add(cMesh);

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmContourGeneratorIntersectionSeparate.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmContourGeneratorIntersectionSeparate.cs
@@ -16,7 +16,7 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
             var cMeshes = new RnmContourMeshList();
             foreach (var inter in target.Intersections())
             {
-                var targetObjs = inter.TargetTrans.Select(t => t.gameObject).ToArray();
+                var targetObjs = new[] { new RoadReproduceSource(inter) };
                 foreach (var c in GenerateContours(inter))
                 {
                     cMeshes.Add(new RnmContourMesh(targetObjs, c));

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmContourGeneratorMedianLane.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmContourGeneratorMedianLane.cs
@@ -14,7 +14,7 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
             foreach (var road in target.Roads())
             {
                 var contours = GenerateMedianLane(road);
-                var targetObjs = road.TargetTrans.Select(cog => cog.gameObject);
+                var targetObjs = new[] { new RoadReproduceSource(road) };
                 var contourMeshes = new RnmContourMeshList(
                     contours.Select(c => new RnmContourMesh(targetObjs, c))
                 );

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmContourGeneratorRoadCombine.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmContourGeneratorRoadCombine.cs
@@ -13,7 +13,7 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
             // 道路ごとに輪郭を追加します。
             foreach (var road in target.Roads())
             {
-                var targetObjs = road.TargetTrans.Where(t => t != null).Select(t => t.gameObject);
+                var targetObjs = new []{new RoadReproduceSource(road)};
 
                 var carLanes = new RnmContourGeneratorCarLane().GenerateCarLane(road);
                 var sideWalks = new RnmContourGeneratorSidewalk().GenerateSidewalks(road);

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmContourGeneratorSidewalk.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmContourGeneratorSidewalk.cs
@@ -19,7 +19,7 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
             var contours = new RnmContourMeshList();
             foreach (var road in target.Roads())
             {
-                var targetObjs = road.TargetTrans.Select(t => t.gameObject);
+                var targetObjs = new[] { new RoadReproduceSource(road) };
                 var sideWalkContours = GenerateSidewalks(road);
                 var sideWalkContourMeshes = new RnmContourMeshList(sideWalkContours.Select(s => new RnmContourMesh(targetObjs, s)));
                 contours.AddRange(sideWalkContourMeshes);

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/PLATEAUReproducedRoad.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/PLATEAUReproducedRoad.cs
@@ -1,6 +1,8 @@
 using PLATEAU.RoadNetwork.Structure;
 using System;
+using System.Linq;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
 {
@@ -10,23 +12,23 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
     public class PLATEAUReproducedRoad : MonoBehaviour
     {
         public ReproducedRoadType roadType;
-        public Transform sourceRoad;
+        [FormerlySerializedAs("sourceRoad")] public RoadReproduceSource reproduceSource;
         public ReproducedRoadDirection roadDirection;
 
-        public void Init(ReproducedRoadType roadTypeArg, Transform sourceRoadArg, ReproducedRoadDirection roadDirectionArg)
+        public void Init(ReproducedRoadType roadTypeArg, RoadReproduceSource sourceRoadArg, ReproducedRoadDirection roadDirectionArg)
         {
             roadType = roadTypeArg;
-            sourceRoad = sourceRoadArg;
+            reproduceSource = sourceRoadArg;
             roadDirection = roadDirectionArg;
         }
 
         /// <summary> 値が合致するものをシーンから探します。なければnullを返します。 </summary>
-        public static GameObject Find(ReproducedRoadType roadTypeArg, Transform sourceRoadArg, ReproducedRoadDirection roadDirectionArg)
+        public static GameObject Find(ReproducedRoadType roadTypeArg, RoadReproduceSource sourceRoadArg, ReproducedRoadDirection roadDirectionArg)
         {
             var comps = FindObjectsOfType<PLATEAUReproducedRoad>(false);
             foreach (var c in comps)
             {
-                bool match = c.roadType == roadTypeArg && c.sourceRoad == sourceRoadArg && c.roadDirection == roadDirectionArg;
+                bool match = c.roadType == roadTypeArg && c.reproduceSource.IsMatch(sourceRoadArg) && c.roadDirection == roadDirectionArg;
                 if (match)
                 {
                     return c.gameObject;
@@ -35,6 +37,8 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
 
             return null;
         }
+
+        
     }
 
     /// <summary> 道路の両端に配置される道路標示（横断歩道）において、道路のどちら側に配置されたかを示します。どちらでもない道路標示はNoneとなります。 </summary>
@@ -66,6 +70,61 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+        }
+    }
+    
+    /// <summary>
+    /// 生成された道路について、生成元となった道路オブジェクトを記録するためのクラスです。
+    /// </summary>
+    [Serializable]
+    public class RoadReproduceSource
+    {
+        [SerializeField] private Transform transform;
+        [SerializeField] private long roadNetworkID; // 元となるtransformが削除された場合、代わりにこちらを一致判定に使います。不明な場合は-1です。
+        public Transform Transform => transform;
+        
+
+        public RoadReproduceSource(RnRoadBase road)
+        {
+            // transformの設定
+            if (road != null)
+            {
+                var targetTrans = road.TargetTrans;
+                if (targetTrans != null)
+                {
+                    var targetTran = targetTrans.FirstOrDefault();
+                    if (targetTran != null)
+                    {
+                        transform = targetTran == null ? null : targetTran.transform;
+                    }
+                }
+            }
+            
+            // roadNetworkIDの設定
+            roadNetworkID = road == null ? -1 : (long)road.DebugMyId;
+        }
+
+        public string GetName()
+        {
+            if(transform == null) return "UnknownRoad";
+            return transform.name;
+        }
+
+        public bool IsSourceExists()
+        {
+            return transform != null;
+        }
+
+        public bool IsMatch(RoadReproduceSource other)
+        {
+            if (other == null) return false;
+            // 元の道路が削除された場合は、代わりに道路ネットワーク上のIDで比較
+            if (transform == null && other.transform == null)
+            {
+                return roadNetworkID == other.roadNetworkID && roadNetworkID >= 0;
+            }
+            // 元の道路で比較
+            return transform == other.transform;
         }
     }
 }

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/RnmUV4Copier.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/RnmUV4Copier.cs
@@ -12,7 +12,7 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
     {
         private const float DistanceMinDiff = 0.01f;
 
-        public void Copy(IEnumerable<GameObject> srcObjsArg, GameObject dst)
+        public void Copy(IEnumerable<RoadReproduceSource> srcObjsArg, GameObject dst)
         {
             // 必要なコンポーネントがなければ何もせず終了します。
             var srcObjs = srcObjsArg.ToArray();
@@ -30,7 +30,8 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
             var srcUV4 = new SrcUV4List();
             foreach (var srcObj in srcObjs)
             {
-                var srcMeshFilter = srcObj.GetComponent<MeshFilter>();
+                if (!srcObj.IsSourceExists()) continue;
+                var srcMeshFilter = srcObj.Transform.GetComponent<MeshFilter>();
                 if (srcMeshFilter == null) continue;
                 var srcMesh = srcMeshFilter.sharedMesh;
                 if (srcMesh == null) continue;

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/RoadNetworkToMesh.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/RoadNetworkToMesh.cs
@@ -138,7 +138,7 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
 
                     // 属性情報をコピーします。
                     // FIXME: srcObjsが複数のケースに未対応
-                    var srcAttr = srcObjs[0].GetComponent<PLATEAUCityObjectGroup>();
+                    var srcAttr = srcObjs[0].Transform == null ? null : srcObjs[0].Transform.GetComponent<PLATEAUCityObjectGroup>();
                     if (srcAttr != null)
                     {
                         var dstAttr = dstObj.GetOrAddComponent<PLATEAUCityObjectGroup>();
@@ -148,12 +148,19 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
                     
                     // 他のコンポーネントをコピーします。
                     // FIXME: srcObjsが複数のケースに未対応
-                    new ComponentCopier(
-                        ignoreTypes: new[]
-                        { // 上述で作るコンポーネントは除外します。
-                            typeof(MeshFilter), typeof(MeshRenderer), typeof(PLATEAUCityObjectGroup), typeof(MeshCollider)
-                        })
-                        .Copy(srcObjs[0], dstObj);
+                    if (srcObjs[0].Transform != null)
+                    {
+                        var componentCopier =
+                            new ComponentCopier(
+                                ignoreTypes: new[]
+                                {
+                                    // 上述で作るコンポーネントは除外します。
+                                    typeof(MeshFilter), typeof(MeshRenderer), typeof(PLATEAUCityObjectGroup),
+                                    typeof(MeshCollider)
+                                });
+                        componentCopier.Copy(srcObjs[0].Transform.gameObject, dstObj);
+                    }
+                    
                     
                 }
             }
@@ -170,16 +177,16 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
         /// シーン中にゲームオブジェクトとして配置します。
         /// 同じものがシーンにあれば置き換え、なければ生成します。
         /// </summary>
-        private GameObject GenerateDstGameObj(Transform dstParent, GameObject[] srcObjs)
+        private GameObject GenerateDstGameObj(Transform dstParent, RoadReproduceSource[] srcObjs)
         {
             var srcObj = srcObjs.Length == 0 ? null : srcObjs[0];
-            string srcObjName = srcObj == null ? "RoadUnknown" : $"{srcObj.name}";
+            string srcObjName = srcObj == null? "UnknownRoad" : srcObj.GetName();
             string dstObjName = $"{ReproducedRoadType.RoadMesh.ToGameObjName()}-{srcObjName}";
 
             GameObject dstObj = null;
             if (srcObj != null)
             {
-                dstObj = PLATEAUReproducedRoad.Find(ReproducedRoadType.RoadMesh, srcObj.transform, ReproducedRoadDirection.None);
+                dstObj = PLATEAUReproducedRoad.Find(ReproducedRoadType.RoadMesh, srcObj, ReproducedRoadDirection.None);
             }
 
             if (dstObj == null)
@@ -188,7 +195,7 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
             }
             dstObj.transform.SetParent(dstParent);
             var comp = dstObj.GetOrAddComponent<PLATEAUReproducedRoad>();
-            comp.Init(ReproducedRoadType.RoadMesh, srcObj == null ? null : srcObj.transform, ReproducedRoadDirection.None);
+            comp.Init(ReproducedRoadType.RoadMesh, srcObj == null ? null : srcObj, ReproducedRoadDirection.None);
             return dstObj;
         }
         

--- a/Runtime/RoadAdjust/RrRoadNetworkCopier.cs
+++ b/Runtime/RoadAdjust/RrRoadNetworkCopier.cs
@@ -24,6 +24,7 @@ namespace PLATEAU.RoadAdjust
             foreach (var srcPoint in src.CollectAllLineStrings().SelectMany(ls => ls.Points).Distinct())
             {
                 var dstPoint = new RnPoint(srcPoint.Vertex);
+                dstPoint.DebugMyId = srcPoint.DebugMyId;
                 points.Add(srcPoint, dstPoint);
             }
             
@@ -32,6 +33,7 @@ namespace PLATEAU.RoadAdjust
             foreach (var srcLineStr in src.CollectAllLineStrings())
             {
                 var dstLineStr = new RnLineString(srcLineStr.Points.Select(p => points[p]));
+                dstLineStr.DebugMyId = srcLineStr.DebugMyId;
                 lineStrings.Add(srcLineStr, dstLineStr);
             }
                 
@@ -40,7 +42,9 @@ namespace PLATEAU.RoadAdjust
             foreach (var srcWay in src.CollectAllWays())
             {
                 var lineStr = lineStrings[srcWay.LineString];
-                ways.Add(srcWay, new RnWay(lineStr, srcWay.IsReversed, srcWay.IsReverseNormal));
+                var dstWay = new RnWay(lineStr, srcWay.IsReversed, srcWay.IsReverseNormal);
+                dstWay.DebugMyId = srcWay.DebugMyId;
+                ways.Add(srcWay, dstWay);
             }
             
             // Laneのコピー
@@ -54,6 +58,7 @@ namespace PLATEAU.RoadAdjust
                 
                 var dstLane = new RnLane(dstLeftWay, dstRightWay, dstPrevBorder, dstNextBorder);
                 dstLane.IsReverse = srcLane.IsReverse;
+                dstLane.DebugMyId = srcLane.DebugMyId;
                 
                 lanes.Add(srcLane, dstLane);
             }
@@ -64,6 +69,7 @@ namespace PLATEAU.RoadAdjust
             foreach (var srcRoad in src.Roads)
             {
                 var dstRoad = new RnRoad(srcRoad.TargetTrans);
+                dstRoad.DebugMyId = srcRoad.DebugMyId;
                 foreach (var srcLane in srcRoad.MainLanes)
                 {
                     var dstLane = lanes[srcLane];
@@ -91,6 +97,7 @@ namespace PLATEAU.RoadAdjust
             foreach(var srcInter in src.Intersections)
             {
                 var dstInter = new RnIntersection(srcInter.TargetTrans);
+                dstInter.DebugMyId = srcInter.DebugMyId;
                 dstInter.SetIsEmptyIntersection(srcInter.IsEmptyIntersection);
                 
                 inters.Add(srcInter, dstInter);
@@ -104,6 +111,7 @@ namespace PLATEAU.RoadAdjust
                 var dstEdge = new RnNeighbor();
                 dstEdge.Border = ways[srcEdge.Border];
                 dstEdge.Road = srcEdge.Road == null || !roadBases.ContainsKey(srcEdge.Road) ? null : roadBases[srcEdge.Road];
+                dstEdge.DebugMyId = srcEdge.DebugMyId;
                 neighbors.Add(srcEdge, dstEdge);
             }
 
@@ -115,6 +123,7 @@ namespace PLATEAU.RoadAdjust
                 dstSpline.Copy(srcTrack.Spline);
                 var dstTrack = new RnTrack(ways[srcTrack.FromBorder], ways[srcTrack.ToBorder], dstSpline,
                     srcTrack.TurnType);
+                dstTrack.DebugMyId = srcTrack.DebugMyId;
                 tracks.Add(srcTrack, dstTrack);
             }
 
@@ -161,6 +170,7 @@ namespace PLATEAU.RoadAdjust
                 dstSidewalk.SetStartEdgeWay(dstStartEdge);
                 dstSidewalk.SetEndEdgeWay(dstEndEdge);
                 dstSidewalk.LaneType = laneType;
+                dstSidewalk.DebugMyId = srcSidewalk.DebugMyId;
                 sidewalks.Add(srcSidewalk, dstSidewalk);
             }
             

--- a/Runtime/RoadNetwork/ARnParts.cs
+++ b/Runtime/RoadNetwork/ARnParts.cs
@@ -12,7 +12,17 @@ namespace PLATEAU.RoadNetwork
         [SerializeField]
         private ulong debugId;
 
-        public ulong DebugMyId => debugId;
+        public ulong DebugMyId
+        {
+            get
+            {
+                return debugId;
+            }
+            set
+            {
+                debugId = value;
+            }
+        }
 
         protected ARnPartsBase(ulong id)
         {


### PR DESCRIPTION
- 道路ネットワークを作成
- 元となった道路オブジェクトを削除
- 道路編集

今までは元となったオブジェクトがないと道路編集でエラーとなっていましたが、動作するようにしました。