### PR TITLE
Fix/road network pltsdk3 481

### DIFF
--- a/Runtime/RoadNetwork/Data/RoadNetworkSerializer.cs
+++ b/Runtime/RoadNetwork/Data/RoadNetworkSerializer.cs
@@ -511,6 +511,18 @@ namespace PLATEAU.RoadNetwork.Data
             CreateRnDataStorage(refTable, collectWork.RnRoadBases, ret.PrimitiveDataStorage.RoadBases, ignoreKeyNotFoundWarning);
             CreateRnDataStorage(refTable, collectWork.RnWays, ret.PrimitiveDataStorage.Ways, ignoreKeyNotFoundWarning);
             CreateRnDataStorage(refTable, collectWork.RnSideWalks, ret.PrimitiveDataStorage.SideWalks, ignoreKeyNotFoundWarning);
+
+            void Log<T>(string label, HashSet<T> data)
+            {
+                DebugEx.Log($"{label}[{data.Count}]");
+            }
+            Log(nameof(collectWork.RnRoadBases), collectWork.RnRoadBases);
+            Log(nameof(collectWork.RnSideWalks), collectWork.RnSideWalks);
+            Log(nameof(collectWork.RnLanes), collectWork.RnLanes);
+            Log(nameof(collectWork.RnWays), collectWork.RnWays);
+            Log(nameof(collectWork.RnLineStrings), collectWork.RnLineStrings);
+            Log(nameof(collectWork.RnPoints), collectWork.RnPoints);
+
             refTable.ConvertAll();
             return ret;
         }

--- a/Runtime/RoadNetwork/Factory/RoadNetworkFactory.cs
+++ b/Runtime/RoadNetwork/Factory/RoadNetworkFactory.cs
@@ -585,7 +585,7 @@ namespace PLATEAU.RoadNetwork.Factory
 
                     if (leftLine == null && rightLine == null)
                     {
-                        Debug.LogError($"不正なーレーン構成(Wayの存在しないLane) {cityObjectGroup.name}");
+                        Debug.LogError($"不正なレーン構成(Wayの存在しないLane) {cityObjectGroup.name}");
                         return road;
                     }
 

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -104,7 +104,7 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
                         visibleType &= ~VisibleType.NonSelected;
                     }
 
-                    if (work.IsVisited(self) == false)
+                    if (work.IsVisited(self))
                         return false;
 
                     if (GetTargetGameObjects(self) != null && work.Self.targetTran && GetTargetGameObjects(self).Contains(work.Self.targetTran) == false)
@@ -1054,7 +1054,7 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
                 var ret = Visited.Contains(obj);
                 if (ret == false)
                     Visited.Add(obj);
-                return true;
+                return ret;
             }
 
             public VisibleType GetVisibleType(Object obj, IEnumerable<PLATEAUCityObjectGroup> cityObjects)

--- a/Runtime/RoadNetwork/Structure/RnLineString.cs
+++ b/Runtime/RoadNetwork/Structure/RnLineString.cs
@@ -379,7 +379,7 @@ namespace PLATEAU.RoadNetwork.Structure
 
         private const float DefaultDistanceEpsilon = 0f;
         private const float DefaultDegEpsilon = 0.5f;
-        private const float DefaultMidPointTolerance = 0.3f;
+        private const float DefaultMidPointTolerance = 0.1f;
 
 
         /// <summary>

--- a/Runtime/Util/GeoGraph/GeoGraphEx.cs
+++ b/Runtime/Util/GeoGraph/GeoGraphEx.cs
@@ -306,7 +306,7 @@ namespace PLATEAU.Util.GeoGraph
             {
                 var segment = new LineSegment3D(a, c);
                 var pos = segment.GetNearestPoint(b);
-                return midPointTolerance > 0f && (b - pos).sqrMagnitude <= midPointTolerance * midPointTolerance;
+                return (b - pos).sqrMagnitude <= midPointTolerance * midPointTolerance;
             }
 
             return false;


### PR DESCRIPTION
﻿## 関連リンク
https://synesthesias.atlassian.net/browse/PLTSDK3-481

## 車線幅が0に近い箇所があるレーンが発生するバグ修正.
LineString生成時に, 可能な限りデータサイズを減らすために, v0-v1-v2の頂点があったときに、v0-v2の直線と頂点v1の距離が30cm以下になる場合v1を削除する処理を入れていた。
この閾値が大きかったため, 実際はカーブしてほしい部分が直線になり、その結果隣のレーンが幅０のような状況が発生していた。
![image](https://github.com/user-attachments/assets/fea8e923-2e92-4baa-8707-7ff1416990f2)

閾値を30cm -> 10cmに置き換えることで対応.
RnLineString.DefaultMidPointToleranceを0.3 -> 0.1に変更

### 動作確認
53393599_tran_6697_op.gml
tran_fda39ae6-93b6-4656-b3cc-5dd4a29595a5
を見てい以下のように幅が極端に狭い道路が発生しないかチェックする
![image](https://github.com/user-attachments/assets/fc8f33b8-c34e-42c8-abcb-270e2490547e)

## シリアライズ時に各データの個数をデバッグ表示
上記対応の結果データがどれだけ増えるのか確認するためにシリアライズ時に各データの配列サイズをログ表示
Pointが約6%程増加した
### 動作確認
ログ描画だけなので特に必要なし

## GeoGraph2D.ComputeOutlineのリファクタリング
動作内容は変わらず。
関数内の途中経過をリザルトの型と合わせることで無駄にコピーしていた部分を削除

### 動作確認
内容は変わらずなので、道路構造を生成してみておかしな形状が無ければOK

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
