### PR TITLE
update : CityObject.CityObjectTypeがCOT_Roadの物はRRoadTypeMask.Roadをつけるよ…

### DIFF
--- a/Runtime/RoadNetwork/Util/CityObjectEx.cs
+++ b/Runtime/RoadNetwork/Util/CityObjectEx.cs
@@ -1,4 +1,5 @@
-﻿using PLATEAU.CityInfo;
+﻿using PLATEAU.CityGML;
+using PLATEAU.CityInfo;
 using PLATEAU.RoadNetwork.Graph;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -26,6 +27,11 @@ namespace PLATEAU.RoadNetwork.Util
             // 緊急輸送道路もはじく必要がある
             // LOD3からチェックする
             var ret = RRoadTypeMask.Empty;
+
+            // COT_Roadは強制的に対象にする
+            if (self.CityObjectType == CityObjectType.COT_Road)
+                ret = RRoadTypeMask.Road;
+
             if (self.AttributesMap.TryGetValue("tran:function", out var tranFunction))
             {
                 var str = tranFunction.StringValue;

--- a/Runtime/RoadNetwork/Util/CityObjectEx.cs
+++ b/Runtime/RoadNetwork/Util/CityObjectEx.cs
@@ -30,7 +30,7 @@ namespace PLATEAU.RoadNetwork.Util
 
             // COT_Roadは強制的に対象にする
             if (self.CityObjectType == CityObjectType.COT_Road)
-                ret = RRoadTypeMask.Road;
+                ret |= RRoadTypeMask.Road;
 
             if (self.AttributesMap.TryGetValue("tran:function", out var tranFunction))
             {


### PR DESCRIPTION
…うに( 不明なtranも道路構造の生成対象にするため )

﻿## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->

## 実装内容
CityObject.CityObjectTypeがCOT_RoadのメッシュはRoadとして道路構造変換対象にする。


## 動作確認
以下の場所で道路構造を作成し生成されるか確認する
メッシュコード52354556

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
