### PR TITLE
RnIntersectionのUnLinkでは接続情報のみを削除するように

### DIFF
--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -467,7 +467,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                 }
                 if (GUILayout.Button("DisConnect"))
                 {
-                    work.DelayExec.Add(() => intersection.DisConnect(false));
+                    work.DelayExec.Add(() => intersection.DisConnect(true));
                 }
 
                 if (GUILayout.Button("SeparateContinuousBorder"))

--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -339,7 +339,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                 using var indent = new EditorGUI.IndentLevelScope();
                 if (GUILayout.Button("DisConnect"))
                 {
-                    work.DelayExec.Add(() => road.DisConnect(false));
+                    work.DelayExec.Add(() => road.DisConnect(true));
                 }
                 if (GUILayout.Button("SeparateContinuousBorder"))
                 {

--- a/Runtime/RoadNetwork/Structure/RnIntersection.cs
+++ b/Runtime/RoadNetwork/Structure/RnIntersection.cs
@@ -535,7 +535,12 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <param name="other"></param>
         public override void UnLink(RnRoadBase other)
         {
-            RemoveEdges(n => n.Road == other);
+            // リンクを削除する
+            foreach (var e in Edges)
+            {
+                if (e.Road == other)
+                    e.Road = null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## 実装内容
UnLinkで輪郭情報自体を消していたが, あくまで接続しているRoadBaseの情報のみを削除するように変更

## 動作確認
1. 道路構造を生成
2. PLATEAURnStructureModelのInspectorからRnModel Debug Editorでデバッグ編集エディタを選ぶ
3. シーン上で適当な交差点横の道路を選んでおく -> デバッグエディタでRoads以下に出てくるのでその中のOption -> Disconnectでその道路が削除される
4. 交差点のエッジが消えないか確認
![image](https://github.com/user-attachments/assets/5cb63542-3992-4c8e-81f5-213ac6b83e16)


## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること


## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
