### PR TITLE
fix : RnRoadGroup.MergeRoadsでIntersectionのEdgeが壊れるバグ修正

### DIFF
--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -209,7 +209,8 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
             if (roadBase == null)
                 return;
             ShowBase(roadBase);
-            if (RnEditorUtil.Foldout("TargetTrans", FoldOuts, roadBase))
+            EditorGUILayout.LabelField($"Check : {roadBase.Check()}");
+            if (RnEditorUtil.Foldout("TargetTrans", FoldOuts, (roadBase, "TargetTrans")))
             {
                 using var indent = new EditorGUI.IndentLevelScope();
                 foreach (var tran in roadBase.TargetTrans)
@@ -495,6 +496,9 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                         go.transform.position = pos.Vertex;
                     }
                 }
+
+                if (GUILayout.Button("Align"))
+                    intersection.Align();
             }
 
         }

--- a/Runtime/RoadNetwork/Structure/RnIntersection.cs
+++ b/Runtime/RoadNetwork/Structure/RnIntersection.cs
@@ -395,14 +395,21 @@ namespace PLATEAU.RoadNetwork.Structure
 
 
         /// <summary>
-        /// borderを持つEdgeの隣接道路情報をafterRoadに差し替える
+        /// borderを持つEdgeの隣接道路情報をafterRoadに差し替える.
+        /// 戻り値は差し替えが行われた数
         /// </summary>
         /// <param name="border"></param>
         /// <param name="afterRoad"></param>
-        public void ReplaceEdgeLink(RnWay border, RnRoadBase afterRoad)
+        public int ReplaceEdgeLink(RnWay border, RnRoadBase afterRoad)
         {
+            var ret = 0;
             foreach (var e in edges.Where(e => e.Border.IsSameLineReference(border)))
+            {
                 e.Road = afterRoad;
+                ret++;
+            }
+
+            return ret;
         }
 
 

--- a/Runtime/RoadNetwork/Structure/RnIntersection.cs
+++ b/Runtime/RoadNetwork/Structure/RnIntersection.cs
@@ -402,14 +402,14 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <param name="afterRoad"></param>
         public int ReplaceEdgeLink(RnWay border, RnRoadBase afterRoad)
         {
-            var ret = 0;
+            var replaceCount = 0;
             foreach (var e in edges.Where(e => e.Border.IsSameLineReference(border)))
             {
                 e.Road = afterRoad;
-                ret++;
+                replaceCount++;
             }
 
-            return ret;
+            return replaceCount;
         }
 
 

--- a/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
@@ -1222,8 +1222,8 @@ namespace PLATEAU.RoadNetwork.Structure
                 foreach (var l in dstLanes)
                 {
                     var border = dstRoad.GetBorderWay(l, RnLaneBorderType.Next, RnLaneBorderDir.Left2Right);
-                    var linkedNum = NextIntersection.ReplaceEdgeLink(border, dstRoad);
-                    if (linkedNum == 0)
+                    var replaceCount = NextIntersection.ReplaceEdgeLink(border, dstRoad);
+                    if (replaceCount == 0)
                         DebugEx.LogError($"共通辺情報が更新されませんでした. {NextIntersection.GetTargetTransName()}/{l.GetDebugLabelOrDefault()}");
                 }
             }

--- a/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
@@ -1218,10 +1218,13 @@ namespace PLATEAU.RoadNetwork.Structure
 
             if (NextIntersection != null)
             {
-                NextIntersection.RemoveEdges(r => r.Road == Roads[^1]);
+                // ↑のDisConnectですでに参照情報は消えているので, 再度dstRoadを再設定する
                 foreach (var l in dstLanes)
                 {
-                    NextIntersection.AddEdge(dstRoad, dstRoad.GetBorderWay(l, RnLaneBorderType.Next, RnLaneBorderDir.Left2Right));
+                    var border = dstRoad.GetBorderWay(l, RnLaneBorderType.Next, RnLaneBorderDir.Left2Right);
+                    var linkedNum = NextIntersection.ReplaceEdgeLink(border, dstRoad);
+                    if (linkedNum == 0)
+                        DebugEx.LogError($"共通辺情報が更新されませんでした. {NextIntersection.GetTargetTransName()}/{l.GetDebugLabelOrDefault()}");
                 }
             }
 


### PR DESCRIPTION
﻿## 関連リンク
https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/pull/445
にともなぐバグ。

## 実装内容
RnRoadGroup.MergeRoads(連続した道路を1つの道路にまとめる処理)で, NextIntersectionの参照情報を書き換えるときに, 一度以前の道路に紐づくEdgeを削除してから再追加する処理を行っていたが、その直前のDisConnectでNextIntersectionから接続情報が消えていてうまく動かなくなっていたので修正
( 修正以前でも消えていたのだが、その時はEdge自体が削除されていたのでたまたま動いていた）

## 動作確認
1. 道路構造を作成したときに。"共通辺情報が更新されませんでした~"のようなエラーが出ないか確認。

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること


## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
