### PR TITLE
Feature/road network vertex merge

### DIFF
--- a/Editor/RoadNetwork/Graph/RGraphDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Graph/RGraphDebugEditorWindow.cs
@@ -1,4 +1,5 @@
 ﻿using PLATEAU.RoadNetwork;
+using PLATEAU.RoadNetwork.Factory;
 using PLATEAU.RoadNetwork.Graph;
 using PLATEAU.RoadNetwork.Util;
 using PLATEAU.Util;
@@ -6,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 namespace PLATEAU.Editor.RoadNetwork.Graph
 {
@@ -278,6 +280,17 @@ namespace PLATEAU.Editor.RoadNetwork.Graph
                         faceEdit.Update(this, face);
                     }
                 }
+            }
+
+            if (GUILayout.Button("Copy Check"))
+            {
+                var copy = graph.DeepCopy();
+                Assert.IsTrue(RGraphEx.IsEqual(graph, copy));
+            }
+
+            if (GUILayout.Button("Convert To RoadNetwork Graph"))
+            {
+                target.Graph = graph.ConvertRnModelGraph(RoadNetworkFactory.RoadPackTypes, true);
             }
         }
 

--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -533,7 +533,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
 
                     if (GUILayout.Button("SeparateContinuousBorder"))
                     {
-                        work.DelayExec.Add(() => intersection.SeparateContinuousBorder());
+                        work.DelayExec.Add(intersection.SeparateContinuousBorder);
                     }
 
                     if (GUILayout.Button("Create Inside Objects"))

--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -380,6 +380,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
             public long convertPrevRoadId = -1;
             public long convertNextRoadId = -1;
 
+            public bool devTrackAllowCenterLine = true;
             public HashSet<object> Foldouts { get; } = new HashSet<object>();
 
             // Trackのスクロール位置
@@ -409,9 +410,17 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
             if (RnEditorUtil.Foldout("Tracks", p.Foldouts, ("Tracks", intersection)))
             {
                 using var indent = new EditorGUI.IndentLevelScope();
-                if (GUILayout.Button("Build Track"))
+
+                using (var _ = new EditorGUILayout.HorizontalScope())
                 {
-                    intersection.BuildTracks();
+                    if (GUILayout.Button("Build Track"))
+                    {
+                        intersection.BuildTracks(new BuildTrackOption
+                        {
+                            DevAllowCenterLine = p.devTrackAllowCenterLine
+                        });
+                    }
+                    p.devTrackAllowCenterLine = EditorGUILayout.Toggle("Allow Center Line", p.devTrackAllowCenterLine);
                 }
 
                 using var scope = new EditorGUILayout.ScrollViewScope(p.trackScrollPosition);

--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -12,7 +12,7 @@ using UnityEngine;
 
 namespace PLATEAU.Editor.RoadNetwork.Structure
 {
-    public class RnModelDebugEditorWindow : EditorWindow
+    internal class RnModelDebugEditorWindow : EditorWindow
     {
         public interface IInstanceHelper
         {
@@ -55,6 +55,13 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
         {
             // foreach文で回している最中に実行するとまずいもの(リストの変換等)の遅延実行用
             public List<Action> DelayExec { get; } = new();
+
+            public RnModelDebugEditorWindow Self { get; }
+
+            public Work(RnModelDebugEditorWindow self)
+            {
+                Self = self;
+            }
         }
 
         private void ShowBase(ARnPartsBase parts)
@@ -66,126 +73,127 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
 
         private class LaneEdit
         {
-            [Serializable]
-            public class LaneSplitEdit
+            private class LaneSplitEdit
             {
                 public int splitNum = 2;
             }
-            public LaneSplitEdit splitEdit = new LaneSplitEdit();
 
-            [Serializable]
-            public class LaneWidthEdit
+            private LaneSplitEdit splitEdit = new LaneSplitEdit();
+
+            private class LaneWidthEdit
             {
                 public LaneWayMoveOption moveOption = LaneWayMoveOption.MoveBothWay;
                 public float width = 0f;
                 public float moveWidth = 0f;
             }
 
-            public LaneWidthEdit widthEdit = new LaneWidthEdit();
-            public float rightWayPos = 0f;
-            public float leftWayPos = 0f;
-        }
+            private LaneWidthEdit widthEdit = new LaneWidthEdit();
+            private float rightWayPos = 0f;
+            private float leftWayPos = 0f;
 
-        /// <summary>
-        /// レーンの編集
-        /// </summary>
-        /// <param name="lane"></param>
-        /// <param name="work"></param>
-        public void EditLane(RnLane lane, Work work)
-        {
-            if (lane == null)
-                return;
-            var p = laneEdit;
-            ShowBase(lane);
-            using (new EditorGUI.DisabledScope(false))
+
+            /// <summary>
+            /// レーンの編集
+            /// </summary>
+            /// <param name="lane"></param>
+            /// <param name="work"></param>
+            public void Update(RnLane lane, Work work)
             {
-                void Draw(RnLaneBorderType type)
+                if (lane == null)
+                    return;
+
+                work.Self.ShowBase(lane);
+                using (new EditorGUI.DisabledScope(false))
                 {
-                    RnEditorUtil.Separator();
-                    EditorGUILayout.LabelField($"Border {type}");
-                    using (new EditorGUI.IndentLevelScope())
+                    void Draw(RnLaneBorderType type)
                     {
-                        var border = lane.GetBorder(type);
-                        EditorGUILayout.LabelField($"BorderWay {border?.GetDebugIdLabelOrDefault()}");
-                        EditorGUILayout.LabelField($"Connect Lanes [{lane.GetConnectedLanes(type).Select(l => l.GetDebugLabelOrDefault()).Join2String()}]");
-                        EditorGUILayout.LabelField($"Connect Roads [{lane.GetConnectedRoads(type).Select(l => l.GetDebugLabelOrDefault()).Join2String()}]");
+                        RnEditorUtil.Separator();
+                        EditorGUILayout.LabelField($"Border {type}");
+                        using (new EditorGUI.IndentLevelScope())
+                        {
+                            var border = lane.GetBorder(type);
+                            EditorGUILayout.LabelField($"BorderWay {border?.GetDebugIdLabelOrDefault()}");
+                            EditorGUILayout.LabelField($"Connect Lanes [{lane.GetConnectedLanes(type).Select(l => l.GetDebugLabelOrDefault()).Join2String()}]");
+                            EditorGUILayout.LabelField($"Connect Roads [{lane.GetConnectedRoads(type).Select(l => l.GetDebugLabelOrDefault()).Join2String()}]");
+                        }
+                    }
+
+                    lane.IsReverse = EditorGUILayout.Toggle("IsReverse", lane.IsReverse);
+                    lane.Attributes = (RnLaneAttribute)EditorGUILayout.EnumFlagsField("Attribute", lane.Attributes);
+                    Draw(RnLaneBorderType.Prev);
+                    Draw(RnLaneBorderType.Next);
+
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        EditorGUILayout.LabelField($"Left Way {lane.LeftWay.GetDebugIdLabelOrDefault()}");
+                        EditorGUILayout.LabelField($"Right Way {lane.RightWay.GetDebugIdLabelOrDefault()}");
                     }
                 }
 
-                lane.IsReverse = EditorGUILayout.Toggle("IsReverse", lane.IsReverse);
-                lane.Attributes = (RnLaneAttribute)EditorGUILayout.EnumFlagsField("Attribute", lane.Attributes);
-                Draw(RnLaneBorderType.Prev);
-                Draw(RnLaneBorderType.Next);
-
-                using (new EditorGUILayout.HorizontalScope())
+                // 情報表示
+                if (rightWayPos != 0f && lane.RightWay != null)
                 {
-                    EditorGUILayout.LabelField($"Left Way {lane.LeftWay.GetDebugIdLabelOrDefault()}");
-                    EditorGUILayout.LabelField($"Right Way {lane.RightWay.GetDebugIdLabelOrDefault()}");
+                    rightWayPos = 0f;
                 }
-            }
 
-            // 情報表示
-            if (p.rightWayPos != 0f && lane.RightWay != null)
-            {
-                p.rightWayPos = 0f;
-            }
-
-            if (p.leftWayPos != 0f && lane.LeftWay != null)
-            {
-                p.leftWayPos = 0f;
-            }
-
-            using (var _ = new EditorGUILayout.HorizontalScope())
-            {
-                p.splitEdit.splitNum = EditorGUILayout.IntField("SplitNum", p.splitEdit.splitNum);
-                if (GUILayout.Button("Split"))
+                if (leftWayPos != 0f && lane.LeftWay != null)
                 {
-                    if (lane.Parent is RnRoad road)
+                    leftWayPos = 0f;
+                }
+
+                using (var _ = new EditorGUILayout.HorizontalScope())
+                {
+                    splitEdit.splitNum = EditorGUILayout.IntField("SplitNum", splitEdit.splitNum);
+                    if (GUILayout.Button("Split"))
                     {
-                        var lanes = lane.SplitLane(p.splitEdit.splitNum, true);
-                        foreach (var item in lanes)
+                        if (lane.Parent is RnRoad road)
                         {
-                            var l = item.Key;
-                            var parent = l.Parent as RnRoad;
-                            parent?.ReplaceLane(l, item.Value);
+                            var lanes = lane.SplitLane(splitEdit.splitNum, true);
+                            foreach (var item in lanes)
+                            {
+                                var l = item.Key;
+                                var parent = l.Parent as RnRoad;
+                                parent?.ReplaceLane(l, item.Value);
+                            }
                         }
                     }
                 }
-            }
 
-            using (new EditorGUILayout.HorizontalScope())
-            {
-                using (new EditorGUI.DisabledGroupScope(false))
+                using (new EditorGUILayout.HorizontalScope())
                 {
-                    EditorGUILayout.FloatField("Width", lane.CalcWidth());
+                    using (new EditorGUI.DisabledGroupScope(false))
+                    {
+                        EditorGUILayout.FloatField("Width", lane.CalcWidth());
+                    }
+
+                    widthEdit.width = EditorGUILayout.FloatField("->", widthEdit.width);
+                    widthEdit.moveOption = (LaneWayMoveOption)EditorGUILayout.EnumPopup("MoveOption", widthEdit.moveOption);
+                    if (GUILayout.Button("SetWidth"))
+                    {
+                        lane.TrySetWidth(widthEdit.width, widthEdit.moveOption);
+                    }
+
                 }
 
-                p.widthEdit.width = EditorGUILayout.FloatField("->", p.widthEdit.width);
-                p.widthEdit.moveOption = (LaneWayMoveOption)EditorGUILayout.EnumPopup("MoveOption", p.widthEdit.moveOption);
-                if (GUILayout.Button("SetWidth"))
+                if (widthEdit.moveWidth != 0f)
                 {
-                    lane.TrySetWidth(p.widthEdit.width, p.widthEdit.moveOption);
+                    switch (widthEdit.moveOption)
+                    {
+                        case LaneWayMoveOption.MoveBothWay:
+                            lane.LeftWay?.MoveAlongNormal(widthEdit.moveWidth * 0.5f);
+                            lane.RightWay?.MoveAlongNormal(widthEdit.moveWidth * 0.5f);
+                            break;
+                        case LaneWayMoveOption.MoveLeftWay:
+                            lane.LeftWay?.MoveAlongNormal(widthEdit.moveWidth);
+                            break;
+                        case LaneWayMoveOption.MoveRightWay:
+                            lane.RightWay?.MoveAlongNormal(widthEdit.moveWidth);
+                            break;
+                    }
+                    widthEdit.moveWidth = 0f;
                 }
-
             }
 
-            if (p.widthEdit.moveWidth != 0f)
-            {
-                switch (p.widthEdit.moveOption)
-                {
-                    case LaneWayMoveOption.MoveBothWay:
-                        lane.LeftWay?.MoveAlongNormal(p.widthEdit.moveWidth * 0.5f);
-                        lane.RightWay?.MoveAlongNormal(p.widthEdit.moveWidth * 0.5f);
-                        break;
-                    case LaneWayMoveOption.MoveLeftWay:
-                        lane.LeftWay?.MoveAlongNormal(p.widthEdit.moveWidth);
-                        break;
-                    case LaneWayMoveOption.MoveRightWay:
-                        lane.RightWay?.MoveAlongNormal(p.widthEdit.moveWidth);
-                        break;
-                }
-                p.widthEdit.moveWidth = 0f;
-            }
         }
 
 
@@ -193,15 +201,169 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
         private class RoadEdit
         {
             // 左側レーン数
-            public int leftLaneCount = -1;
+            private int leftLaneCount = -1;
             // 右側レーン数
-            public int rightLaneCount = -1;
+            private int rightLaneCount = -1;
 
             // 中央分離帯幅
-            public float medianWidth = 0;
-            public LaneWayMoveOption medianWidthOption = LaneWayMoveOption.MoveBothWay;
+            private float medianWidth = 0;
+            private LaneWayMoveOption medianWidthOption = LaneWayMoveOption.MoveBothWay;
 
-            public HashSet<object> Foldouts { get; } = new HashSet<object>();
+            private HashSet<object> Foldouts { get; } = new HashSet<object>();
+
+            /// <summary>
+            /// 道路の編集
+            /// </summary>
+            /// <param name="road"></param>
+            /// <param name="work"></param>
+            public void Update(RnRoad road, Work work)
+            {
+                if (road == null)
+                    return;
+
+                work.Self.EditRoadBase(road, work);
+                using (new EditorGUI.DisabledScope(false))
+                {
+                    using var _ = (new EditorGUILayout.HorizontalScope());
+                    EditorGUILayout.LabelField($"Prev: {road.Prev.GetDebugLabelOrDefault()} | Next: {road.Next.GetDebugLabelOrDefault()}");
+                    EditorGUILayout.LabelField($"LaneCount L({road.GetLeftLaneCount()})-R({road.GetRightLaneCount()})");
+                }
+
+                RnEditorUtil.Separator();
+                if (RnEditorUtil.Foldout("Lanes", Foldouts))
+                {
+                    using var indent = new EditorGUI.IndentLevelScope();
+                    foreach (var lane in road.AllLanesWithMedian)
+                    {
+                        var foldout =
+                            RnEditorUtil.Foldout($"{(lane.IsMedianLane ? "[Median]" : "")}{lane.GetDebugLabelOrDefault()}",
+                                Foldouts, lane);
+                        if (!foldout)
+                            continue;
+
+                        RnEditorUtil.Separator();
+                        using var _ = new EditorGUI.IndentLevelScope();
+                        work.Self.laneEdit.Update(lane, work);
+                    }
+                }
+
+                RnEditorUtil.Separator();
+                if (RnEditorUtil.Foldout("SideWalks", Foldouts))
+                {
+                    using var indent = new EditorGUI.IndentLevelScope();
+                    foreach (var sideWalk in road.SideWalks)
+                    {
+                        var foldout = RnEditorUtil.Foldout(sideWalk.GetDebugLabelOrDefault(), Foldouts, sideWalk);
+                        if (!foldout)
+                            continue;
+                        using var _ = new EditorGUI.IndentLevelScope();
+                        RnEditorUtil.Separator();
+                        work.Self.sideWalkEdit.Update(sideWalk, work);
+                    }
+                }
+
+                var roadGroup = road.CreateRoadGroupOrDefault();
+                if (RnEditorUtil.Foldout($"RoadGroupOption [{roadGroup.Roads.Count}] ({roadGroup.Roads.Select(x => x.GetDebugLabelOrDefault()).Join2String()})", Foldouts, ("RoadGroupOption", road)))
+                {
+                    if (GUILayout.Button("Align"))
+                    {
+                        work.DelayExec.Add(() => roadGroup.Align());
+                    }
+
+                    if (GUILayout.Button("Merge"))
+                    {
+                        work.DelayExec.Add(() => roadGroup.MergeRoads());
+                    }
+
+                    EditorGUILayout.LabelField($"LaneCount");
+                    using (new EditorGUI.IndentLevelScope())
+                    {
+                        using (new EditorGUILayout.HorizontalScope())
+                        {
+                            leftLaneCount = EditorGUILayout.IntField($"Left({roadGroup.GetLeftLaneCount()}) ->", leftLaneCount);
+                            if (GUILayout.Button("Change Left"))
+                                work.DelayExec.Add(() => roadGroup.SetLeftLaneCount(leftLaneCount));
+                        }
+                        using (new EditorGUILayout.HorizontalScope())
+                        {
+                            rightLaneCount = EditorGUILayout.IntField($"Right({roadGroup.GetRightLaneCount()}) -> ", rightLaneCount);
+                            if (GUILayout.Button("Change Right"))
+                                work.DelayExec.Add(() => roadGroup.SetRightLaneCount(rightLaneCount));
+                        }
+                        if (GUILayout.Button("Change Both"))
+                        {
+                            roadGroup.SetLaneCount(leftLaneCount, rightLaneCount);
+                        }
+                    }
+
+
+
+                    if (roadGroup.HasMedian())
+                    {
+                        medianWidthOption = (LaneWayMoveOption)EditorGUILayout.EnumPopup("MoveOption", medianWidthOption);
+                        if (GUILayout.Button("RemoveMedian"))
+                        {
+                            roadGroup.RemoveMedian(medianWidthOption);
+                        }
+                    }
+                    else
+                    {
+                        using (new EditorGUILayout.HorizontalScope())
+                        {
+                            medianWidth = EditorGUILayout.FloatField("MedianWidth", medianWidth);
+                            if (GUILayout.Button("CreateMedian"))
+                            {
+                                roadGroup.CreateMedianOrSkip(medianWidth);
+                            }
+                        }
+                    }
+
+                    if (GUILayout.Button("Adjust Border"))
+                    {
+                        work.DelayExec.Add(() => roadGroup.AdjustBorder());
+                    }
+                }
+
+                if (RnEditorUtil.Foldout("Option", Foldouts, ("Option", road)))
+                {
+                    using var indent = new EditorGUI.IndentLevelScope();
+                    if (GUILayout.Button("DisConnect"))
+                    {
+                        work.DelayExec.Add(() => road.DisConnect(true));
+                    }
+                    if (GUILayout.Button("SeparateContinuousBorder"))
+                    {
+                        work.DelayExec.Add(() => road.SeparateContinuousBorder());
+                    }
+                    if (GUILayout.Button("Convert2Intersection"))
+                    {
+                        work.DelayExec.Add(() => road.ParentModel.Convert2Intersection(road));
+                    }
+
+                    if (road.Next is RnIntersection && GUILayout.Button("Merge2NextIntersection"))
+                    {
+                        work.DelayExec.Add(() => road.TryMerge2NeighborIntersection(RnLaneBorderType.Next));
+                    }
+                    if (road.Prev is RnIntersection && GUILayout.Button("Merge2PrevIntersection"))
+                    {
+                        work.DelayExec.Add(() => road.TryMerge2NeighborIntersection(RnLaneBorderType.Prev));
+                    }
+
+                    if (GUILayout.Button("TrySliceRoadHorizontalNearByBorder"))
+                    {
+                        work.DelayExec.Add(() => road.ParentModel.TrySliceRoadHorizontalNearByBorder(
+                            road, new RnModelEx.CalibrateIntersectionBorderOption()
+                            , out var prev
+                            , out var center
+                            , out var next
+                            ));
+                    }
+                    if (GUILayout.Button("CalibrateIntersectionBorder"))
+                    {
+                        work.DelayExec.Add(() => road.ParentModel.CalibrateIntersectionBorder(road, new RnModelEx.CalibrateIntersectionBorderOption()));
+                    }
+                }
+            }
         }
 
         private void EditRoadBase(RnRoadBase roadBase, Work work)
@@ -222,324 +384,197 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
         }
 
         /// <summary>
-        /// 道路の編集
+        /// 交差点編集
         /// </summary>
-        /// <param name="road"></param>
-        /// <param name="work"></param>
-        private void EditRoad(RnRoad road, Work work)
-        {
-            var p = roadEdit;
-            if (road == null)
-                return;
-
-            EditRoadBase(road, work);
-            using (new EditorGUI.DisabledScope(false))
-            {
-                using var _ = (new EditorGUILayout.HorizontalScope());
-                EditorGUILayout.LabelField($"Prev: {road.Prev.GetDebugLabelOrDefault()} | Next: {road.Next.GetDebugLabelOrDefault()}");
-                EditorGUILayout.LabelField($"LaneCount L({road.GetLeftLaneCount()})-R({road.GetRightLaneCount()})");
-            }
-
-            RnEditorUtil.Separator();
-            if (RnEditorUtil.Foldout("Lanes", p.Foldouts))
-            {
-                using var indent = new EditorGUI.IndentLevelScope();
-                foreach (var lane in road.AllLanesWithMedian)
-                {
-                    var foldout =
-                        RnEditorUtil.Foldout($"{(lane.IsMedianLane ? "[Median]" : "")}{lane.GetDebugLabelOrDefault()}",
-                            p.Foldouts, lane);
-                    if (!foldout)
-                        continue;
-
-                    RnEditorUtil.Separator();
-                    using var _ = new EditorGUI.IndentLevelScope();
-                    EditLane(lane, work);
-                }
-            }
-
-            RnEditorUtil.Separator();
-            if (RnEditorUtil.Foldout("SideWalks", p.Foldouts))
-            {
-                using var indent = new EditorGUI.IndentLevelScope();
-                foreach (var sideWalk in road.SideWalks)
-                {
-                    var foldout = RnEditorUtil.Foldout(sideWalk.GetDebugLabelOrDefault(), p.Foldouts, sideWalk);
-                    if (!foldout)
-                        continue;
-                    using var _ = new EditorGUI.IndentLevelScope();
-                    RnEditorUtil.Separator();
-                    EditSideWalk(sideWalk, work);
-                }
-            }
-
-            var roadGroup = road.CreateRoadGroupOrDefault();
-            if (RnEditorUtil.Foldout($"RoadGroupOption [{roadGroup.Roads.Count}] ({roadGroup.Roads.Select(x => x.GetDebugLabelOrDefault()).Join2String()})", p.Foldouts, ("RoadGroupOption", road)))
-            {
-                if (GUILayout.Button("Align"))
-                {
-                    work.DelayExec.Add(() => roadGroup.Align());
-                }
-
-                if (GUILayout.Button("Merge"))
-                {
-                    work.DelayExec.Add(() => roadGroup.MergeRoads());
-                }
-
-                EditorGUILayout.LabelField($"LaneCount");
-                using (new EditorGUI.IndentLevelScope())
-                {
-                    using (new EditorGUILayout.HorizontalScope())
-                    {
-                        p.leftLaneCount = EditorGUILayout.IntField($"Left({roadGroup.GetLeftLaneCount()}) ->", p.leftLaneCount);
-                        if (GUILayout.Button("Change Left"))
-                            work.DelayExec.Add(() => roadGroup.SetLeftLaneCount(p.leftLaneCount));
-                    }
-                    using (new EditorGUILayout.HorizontalScope())
-                    {
-                        p.rightLaneCount = EditorGUILayout.IntField($"Right({roadGroup.GetRightLaneCount()}) -> ", p.rightLaneCount);
-                        if (GUILayout.Button("Change Right"))
-                            work.DelayExec.Add(() => roadGroup.SetRightLaneCount(p.rightLaneCount));
-                    }
-                    if (GUILayout.Button("Change Both"))
-                    {
-                        roadGroup.SetLaneCount(p.leftLaneCount, p.rightLaneCount);
-                    }
-                }
-
-
-
-                if (roadGroup.HasMedian())
-                {
-                    p.medianWidthOption = (LaneWayMoveOption)EditorGUILayout.EnumPopup("MoveOption", p.medianWidthOption);
-                    if (GUILayout.Button("RemoveMedian"))
-                    {
-                        roadGroup.RemoveMedian(p.medianWidthOption);
-                    }
-                }
-                else
-                {
-                    using (new EditorGUILayout.HorizontalScope())
-                    {
-                        p.medianWidth = EditorGUILayout.FloatField("MedianWidth", p.medianWidth);
-                        if (GUILayout.Button("CreateMedian"))
-                        {
-                            roadGroup.CreateMedianOrSkip(p.medianWidth);
-                        }
-                    }
-                }
-
-                if (GUILayout.Button("Adjust Border"))
-                {
-                    work.DelayExec.Add(() => roadGroup.AdjustBorder());
-                }
-            }
-
-            if (RnEditorUtil.Foldout("Option", p.Foldouts, ("Option", road)))
-            {
-                using var indent = new EditorGUI.IndentLevelScope();
-                if (GUILayout.Button("DisConnect"))
-                {
-                    work.DelayExec.Add(() => road.DisConnect(true));
-                }
-                if (GUILayout.Button("SeparateContinuousBorder"))
-                {
-                    work.DelayExec.Add(() => road.SeparateContinuousBorder());
-                }
-                if (GUILayout.Button("Convert2Intersection"))
-                {
-                    work.DelayExec.Add(() => road.ParentModel.Convert2Intersection(road));
-                }
-
-                if (road.Next is RnIntersection && GUILayout.Button("Merge2NextIntersection"))
-                {
-                    work.DelayExec.Add(() => road.TryMerge2NeighborIntersection(RnLaneBorderType.Next));
-                }
-                if (road.Prev is RnIntersection && GUILayout.Button("Merge2PrevIntersection"))
-                {
-                    work.DelayExec.Add(() => road.TryMerge2NeighborIntersection(RnLaneBorderType.Prev));
-                }
-
-                if (GUILayout.Button("TrySliceRoadHorizontalNearByBorder"))
-                {
-                    work.DelayExec.Add(() => road.ParentModel.TrySliceRoadHorizontalNearByBorder(
-                        road, new RnModelEx.CalibrateIntersectionBorderOption()
-                        , out var prev
-                        , out var center
-                        , out var next
-                        ));
-                }
-                if (GUILayout.Button("CalibrateIntersectionBorder"))
-                {
-                    work.DelayExec.Add(() => road.ParentModel.CalibrateIntersectionBorder(road, new RnModelEx.CalibrateIntersectionBorderOption()));
-                }
-            }
-        }
         private class IntersectionEdit
         {
-            public long convertPrevRoadId = -1;
-            public long convertNextRoadId = -1;
+            /// <summary>
+            /// 交差点の辺の編集
+            /// </summary>
+            private class IntersectionEdgeEdit
+            {
+                public void Update(RnIntersectionEdge edge, Work work)
+                {
+                    if (edge == null)
+                        return;
+                    work.Self.ShowBase(edge);
+                }
+            }
 
-            public bool devTrackAllowCenterLine = true;
-            public HashSet<object> Foldouts { get; } = new HashSet<object>();
+            private long convertPrevRoadId = -1;
+            private long convertNextRoadId = -1;
+
+            private bool devTrackAllowCenterLine = true;
+            private HashSet<object> Foldouts { get; } = new HashSet<object>();
+
+            private bool showBorderEdgeOnly = false;
 
             // Trackのスクロール位置
-            public Vector2 trackScrollPosition;
-        }
+            private Vector2 trackScrollPosition;
 
-        public void EditIntersection(RnIntersection intersection, Work work)
-        {
-            if (intersection == null)
-                return;
-            var p = intersectionEdit;
+            private IntersectionEdgeEdit edgeEdit = new();
 
-            EditRoadBase(intersection, work);
-            using (new EditorGUI.DisabledScope(false))
+            public void Update(RnIntersection intersection, Work work)
             {
-                if (RnEditorUtil.Foldout("Borders", p.Foldouts, ("Borders", intersection)))
+                work.Self.EditRoadBase(intersection, work);
+                using (new EditorGUI.DisabledScope(false))
                 {
-                    foreach (var b in intersection.Borders)
+                    if (RnEditorUtil.Foldout("Edges", Foldouts, ("Edges", intersection)))
                     {
-                        using var _ = new EditorGUI.IndentLevelScope();
-                        EditorGUILayout.LabelField($"{b.Road.GetDebugLabelOrDefault()}/{b.Border.GetDebugIdLabelOrDefault()}");
-                    }
-                }
-            }
-
-            RnEditorUtil.Separator();
-            if (RnEditorUtil.Foldout("Tracks", p.Foldouts, ("Tracks", intersection)))
-            {
-                using var indent = new EditorGUI.IndentLevelScope();
-
-                using (var _ = new EditorGUILayout.HorizontalScope())
-                {
-                    if (GUILayout.Button("Build Track"))
-                    {
-                        intersection.BuildTracks(new BuildTrackOption
+                        using var _2 = new EditorGUI.IndentLevelScope();
+                        showBorderEdgeOnly = EditorGUILayout.Toggle("Show Border Only", showBorderEdgeOnly);
+                        foreach (var e in intersection.Edges)
                         {
-                            DevAllowCenterLine = p.devTrackAllowCenterLine
-                        });
-                    }
-                    p.devTrackAllowCenterLine = EditorGUILayout.Toggle("Allow Center Line", p.devTrackAllowCenterLine);
-                }
-
-                using var scope = new EditorGUILayout.ScrollViewScope(p.trackScrollPosition);
-                p.trackScrollPosition = scope.scrollPosition;
-                foreach (var track in intersection.Tracks)
-                {
-                    using (new EditorGUILayout.HorizontalScope())
-                    {
-                        void ShowLabel(string label, RnIntersectionEdge edge)
-                        {
-                            var lane = edge.GetConnectedLane();
-                            EditorGUILayout.LabelField($"{label}:{edge.Border.GetDebugIdLabelOrDefault()}/{edge?.Road?.GetDebugLabelOrDefault()}]/{lane.GetDebugLabelOrDefault()}");
+                            if (e.IsBorder == false && showBorderEdgeOnly)
+                                continue;
+                            var label =
+                                $"{e.GetDebugLabelOrDefault()}{e.Road.GetDebugLabelOrDefault()}/{e.Border.GetDebugIdLabelOrDefault()}-{e.IsMedianBorder}";
+                            if (RnEditorUtil.Foldout(label, Foldouts, e))
+                            {
+                                using var _ = new EditorGUI.IndentLevelScope();
+                                edgeEdit.Update(e, work);
+                            }
                         }
-                        EditorGUILayout.LabelField($"{track.GetDebugLabelOrDefault()}");
-                        ShowLabel("From", intersection.FindEdges(track.FromBorder).FirstOrDefault());
-                        ShowLabel("To", intersection.FindEdges(track.ToBorder).FirstOrDefault());
-                        track.TurnType = (RnTurnType)EditorGUILayout.EnumPopup("TurnType", track.TurnType);
+                    }
+                }
+
+                RnEditorUtil.Separator();
+                if (RnEditorUtil.Foldout("Tracks", Foldouts, ("Tracks", intersection)))
+                {
+                    using var indent = new EditorGUI.IndentLevelScope();
+
+                    using (var _ = new EditorGUILayout.HorizontalScope())
+                    {
                         if (GUILayout.Button("Build Track"))
                         {
-                            work.DelayExec.Add(() =>
+                            intersection.BuildTracks(new BuildTrackOption
                             {
-                                var op = new BuildTrackOption();
-                                op.TargetBorderLineStrings.Add(track.FromBorder.LineString);
-                                op.TargetBorderLineStrings.Add(track.ToBorder.LineString);
-                                intersection.BuildTracks(op);
+                                DevAllowCenterLine = devTrackAllowCenterLine
                             });
+                        }
+                        devTrackAllowCenterLine = EditorGUILayout.Toggle("Allow Center Line", devTrackAllowCenterLine);
+                    }
+
+                    using var scope = new EditorGUILayout.ScrollViewScope(trackScrollPosition);
+                    trackScrollPosition = scope.scrollPosition;
+                    foreach (var track in intersection.Tracks)
+                    {
+                        using (new EditorGUILayout.HorizontalScope())
+                        {
+                            void ShowLabel(string label, RnIntersectionEdge edge)
+                            {
+                                var lane = edge.GetConnectedLane();
+                                EditorGUILayout.LabelField($"{label}:{edge.Border.GetDebugIdLabelOrDefault()}/{edge?.Road?.GetDebugLabelOrDefault()}]/{lane.GetDebugLabelOrDefault()}");
+                            }
+                            EditorGUILayout.LabelField($"{track.GetDebugLabelOrDefault()}");
+                            ShowLabel("From", intersection.FindEdges(track.FromBorder).FirstOrDefault());
+                            ShowLabel("To", intersection.FindEdges(track.ToBorder).FirstOrDefault());
+                            track.TurnType = (RnTurnType)EditorGUILayout.EnumPopup("TurnType", track.TurnType);
+                            if (GUILayout.Button("Build Track"))
+                            {
+                                work.DelayExec.Add(() =>
+                                {
+                                    var op = new BuildTrackOption();
+                                    op.TargetBorderLineStrings.Add(track.FromBorder.LineString);
+                                    op.TargetBorderLineStrings.Add(track.ToBorder.LineString);
+                                    intersection.BuildTracks(op);
+                                });
+                            }
                         }
                     }
                 }
-            }
 
-            RnEditorUtil.Separator();
-            if (RnEditorUtil.Foldout("SideWalks", p.Foldouts, ("SideWalks", intersection)))
-            {
-                using var indent = new EditorGUI.IndentLevelScope();
-                foreach (var sideWalk in intersection.SideWalks)
+                RnEditorUtil.Separator();
+                if (RnEditorUtil.Foldout("SideWalks", Foldouts, ("SideWalks", intersection)))
                 {
-                    var foldout = RnEditorUtil.Foldout(sideWalk.GetDebugLabelOrDefault(), p.Foldouts, sideWalk);
-                    if (!foldout)
-                        continue;
-                    using var _ = new EditorGUI.IndentLevelScope();
-                    RnEditorUtil.Separator();
-                    EditSideWalk(sideWalk, work);
-                }
-            }
-
-            if (RnEditorUtil.Foldout("Option", p.Foldouts, ("Option", intersection)))
-            {
-                using var indent = new EditorGUI.IndentLevelScope();
-                using (new EditorGUILayout.HorizontalScope())
-                {
-                    p.convertPrevRoadId = EditorGUILayout.LongField("PrevRoadId", p.convertPrevRoadId);
-                    p.convertNextRoadId = EditorGUILayout.LongField("NextRoadId", p.convertNextRoadId);
-
-                    var prev = intersection.Borders.Select(n => n.Road)
-                        .FirstOrDefault(r => r != null && r.DebugMyId == (ulong)p.convertPrevRoadId);
-                    var next = intersection.Borders.Select(n => n.Road)
-                        .FirstOrDefault(r => r != null && r.DebugMyId == (ulong)p.convertNextRoadId);
-
-                    if (GUILayout.Button("Convert2Road"))
+                    using var indent = new EditorGUI.IndentLevelScope();
+                    foreach (var sideWalk in intersection.SideWalks)
                     {
-                        work.DelayExec.Add(() => intersection.ParentModel.Convert2Road(intersection, prev, next));
-                    }
-                }
-                if (GUILayout.Button("DisConnect"))
-                {
-                    work.DelayExec.Add(() => intersection.DisConnect(true));
-                }
-
-                if (GUILayout.Button("SeparateContinuousBorder"))
-                {
-                    work.DelayExec.Add(() => intersection.SeparateContinuousBorder());
-                }
-
-                if (GUILayout.Button("Create Inside Objects"))
-                {
-                    List<RnPoint> points = new List<RnPoint>(intersection.Edges.Sum(x => x.Border.Count));
-                    foreach (var pos in intersection.Edges.SelectMany(e => e.Border.Points))
-                    {
-                        if (points.Any() && points.Last() == pos)
+                        var foldout = RnEditorUtil.Foldout(sideWalk.GetDebugLabelOrDefault(), Foldouts, sideWalk);
+                        if (!foldout)
                             continue;
-                        points.Add(pos);
-                    }
-                    if (points.Count > 1 && points[0] == points[^1])
-                        points.RemoveAt(points.Count - 1);
-
-                    var obj = new GameObject("InsideObjects");
-                    foreach (var pos in points)
-                    {
-                        var go = new GameObject("Point");
-                        go.transform.SetParent(obj.transform);
-                        go.transform.position = pos.Vertex;
+                        using var _ = new EditorGUI.IndentLevelScope();
+                        RnEditorUtil.Separator();
+                        work.Self.sideWalkEdit.Update(sideWalk, work);
                     }
                 }
 
-                if (GUILayout.Button("Align"))
-                    intersection.Align();
+                if (RnEditorUtil.Foldout("Option", Foldouts, ("Option", intersection)))
+                {
+                    using var indent = new EditorGUI.IndentLevelScope();
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        convertPrevRoadId = EditorGUILayout.LongField("PrevRoadId", convertPrevRoadId);
+                        convertNextRoadId = EditorGUILayout.LongField("NextRoadId", convertNextRoadId);
+
+                        var prev = intersection.Borders.Select(n => n.Road)
+                            .FirstOrDefault(r => r != null && r.DebugMyId == (ulong)convertPrevRoadId);
+                        var next = intersection.Borders.Select(n => n.Road)
+                            .FirstOrDefault(r => r != null && r.DebugMyId == (ulong)convertNextRoadId);
+
+                        if (GUILayout.Button("Convert2Road"))
+                        {
+                            work.DelayExec.Add(() => intersection.ParentModel.Convert2Road(intersection, prev, next));
+                        }
+                    }
+                    if (GUILayout.Button("DisConnect"))
+                    {
+                        work.DelayExec.Add(() => intersection.DisConnect(true));
+                    }
+
+                    if (GUILayout.Button("SeparateContinuousBorder"))
+                    {
+                        work.DelayExec.Add(() => intersection.SeparateContinuousBorder());
+                    }
+
+                    if (GUILayout.Button("Create Inside Objects"))
+                    {
+                        List<RnPoint> points = new List<RnPoint>(intersection.Edges.Sum(x => x.Border.Count));
+                        foreach (var pos in intersection.Edges.SelectMany(e => e.Border.Points))
+                        {
+                            if (points.Any() && points.Last() == pos)
+                                continue;
+                            points.Add(pos);
+                        }
+                        if (points.Count > 1 && points[0] == points[^1])
+                            points.RemoveAt(points.Count - 1);
+
+                        var obj = new GameObject("InsideObjects");
+                        foreach (var pos in points)
+                        {
+                            var go = new GameObject("Point");
+                            go.transform.SetParent(obj.transform);
+                            go.transform.position = pos.Vertex;
+                        }
+                    }
+
+                    if (GUILayout.Button("Align"))
+                        intersection.Align();
+                }
+
             }
 
         }
+
 
         public class SideWalkEdit
         {
-        }
-
-        public void EditSideWalk(RnSideWalk sideWalk, Work work)
-        {
-            ShowBase(sideWalk);
-            using (new EditorGUI.DisabledScope(false))
+            public void Update(RnSideWalk sideWalk, Work work)
             {
-                EditorGUILayout.LabelField($"ParentRoad:{sideWalk.ParentRoad.GetDebugMyIdOrDefault()}");
-                EditorGUILayout.EnumPopup("LaneType", sideWalk.LaneType);
-            }
+                work.Self.ShowBase(sideWalk);
+                using (new EditorGUI.DisabledScope(false))
+                {
+                    EditorGUILayout.LabelField($"ParentRoad:{sideWalk.ParentRoad.GetDebugMyIdOrDefault()}");
+                    EditorGUILayout.EnumPopup("LaneType", sideWalk.LaneType);
+                }
 
-            EditorGUILayout.LabelField($"Outside Way {sideWalk.OutsideWay.GetDebugIdLabelOrDefault()}");
-            EditorGUILayout.LabelField($"Inside Way {sideWalk.InsideWay.GetDebugIdLabelOrDefault()}");
-            EditorGUILayout.LabelField($"StartEdge Way {sideWalk.StartEdgeWay.GetDebugIdLabelOrDefault()}");
-            EditorGUILayout.LabelField($"EndEdge Way {sideWalk.EndEdgeWay.GetDebugIdLabelOrDefault()}");
+                EditorGUILayout.LabelField($"Outside Way {sideWalk.OutsideWay.GetDebugIdLabelOrDefault()}");
+                EditorGUILayout.LabelField($"Inside Way {sideWalk.InsideWay.GetDebugIdLabelOrDefault()}");
+                EditorGUILayout.LabelField($"StartEdge Way {sideWalk.StartEdgeWay.GetDebugIdLabelOrDefault()}");
+                EditorGUILayout.LabelField($"EndEdge Way {sideWalk.EndEdgeWay.GetDebugIdLabelOrDefault()}");
+            }
         }
+
 
         /// <summary>
         /// 選択/非表示オブジェクトなどの情報を削除する
@@ -570,7 +605,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
             var model = InstanceHelper?.GetModel();
             if (model == null)
                 return;
-            var work = new Work();
+            var work = new Work(this);
             if (GUILayout.Button("Clear Picked Objects"))
             {
                 ClearPickedObjects();
@@ -621,7 +656,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
 
                     RnEditorUtil.Separator();
                     using var _ = new EditorGUI.IndentLevelScope();
-                    EditRoad(r, work);
+                    roadEdit.Update(r, work);
                 }
             }
 
@@ -644,7 +679,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                     using (new EditorGUI.IndentLevelScope())
                     {
                         FoldOuts.Add(i);
-                        EditIntersection(i, work);
+                        intersectionEdit.Update(i, work);
                     }
                 }
             }
@@ -665,7 +700,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                     using (new EditorGUI.IndentLevelScope())
                     {
                         FoldOuts.Add(sw);
-                        EditSideWalk(sw, work);
+                        work.Self.sideWalkEdit.Update(sw, work);
                     }
                 }
             }
@@ -682,7 +717,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                 // 内部でTargetLanesを更新するため、ToListでコピーを取得
                 foreach (var l in pickedLanes)
                 {
-                    EditLane(l, work);
+                    work.Self.laneEdit.Update(l, work);
                 }
             }
 

--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -381,6 +381,15 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                 }
             }
 
+            if (GUILayout.Button("SideWalk Reduction"))
+            {
+                roadBase.MergeConnectedSideWalks();
+            }
+
+            if (GUILayout.Button("Merge Same LineString"))
+            {
+                roadBase.MergeSamePointLineStrings();
+            }
         }
 
         /// <summary>
@@ -786,6 +795,12 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                         Check(work1.TrafficSignalLightControllers, work2.TrafficSignalLightControllers);
                         if (success)
                             DebugEx.Log("Collect Check Success");
+                    }
+
+                    if (GUILayout.Button("Edge Reduction"))
+                    {
+                        foreach (var inter in model.Intersections)
+                            inter.MergeContinuousNonBorderEdge();
                     }
                 }
             }

--- a/Editor/RoadNetwork/Tester/PLATEAURoadNetworkTesterEditor.cs
+++ b/Editor/RoadNetwork/Tester/PLATEAURoadNetworkTesterEditor.cs
@@ -1,3 +1,4 @@
+using PLATEAU.CityInfo;
 using PLATEAU.RoadNetwork.CityObject;
 using PLATEAU.RoadNetwork.Graph;
 using PLATEAU.RoadNetwork.Structure;
@@ -16,6 +17,7 @@ namespace PLATEAU.Editor.RoadNetwork.Tester
     public class PLATEAURoadNetworkTesterEditor : UnityEditor.Editor
     {
         private HashSet<object> foldouts = new();
+
         public override void OnInspectorGUI()
         {
             var obj = target as PLATEAURoadNetworkTester;
@@ -29,6 +31,19 @@ namespace PLATEAU.Editor.RoadNetwork.Tester
             if (GUILayout.Button("Check Lod"))
                 obj.RemoveSameNameCityObjectGroup();
 
+            if (GUILayout.Button("Add SceneSelected CityObject To Test Preset"))
+            {
+                var targets = Selection.gameObjects
+                    .Select(go => go.GetComponent<PLATEAUCityObjectGroup>())
+                    .Where(cog => cog)
+                    .ToList();
+                if (targets.Any())
+                    obj.TargetPresets.Add(new PLATEAURoadNetworkTester.TestTargetPresets
+                    {
+                        targets = targets
+                    });
+            }
+
             if (RnEditorUtil.Foldout("Option", foldouts, "Option"))
             {
                 var cityObjects = obj.GetComponent<PLATEAUSubDividedCityObjectGroup>();
@@ -39,9 +54,16 @@ namespace PLATEAU.Editor.RoadNetwork.Tester
                 if (GUILayout.Button("Create SubDivided City Object"))
                 {
                     cityObjects = obj.gameObject.GetOrAddComponent<PLATEAUSubDividedCityObjectGroup>();
+
+                    var targets = obj.GetTargetCityObjects();
+                    //var subDivideTask = Task.Run(() =>
+                    //{
                     var subDividedRes =
-                        SubDividedCityObjectFactory.ConvertCityObjects(obj.GetTargetCityObjects(), useContourMesh: obj.Factory.UseContourMesh);
+                        SubDividedCityObjectFactory.ConvertCityObjects(targets,
+                            useContourMesh: obj.Factory.UseContourMesh);
                     cityObjects.CityObjects = subDividedRes.ConvertedCityObjects;
+                    //});
+                    //subDivideTask.ContinueWithErrorCatch();
                 }
 
                 if (cityObjects && cityObjects.CityObjects.Any() && GUILayout.Button("Create RGraph"))

--- a/Runtime/RoadNetwork/Graph/Drawer/PLATEAURGraphDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Graph/Drawer/PLATEAURGraphDrawerDebug.cs
@@ -512,9 +512,6 @@ namespace PLATEAU.RoadNetwork.Graph.Drawer
             }
             protected override bool DrawImpl(DrawWork work, RFace face)
             {
-                if (face.Visible == false)
-                    return false;
-
                 var roadTypes = AdjustRoadTypeMask(face.RoadTypes);
                 if (roadTypes.HasAnyFlag(work.Self.showFaceType) == false)
                     return false;

--- a/Runtime/RoadNetwork/Graph/RGraph.cs
+++ b/Runtime/RoadNetwork/Graph/RGraph.cs
@@ -140,22 +140,6 @@ namespace PLATEAU.RoadNetwork.Graph
         /// </summary>
         public IReadOnlyCollection<REdge> Edges => edges;
 
-        public RRoadTypeMask TypeMask
-        {
-            get
-            {
-                var ret = RRoadTypeMask.Empty;
-                foreach (var edge in Edges)
-                {
-                    foreach (var face in edge.Faces)
-                        ret |= face.RoadTypes;
-                }
-
-                return ret;
-            }
-        }
-
-
         public IEnumerable<RFace> GetFaces()
         {
             foreach (var edge in Edges)
@@ -697,11 +681,6 @@ namespace PLATEAU.RoadNetwork.Graph
         //----------------------------------
         // start: フィールド
         //----------------------------------
-        /// <summary>
-        /// 表示非表示
-        /// </summary>
-        [field: SerializeField]
-        public bool Visible { get; set; } = true;
 
         /// <summary>
         /// 対応するCityObjectGroup
@@ -854,7 +833,6 @@ namespace PLATEAU.RoadNetwork.Graph
         /// moveEdge = falseの時は自身のEdgesは移動しない.
         /// </summary>
         /// <param name="dst"></param>
-        /// <param name="moveEdge"></param>
         public bool TryMergeTo(RFace dst)
         {
             if (dst.CityObjectGroup && CityObjectGroup && dst.CityObjectGroup != CityObjectGroup)
@@ -957,11 +935,25 @@ namespace PLATEAU.RoadNetwork.Graph
 
         public HashSet<RFace> Faces { get; } = new HashSet<RFace>();
 
+        /// <summary>
+        /// 道路タイプ
+        /// </summary>
         public RRoadTypeMask RoadTypes
         {
             get
             {
                 return Faces.Aggregate((RRoadTypeMask)0, (a, f) => a | f.RoadTypes);
+            }
+        }
+
+        /// <summary>
+        /// 最大LODレベル
+        /// </summary>
+        public int MaxLodLevel
+        {
+            get
+            {
+                return Faces.Any() ? Faces.Max(f => f.LodLevel) : 0;
             }
         }
 

--- a/Runtime/RoadNetwork/Graph/RGraphEx.cs
+++ b/Runtime/RoadNetwork/Graph/RGraphEx.cs
@@ -241,6 +241,7 @@ namespace PLATEAU.RoadNetwork.Graph
                 if (vertices.Count == afterCount)
                     break;
             }
+
             // a-b-cのような直線状の頂点を削除する
             while (true)
             {
@@ -1160,10 +1161,6 @@ namespace PLATEAU.RoadNetwork.Graph
             if (self.Edges.Count < 3)
                 return false;
 
-            var vertices = self.ComputeOutlineVertices();
-            // 面ができない場合は無視
-            if (vertices.Count < 3)
-                return false;
             var faceGroup = new RFaceGroup(self.Graph, self.CityObjectGroup, new[] { self });
             return TryGroupBySideWalkEdge(faceGroup, out edgeGroups, neighborCityObjectGroupsFilter);
         }

--- a/Runtime/RoadNetwork/Graph/RGraphFactory.cs
+++ b/Runtime/RoadNetwork/Graph/RGraphFactory.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEditor.Graphs;
 using UnityEngine;
 
 namespace PLATEAU.RoadNetwork.Graph
@@ -36,6 +35,9 @@ namespace PLATEAU.RoadNetwork.Graph
         public bool separateFace = true;
 
         public bool modifySideWalkShape = true;
+
+        // 全く同じ辺(CityObjectGroup)を持つFaceを統合する
+        public bool faceReduction = true;
         // --------------------
         // end:フィールド
         // --------------------
@@ -111,6 +113,9 @@ namespace PLATEAU.RoadNetwork.Graph
             {
                 self.ModifySideWalkShape();
             }
+
+            if (faceReduction)
+                self.FaceReduction();
         }
     }
 }

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -468,6 +468,9 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
             // 輪郭線の法線を表示する
             public bool showEdgeNormal = false;
 
+            // 繋がっていないエッジ場所を表示する
+            public bool showDisConnectEdgePoint = false;
+
             protected override IEnumerable<RnDebugDrawerModel<RnModel>.Drawer<DrawWork, RnIntersection>> GetChildDrawers()
             {
                 yield return showTrack;
@@ -498,32 +501,42 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
 
                 for (var i = 0; i < intersection.Edges.Count; i++)
                 {
-                    var n = intersection.Edges[i];
+                    var edge = intersection.Edges[i];
+                    var nextEdge = intersection.Edges[(i + 1) % intersection.Edges.Count];
+
+                    // ループしていない時にエラー表示を行う
+                    if (showDisConnectEdgePoint && edge.Border.GetPoint(-1) != nextEdge.Border.GetPoint(0))
+                    {
+                        DebugEx.DrawArrow(edge.Border.GetPoint(-1).Vertex, nextEdge.Border.GetPoint(0).Vertex, bodyColor: Color.red);
+                    }
 
                     void DrawEdge(IntersectionEdgeDrawer p)
                     {
                         if (p.visible == false)
                             return;
-                        p.Draw(work, n);
+                        p.Draw(work, edge);
                         if (showEdgeIndex)
                         {
-                            var pos = n.Border.GetLerpPoint(0.5f);
+                            var pos = edge.Border.GetLerpPoint(0.5f);
                             work.Self.DrawString($"B[{i}]", pos);
                         }
                     }
 
-                    if (n.IsBorder)
+                    if (edge.IsBorder)
                     {
-                        DrawEdge(n.IsMedianBorder ? showMedianBorderEdge : showBorderEdge);
+                        DrawEdge(edge.IsMedianBorder ? showMedianBorderEdge : showBorderEdge);
                     }
                     else
                     {
                         DrawEdge(showNonBorderEdge);
                     }
+
+
+
                     if (showEdgeNormal)
                     {
-                        var normal = RnIntersection.GetEdgeNormal(n);
-                        var center = RnIntersection.GetEdgeCenter(n);
+                        var normal = RnIntersection.GetEdgeNormal(edge);
+                        var center = RnIntersection.GetEdgeCenter(edge);
                         work.Self.DrawLine(center, center - 50 * normal);
                     }
 

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Splines;
-using static UnityEditor.PlayerSettings;
 
 namespace PLATEAU.RoadNetwork.Structure.Drawer
 {

--- a/Runtime/RoadNetwork/Structure/RnIntersection.cs
+++ b/Runtime/RoadNetwork/Structure/RnIntersection.cs
@@ -391,11 +391,15 @@ namespace PLATEAU.RoadNetwork.Structure
         /// roadとの境界線をbordersに置き換える
         /// </summary>
         /// <param name="road"></param>
+        /// <param name="borderType"></param>
         /// <param name="borders"></param>
         /// <param name="reBuildTrack"></param>
-        public void ReplaceEdges(RnRoad road, List<RnWay> borders, bool reBuildTrack = true)
+        public void ReplaceEdges(RnRoad road, RnLaneBorderType borderType, List<RnWay> borders, bool reBuildTrack = true)
         {
-            RemoveEdges(n => n.Road == road);
+            if (road == null)
+                return;
+            var borderWays = road.GetBorderWays(borderType);
+            RemoveEdges(n => n.Road == road && borderWays.Any(b => b.IsSameLineReference(n.Border)));
             edges.AddRange(borders.Select(b => new RnIntersectionEdge { Road = road, Border = b }));
         }
 

--- a/Runtime/RoadNetwork/Structure/RnLane.cs
+++ b/Runtime/RoadNetwork/Structure/RnLane.cs
@@ -544,6 +544,42 @@ namespace PLATEAU.RoadNetwork.Structure
             return RnLaneBorderDir.Right2Left;
         }
 
+
+        /// <summary>
+        /// 不正値チェック
+        /// </summary>
+        public bool Check()
+        {
+            // 
+            if (LeftWay != null && RightWay != null && PrevBorder != null && NextBorder != null)
+            {
+                if (PrevBorder.Points.Contains(LeftWay.GetPoint(0)) == false)
+                {
+                    DebugEx.LogError($"PrevBorderにLeftWay[0]が含まれていません. {Parent.GetTargetTransName()}");
+                    return false;
+                }
+                if (PrevBorder.Points.Contains(RightWay.GetPoint(0)) == false)
+                {
+                    DebugEx.LogError($"PrevBorderにRightWay[0]が含まれていません. {Parent.GetTargetTransName()}");
+                    return false;
+                }
+
+                if (NextBorder.Points.Contains(LeftWay.GetPoint(-1)) == false)
+                {
+                    DebugEx.LogError($"PrevBorderにLeftWay[^1]が含まれていません. {Parent.GetTargetTransName()}");
+                    return false;
+                }
+
+                if (NextBorder.Points.Contains(RightWay.GetPoint(-1)) == false)
+                {
+                    DebugEx.LogError($"PrevBorderにRightWay[^1]が含まれていません. {Parent.GetTargetTransName()}");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         // ---------------
         // Static Methods
         // ---------------

--- a/Runtime/RoadNetwork/Structure/RnLineString.cs
+++ b/Runtime/RoadNetwork/Structure/RnLineString.cs
@@ -37,7 +37,6 @@ namespace PLATEAU.RoadNetwork.Structure
             Points = new RnPoint[initialSize].ToList();
         }
 
-
         public RnLineString(IEnumerable<RnPoint> points)
         {
             Points = points.ToList();
@@ -406,19 +405,21 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <param name="vertices"></param>
         /// <param name="removeDuplicate"></param>
         /// <returns></returns>
-        public static RnLineString Create(IEnumerable<RnPoint> vertices, bool removeDuplicate)
+        public static RnLineString Create(IEnumerable<RnPoint> vertices, bool removeDuplicate = true)
         {
             if (removeDuplicate)
                 return Create(vertices, DefaultDistanceEpsilon, DefaultDegEpsilon, DefaultMidPointTolerance);
 
-            return new RnLineString(vertices);
+            return Create(vertices, -1, -1, -1);
         }
 
-        public static RnLineString Create(IEnumerable<RnPoint> vertices)
-        {
-            return Create(vertices, true);
-        }
-
+        /// <summary>
+        /// 頂点リストから線分を生成する
+        /// removeDuplicate : 重複する頂点を取り除くかのフラグ
+        /// </summary>
+        /// <param name="vertices"></param>
+        /// <param name="removeDuplicate"></param>
+        /// <returns></returns>
         public static RnLineString Create(IEnumerable<Vector3> vertices, bool removeDuplicate = true)
         {
             return Create(vertices.Select(v => new RnPoint(v)), removeDuplicate);

--- a/Runtime/RoadNetwork/Structure/RnLineString.cs
+++ b/Runtime/RoadNetwork/Structure/RnLineString.cs
@@ -399,11 +399,24 @@ namespace PLATEAU.RoadNetwork.Structure
             return ret;
         }
 
-        public static RnLineString Create(IEnumerable<RnPoint> vertices, bool removeDuplicate = true)
+        /// <summary>
+        /// 頂点リストから線分を生成する
+        /// removeDuplicate : 重複する頂点を取り除くかのフラグ
+        /// </summary>
+        /// <param name="vertices"></param>
+        /// <param name="removeDuplicate"></param>
+        /// <returns></returns>
+        public static RnLineString Create(IEnumerable<RnPoint> vertices, bool removeDuplicate)
         {
             if (removeDuplicate)
                 return Create(vertices, DefaultDistanceEpsilon, DefaultDegEpsilon, DefaultMidPointTolerance);
-            return Create(vertices, -1, -1, -1f);
+
+            return new RnLineString(vertices);
+        }
+
+        public static RnLineString Create(IEnumerable<RnPoint> vertices)
+        {
+            return Create(vertices, true);
         }
 
         public static RnLineString Create(IEnumerable<Vector3> vertices, bool removeDuplicate = true)
@@ -771,12 +784,18 @@ namespace PLATEAU.RoadNetwork.Structure
         public static bool IsSequenceEqual(RnLineString a, RnLineString b, out bool isReverseSequence)
         {
             isReverseSequence = false;
-            if (a.Count != b.Count)
-                return false;
 
             // 参照一致
             if (ReferenceEquals(a, b))
                 return true;
+
+            // どっちかがnullならfalse
+            if (a == null || b == null)
+                return false;
+
+            // 個数が違ったら無視
+            if (a.Count != b.Count)
+                return false;
 
             // 0番目が同じであればそのまま比較
             if (a[0] == b[0])

--- a/Runtime/RoadNetwork/Structure/RnModel.cs
+++ b/Runtime/RoadNetwork/Structure/RnModel.cs
@@ -27,10 +27,13 @@ namespace PLATEAU.RoadNetwork.Structure
         public string FactoryVersion { get; set; } = "";
 
         // #NOTE : Editorが重いのでSerialize対象にしない
+        // 道路リスト
         private List<RnRoad> roads = new List<RnRoad>();
 
+        // 交差点リスト
         private List<RnIntersection> intersections = new List<RnIntersection>();
 
+        // 歩道リスト(道路/交差点に依存しない歩道があるかもしれないので別に持つ)
         private List<RnSideWalk> sideWalks = new List<RnSideWalk>();
 
         //----------------------------------
@@ -1507,6 +1510,5 @@ namespace PLATEAU.RoadNetwork.Structure
             if (prevSideRoad?.Prev is RnIntersection)
                 prevSideRoad.TryMerge2NeighborIntersection(RnLaneBorderType.Prev);
         }
-
     }
 }

--- a/Runtime/RoadNetwork/Structure/RnModel.cs
+++ b/Runtime/RoadNetwork/Structure/RnModel.cs
@@ -500,12 +500,6 @@ namespace PLATEAU.RoadNetwork.Structure
         /// </summary>
         public void SeparateContinuousBorder()
         {
-            foreach (var inter in intersections)
-            {
-                // 連続した境界線を分離する
-                inter.SeparateContinuousBorder();
-            }
-
             foreach (var road in roads)
             {
                 road.SeparateContinuousBorder();

--- a/Runtime/RoadNetwork/Structure/RnRoad.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoad.cs
@@ -1067,7 +1067,7 @@ namespace PLATEAU.RoadNetwork.Structure
             }
 
             // intersectionの輪郭情報を差し替える
-            intersection.ReplaceEdges(self, oppositeBorders, false);
+            intersection.ReplaceEdges(self, borderType, oppositeBorders, false);
 
             // selfの隣接道路に対して, selfに対する接続情報を置き換える
             intersection.ReplaceNeighbor(self, oppositeRoadBase);

--- a/Runtime/RoadNetwork/Structure/RnRoad.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoad.cs
@@ -608,7 +608,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 return false;
             }
 
-            static void Check(RnLane lane)
+            static void SeparateLane(RnLane lane)
             {
                 // 境界線がない場合は何もしない
                 if (lane.PrevBorder == null || lane.NextBorder == null)
@@ -634,7 +634,7 @@ namespace PLATEAU.RoadNetwork.Structure
             }
 
             foreach (var lane in AllLanesWithMedian)
-                Check(lane);
+                SeparateLane(lane);
         }
         /// <summary>
         /// 接続を解除する
@@ -757,10 +757,15 @@ namespace PLATEAU.RoadNetwork.Structure
 
         public override bool Check()
         {
-
             foreach (var BorderType in new[] { RnLaneBorderType.Prev, RnLaneBorderType.Next })
             {
                 if (!this.IsValidBorderAdjacentNeighbor(BorderType, true))
+                    return false;
+            }
+
+            foreach (var lane in AllLanesWithMedian)
+            {
+                if (lane.Check() == false)
                     return false;
             }
 

--- a/Runtime/RoadNetwork/Structure/RnRoad.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoad.cs
@@ -674,6 +674,34 @@ namespace PLATEAU.RoadNetwork.Structure
         }
 
         /// <summary>
+        /// 情報を直接書き換えるので呼び出し注意(相互に隣接情報を維持するように書き換える必要がある)
+        /// borderWayで指定される境界線の隣接道路情報をtoに置き換える
+        /// </summary>
+        /// <param name="borderWay"></param>
+        /// <param name="to"></param>
+        public override void ReplaceNeighbor(RnWay borderWay, RnRoadBase to)
+        {
+            if (borderWay == null)
+                return;
+
+            foreach (var lane in AllLanesWithMedian)
+            {
+                var prev = GetBorderWay(lane, RnLaneBorderType.Prev, RnLaneBorderDir.Left2Right);
+                if (prev != null && prev.IsSameLineReference(borderWay))
+                {
+                    Prev = to;
+                    return;
+                }
+
+                var next = GetBorderWay(lane, RnLaneBorderType.Next, RnLaneBorderDir.Left2Right);
+                if (next != null && next.IsSameLineReference(borderWay))
+                {
+                    Next = to;
+                    return;
+                }
+            }
+        }
+        /// <summary>
         /// デバッグ用) その道路の中心を表す代表頂点を返す
         /// </summary>
         /// <returns></returns>

--- a/Runtime/RoadNetwork/Structure/RnRoadBase.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoadBase.cs
@@ -161,6 +161,14 @@ namespace PLATEAU.RoadNetwork.Structure
         public virtual void ReplaceNeighbor(RnRoadBase from, RnRoadBase to) { }
 
         /// <summary>
+        /// 情報を直接書き換えるので呼び出し注意(相互に隣接情報を維持するように書き換える必要がある)
+        /// borderWayで指定される境界線の隣接道路情報をtoに置き換える
+        /// </summary>
+        /// <param name="borderWay"></param>
+        /// <param name="to"></param>
+        public virtual void ReplaceNeighbor(RnWay borderWay, RnRoadBase to) { }
+
+        /// <summary>
         /// 不正チェック処理を行う
         /// </summary>
         /// <returns></returns>

--- a/Runtime/RoadNetwork/Structure/RnRoadBase.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoadBase.cs
@@ -43,16 +43,18 @@ namespace PLATEAU.RoadNetwork.Structure
         /// sideWalkの親情報も書き換える
         /// </summary>
         /// <param name="sideWalk"></param>
-        public void AddSideWalk(RnSideWalk sideWalk)
+        public bool AddSideWalk(RnSideWalk sideWalk)
         {
             if (sideWalk == null)
-                return;
+                return false;
+            // すでに存在する場合は無視
             if (sideWalks.Contains(sideWalk))
-                return;
+                return false;
             // 以前の親からは削除
             sideWalk?.ParentRoad?.RemoveSideWalk(sideWalk);
             sideWalk.SetParent(this);
             sideWalks.Add(sideWalk);
+            return true;
         }
 
         /// <summary>

--- a/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
@@ -333,13 +333,13 @@ namespace PLATEAU.RoadNetwork.Structure
 
                 if (i == Roads.Count - 1 && NextIntersection != null)
                 {
-                    NextIntersection.ReplaceEdges(Roads[^1], RnLaneBorderType.Next, lanes.Select(l => l.NextBorder).ToList());
+                    NextIntersection.ReplaceEdges(road, RnLaneBorderType.Next, lanes.Select(l => l.NextBorder).ToList());
                     newNextBorders.AddRange(lanes.Select(l => l.NextBorder.LineString));
                 }
 
                 if (i == 0 && PrevIntersection != null)
                 {
-                    PrevIntersection.ReplaceEdges(Roads[0], RnLaneBorderType.Prev, lanes.Select(l => l.PrevBorder).ToList());
+                    PrevIntersection.ReplaceEdges(road, RnLaneBorderType.Prev, lanes.Select(l => l.PrevBorder).ToList());
                     newPrevBorders.AddRange(lanes.Select(l => l.PrevBorder.LineString));
                 }
 
@@ -395,9 +395,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 var lanes = afterLanes[road];
                 if (i == Roads.Count - 1 && NextIntersection != null)
                 {
-                    var oldBorders = road.GetBorderWays(RnLaneBorderType.Next);
                     NextIntersection.ReplaceEdges(road, RnLaneBorderType.Next, lanes.Select(l => l.NextBorder).ToList());
-
                     newNextBorders.AddRange(lanes.Select(l => l.NextBorder.LineString));
                 }
 

--- a/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
@@ -333,13 +333,13 @@ namespace PLATEAU.RoadNetwork.Structure
 
                 if (i == Roads.Count - 1 && NextIntersection != null)
                 {
-                    NextIntersection.ReplaceEdges(Roads[^1], lanes.Select(l => l.NextBorder).ToList());
+                    NextIntersection.ReplaceEdges(Roads[^1], RnLaneBorderType.Next, lanes.Select(l => l.NextBorder).ToList());
                     newNextBorders.AddRange(lanes.Select(l => l.NextBorder.LineString));
                 }
 
                 if (i == 0 && PrevIntersection != null)
                 {
-                    PrevIntersection.ReplaceEdges(Roads[0], lanes.Select(l => l.PrevBorder).ToList());
+                    PrevIntersection.ReplaceEdges(Roads[0], RnLaneBorderType.Prev, lanes.Select(l => l.PrevBorder).ToList());
                     newPrevBorders.AddRange(lanes.Select(l => l.PrevBorder.LineString));
                 }
 
@@ -393,16 +393,17 @@ namespace PLATEAU.RoadNetwork.Structure
             {
                 var road = Roads[i];
                 var lanes = afterLanes[road];
-
-                if (i == Roads.Count - 1)
+                if (i == Roads.Count - 1 && NextIntersection != null)
                 {
-                    NextIntersection?.ReplaceEdges(road, lanes.Select(l => l.NextBorder).ToList());
+                    var oldBorders = road.GetBorderWays(RnLaneBorderType.Next);
+                    NextIntersection.ReplaceEdges(road, RnLaneBorderType.Next, lanes.Select(l => l.NextBorder).ToList());
+
                     newNextBorders.AddRange(lanes.Select(l => l.NextBorder.LineString));
                 }
 
                 if (i == 0 && PrevIntersection != null)
                 {
-                    PrevIntersection?.ReplaceEdges(road, lanes.Select(l => l.PrevBorder).ToList());
+                    PrevIntersection?.ReplaceEdges(road, RnLaneBorderType.Prev, lanes.Select(l => l.PrevBorder).ToList());
                     newPrevBorders.AddRange(lanes.Select(l => l.PrevBorder.LineString));
                 }
 
@@ -1345,7 +1346,7 @@ namespace PLATEAU.RoadNetwork.Structure
                         newBorders.Add(way);
                     }
 
-                    inter.ReplaceEdges(road, newBorders);
+                    inter.ReplaceEdges(road, borderType, newBorders);
                     for (var i = 0; i < lanes.Count; ++i)
                     {
                         var b = newBorders[i];

--- a/Runtime/RoadNetwork/Structure/RnSideWalk.cs
+++ b/Runtime/RoadNetwork/Structure/RnSideWalk.cs
@@ -285,6 +285,7 @@ namespace PLATEAU.RoadNetwork.Structure
 
             static void MergeSideWays(RnSideWalk srcSw, RnSideWalk dstSw)
             {
+                // #TODO : 現状の使い方だと問題ないが, 今後OutsideWay同士, InsideWay同士が繋がっているかの保証が無いのでポイント単位でチェックすべき
                 dstSw.SetSideWays(
                     RnWayEx.CreateMergedWay(srcSw.OutsideWay, dstSw.OutsideWay, false)
                     , RnWayEx.CreateMergedWay(srcSw.InsideWay, dstSw.InsideWay, false)

--- a/Runtime/RoadNetwork/Structure/RnTracksBuilder.cs
+++ b/Runtime/RoadNetwork/Structure/RnTracksBuilder.cs
@@ -240,7 +240,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 return track;
 
             // 中央テーブル作れない時は諦める
-            if (widthTable == null)
+            if (widthTable == null || op.DevAllowCenterLine == false)
                 return null;
 
             List<BezierKnot> knots = new()
@@ -394,6 +394,8 @@ namespace PLATEAU.RoadNetwork.Structure
             Vector3 toPos, Vector3 toNormal, RnIntersectionEdge from, RnIntersectionEdge to, RnTurnType edgeTurnType)
         {
             var offset = 0.01f;
+            var curveOffset = 3;
+
             var fromRay = new Ray(fromPos - fromNormal * offset, -fromNormal);
             var toRay = new Ray(toPos - toNormal * offset, -toNormal);
 
@@ -416,7 +418,6 @@ namespace PLATEAU.RoadNetwork.Structure
             if (IsCollide(cp1, from, to) || IsCollide(cp2, from, to))
                 return null;
 
-            var curveOffset = 3;
             var spline = new Spline();
             spline.Add(new BezierKnot(fromPos), TangentMode.AutoSmooth);
 
@@ -503,6 +504,11 @@ namespace PLATEAU.RoadNetwork.Structure
         /// 空の場合は全てのトラックが対象となる
         /// </summary>
         public HashSet<RnLineString> TargetBorderLineStrings { get; set; } = new();
+
+        /// <summary>
+        /// デバッグ用) 中央パスを用いるかどうか
+        /// </summary>
+        public bool DevAllowCenterLine { get; set; } = false;
 
         /// <summary>
         /// ビルド対象のトラックかどうか

--- a/Runtime/RoadNetwork/Structure/RnWay.cs
+++ b/Runtime/RoadNetwork/Structure/RnWay.cs
@@ -731,10 +731,11 @@ namespace PLATEAU.RoadNetwork.Structure
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
+        /// <param name="removeDuplicate"></param>
         /// <returns></returns>
-        public static RnWay CreateMergedWay(RnWay a, RnWay b)
+        public static RnWay CreateMergedWay(RnWay a, RnWay b, bool removeDuplicate = true)
         {
-            var ls = RnLineString.Create(a.Points.Concat(b.Points));
+            var ls = RnLineString.Create((a?.Points ?? new List<RnPoint>()).Concat(b?.Points ?? new List<RnPoint>()), removeDuplicate);
             return new RnWay(ls);
         }
 
@@ -911,7 +912,7 @@ namespace PLATEAU.RoadNetwork.Structure
         }
 
         /// <summary>
-        /// 2D平面におけるRnway同士の距離を返す
+        /// 2D平面におけるRnWay同士の距離を返す
         /// </summary>
         /// <param name="self"></param>
         /// <param name="other"></param>

--- a/Runtime/RoadNetwork/Structure/RnWay.cs
+++ b/Runtime/RoadNetwork/Structure/RnWay.cs
@@ -101,7 +101,6 @@ namespace PLATEAU.RoadNetwork.Structure
 
             set
             {
-                var points = value.ToArray();
                 LineString = RnLineString.Create(value, false);
             }
         }
@@ -512,7 +511,6 @@ namespace PLATEAU.RoadNetwork.Structure
             if (other == null)
                 return false;
             return LineString == other.LineString;
-
         }
 
         /// <summary>
@@ -990,5 +988,27 @@ namespace PLATEAU.RoadNetwork.Structure
 
             return true;
         }
+
+        /// <summary>
+        /// 内部のポイントが同じかどうか.
+        /// ただし、リストが逆順でもtrueとなる(その時はisReverseSequenceはtrue)
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <param name="isReverseSequence"></param>
+        /// <returns></returns>
+        public static bool IsSequentialEqual(RnWay a, RnWay b, out bool isReverseSequence)
+        {
+            isReverseSequence = false;
+            // 参照一致チェック
+            if (ReferenceEquals(a, b))
+                return true;
+
+            if (a == null || b == null)
+                return false;
+
+            return RnLineStringEx.IsSequenceEqual(a.LineString, b.LineString, out isReverseSequence);
+        }
+
     }
 }

--- a/Runtime/RoadNetwork/Tester/PLATEAUGeoGraphTesterLineString.cs
+++ b/Runtime/RoadNetwork/Tester/PLATEAUGeoGraphTesterLineString.cs
@@ -79,28 +79,28 @@ namespace PLATEAU.RoadNetwork.Tester
             if (p.enable == false)
                 return;
             var vertices = GetVertices().Skip(1).ToList();
-            var indices = GeoGraph2D.SplitByCollinearSegment(vertices, p.allowAngle, p.midPointTolerance, p.checkAdjustSegAngleOnly);
-
-            for (var i = 0; i < indices.Count - 1; i++)
-            {
-                var start = indices[i];
-                var end = indices[i + 1];
-                var color = DebugEx.GetDebugColor(i % 2, 2);
-
-                DebugEx.DrawLines(Enumerable.Range(start, end - start + 1).Select(i => vertices[i].ToVector3(plane)), false, color: color);
-            }
-            var afterVerts = indices.Select(i => vertices[i]).ToList();
-
-            var ind = GeoGraph2D.FindMidEdge(afterVerts, edgeBorderTest.allowAngle, edgeBorderTest.skipAngle);
-
+            var indices = GeoGraph2D.SplitByCollinearSegment(vertices, p.allowAngle, p.midPointTolerance);
+            var simpleVertices = indices.Select(i => vertices[i]).ToList();
             DebugEx.DrawLines(
-                ind.Select(i =>
-                {
-                    return vertices[indices[i]].ToVector3(plane);
-                })
+                simpleVertices.Select(v => v.ToVector3(plane)),
+                false,
+                Color.blue
+            );
 
-                , false, color: Color.green
+            var terminateIndex = GeoGraph2D.FindTerminateEdgeIndex(simpleVertices);
+            if (terminateIndex >= 0 && terminateIndex < indices.Count - 1)
+            {
+                var edgeStartIndex = indices[terminateIndex];
+                var edgeEndIndex = indices[terminateIndex + 1];
+                DebugEx.DrawLines(
+                    Enumerable.Range(edgeStartIndex, edgeEndIndex - edgeStartIndex + 1)
+                        .Select(i => vertices[i].ToVector3(plane))
+
+                    , false, color: Color.green
                 );
+
+            }
+
 
         }
         private void EdgeBorderTest(EdgeBorderTestParam p)

--- a/Runtime/RoadNetwork/Util/CityObjectEx.cs
+++ b/Runtime/RoadNetwork/Util/CityObjectEx.cs
@@ -95,11 +95,6 @@ namespace PLATEAU.RoadNetwork.Util
                 {
                     ret |= RRoadTypeMask.HighWay;
                 }
-
-                if (str.Contains("車線"))
-                {
-                    ret |= RRoadTypeMask.Lane;
-                }
             }
 
             // LOD1

--- a/Runtime/RoadNetwork/Util/DebugDrawerUtil.cs
+++ b/Runtime/RoadNetwork/Util/DebugDrawerUtil.cs
@@ -145,6 +145,9 @@ namespace PLATEAU.RoadNetwork.Util
                         if (drawer.visible == false)
                             return false;
 
+                        if (drawer.IsShowTarget(work, obj) == false)
+                            return false;
+
                         var visibleType = work.visibleType;
                         if (drawer.IsValid(obj))
                         {

--- a/Runtime/RoadNetwork/Util/DebugDrawerUtil.cs
+++ b/Runtime/RoadNetwork/Util/DebugDrawerUtil.cs
@@ -120,14 +120,14 @@ namespace PLATEAU.RoadNetwork.Util
             // 子Drawer
             protected virtual IEnumerable<Drawer<TWork, T>> GetChildDrawers() => Enumerable.Empty<Drawer<TWork, T>>();
 
-            public bool Draw(TWork work, T self, VisibleType visibleType)
+            public bool Draw(TWork work, T self, VisibleType? overrideVisibleType = null)
             {
                 if (visible == false)
                     return false;
 
                 if (self == null)
                     return false;
-
+                var visibleType = overrideVisibleType ?? work.visibleType;
                 var lastVisibleType = visibleType;
                 try
                 {

--- a/Runtime/RoadNetwork/Util/RnEx.cs
+++ b/Runtime/RoadNetwork/Util/RnEx.cs
@@ -279,6 +279,14 @@ namespace PLATEAU.RoadNetwork.Util
             public IEnumerable<Vector2> BorderVertices => BorderVertexIndices.Select(i => SrcVertices[i]);
         }
 
+        /// <summary>
+        /// verticesで表される線分を両端から見ていき, 終端点となる線分を求める
+        /// </summary>
+        /// <param name="vertices"></param>
+        /// <param name="toleranceAngleDegForMidEdge"></param>
+        /// <param name="skipAngleDeg"></param>
+        /// <param name="plane"></param>
+        /// <returns></returns>
         public static FindBorderEdgesResult FindBorderEdges(IReadOnlyList<Vector2> vertices, float toleranceAngleDegForMidEdge = 20f, float skipAngleDeg = 20f, AxisPlane plane = RnDef.Plane)
         {
             var verts = vertices.ToList();

--- a/Runtime/Util/GeoGraph/GeoGraph2d.cs
+++ b/Runtime/Util/GeoGraph/GeoGraph2d.cs
@@ -1572,16 +1572,16 @@ namespace PLATEAU.Util.GeoGraph
         /// verticesで表される線分を, toleranceAngleDeg/midPointToleranceを使った同一直線判定でグルーピングする
         /// 戻り値はグループの始点インデックス
         /// 例) (v0, v1, v2, v3, v4, v5)
-        /// v0~v1, v1~v5が同一直線なら[0, 2]が返る
-        /// v0~v5が同一直線なら[0]が返る
+        /// v0~v1, v1~v5が同一直線なら[0, 2, 5]が返る
+        /// v0~v5が同一直線なら[0, 5]が返る
         /// </summary>
         /// <param name="vertices"></param>
         /// <param name="toleranceAngleDeg"></param>
         /// <param name="midPointTolerance"></param>
-        /// <returns></returns>
+        /// <param name="checkAdjustSegmentAngleOnly"></param>
         public static List<int> SplitByCollinearSegment(IReadOnlyList<Vector2> vertices, float toleranceAngleDeg = 0f, float midPointTolerance = 0f, bool checkAdjustSegmentAngleOnly = false)
         {
-            return GeoGraphEx.SplitByCollinearSegment(vertices, v => (Vector3)v, toleranceAngleDeg, midPointTolerance);
+            return GeoGraphEx.SplitByCollinearSegment(vertices, v => (Vector3)v, toleranceAngleDeg, midPointTolerance, checkAdjustSegmentAngleOnly);
         }
 
         [Serializable]
@@ -1598,6 +1598,8 @@ namespace PLATEAU.Util.GeoGraph
         /// <param name="edgeBaseIndex"></param>
         /// <param name="edges"></param>
         /// <param name="toleranceAngleDegForMidEdge"></param>
+        /// <param name="startIndex"></param>
+        /// <param name="endIndex"></param>
         /// <returns></returns>
         public static List<int> FindCollinearRange(
             int edgeBaseIndex
@@ -1624,7 +1626,7 @@ namespace PLATEAU.Util.GeoGraph
                 // 差が小さいほうから見る
                 var es = Enumerable.Range(0, 2)
                     // すでに停止している or 最後まで進んだら無視
-                    .Where(i => stop[i] == false && startIndex <= infos[i].now + infos[i].d && infos[i].now + infos[i].d <= endIndex)
+                    .Where(i => stop[i] == false && startIndex <= (infos[i].now + infos[i].d) && (infos[i].now + infos[i].d) <= endIndex)
                     .Select(j =>
                     {
                         var info = infos[j];
@@ -1752,6 +1754,112 @@ namespace PLATEAU.Util.GeoGraph
             // edge -> 頂点の配列に戻すために最後のインデックスを足す
             ret.Add(ret.Last() + 1);
             return ret;
+        }
+
+        /// <summary>
+        /// verticesを始点終点から見ていき,中央を表す頂点のインデックスを返す
+        /// </summary>
+        /// <param name="vertices"></param>
+        /// <param name="edgeStartIndex">中央線分の開始インデックス</param>
+        /// <param name="edgeEndIndex">中央線分の終了インデックス</param>
+        /// <param name="toleranceAngleDegForMidEdge">中心線と同一直線と判断する線分の角度[deg]</param>
+        /// <param name="skipAngleDeg">開始線分との角度がこれ以下の間は絶対に中心線にならない</param>
+        /// <param name="op"></param>
+        /// <returns></returns>
+        public static bool TryFindMidEdge2(
+            IReadOnlyList<Vector2> vertices
+            , out int edgeStartIndex
+            , out int edgeEndIndex
+            , float toleranceAngleDegForMidEdge = 20f
+            , float skipAngleDeg = 20f
+            , DebugFindOppositeOption op = null)
+        {
+            edgeStartIndex = edgeEndIndex = -1;
+            var indices = SplitByCollinearSegment(vertices, toleranceAngleDegForMidEdge, skipAngleDeg);
+            var simpleVertices = indices.Select(i => vertices[i]).ToList();
+
+            var terminateIndex = FindTerminateEdgeIndex(simpleVertices);
+            if (terminateIndex < 0 || terminateIndex >= indices.Count - 1)
+                return false;
+
+            edgeStartIndex = indices[terminateIndex];
+            edgeEndIndex = indices[terminateIndex + 1];
+            return true;
+        }
+
+        /// <summary>
+        /// verticesを始点終点から見ていき, 中間地点となる辺を表すインデックスを返す
+        /// vertices[index], vertices[index + 1]が中間地点となる
+        /// </summary>
+        /// <param name="vertices"></param>
+        /// <returns></returns>
+        public static int FindTerminateEdgeIndex(
+            IReadOnlyList<Vector2> vertices)
+        {
+            var edges = GeoGraphEx.GetEdges(vertices, false).Select(v => new LineSegment2D(v.Item1, v.Item2)).ToList();
+
+            // 線分数が3以下の時は中間点そのまま
+            if (edges.Count <= 3)
+            {
+                return edges.Count / 2;
+            }
+
+            var startSideIndex = 0;
+            var endSideIndex = edges.Count - 1;
+
+            // left ~ rightの間にエッジが1つしかなくなるまで続ける
+            //   -> その残った一つがエッジ
+            while (startSideIndex < endSideIndex - 2)
+            {
+                var startSideEdge = edges[startSideIndex];
+                // 0 ~ edge.Countまでつながっているような線なので逆順の線分の方向を逆にする
+                var endSideEdge = edges[endSideIndex].Reversed();
+
+                // 中心線を計算
+                var centerRay = LerpRay(startSideEdge.Ray, endSideEdge.Ray, 0.5f);
+                var startSideNormalDir = new Vector2(startSideEdge.Direction.y, -startSideEdge.Direction.x);
+                var endSideNormalDir = new Vector2(endSideEdge.Direction.y, -endSideEdge.Direction.x);
+                var checkPoints = new[]
+                {
+                    new { ray = new Ray2D(startSideEdge.Start, startSideNormalDir), isStartSide = true },
+                    new { ray = new Ray2D(startSideEdge.End, startSideNormalDir), isStartSide = true },
+                    new { ray = new Ray2D(endSideEdge.Start, endSideNormalDir), isStartSide = false },
+                    new { ray = new Ray2D(endSideEdge.End, endSideNormalDir), isStartSide = false }
+                };
+
+                var maxCenterRayOffset = float.MinValue;
+                bool? maxCenterRayIsStartSide = null;
+                foreach (var cp in checkPoints)
+                {
+                    var hit = LineUtil.LineIntersection(centerRay, cp.ray, out var inter, out var centerRayOffset, out var rayBOffset);
+                    if (hit)
+                        continue;
+
+                    if (maxCenterRayOffset < centerRayOffset || maxCenterRayIsStartSide == null)
+                    {
+                        maxCenterRayOffset = centerRayOffset;
+                        maxCenterRayIsStartSide = cp.isStartSide;
+                    }
+                }
+
+                if (maxCenterRayIsStartSide.HasValue == false)
+                    maxCenterRayIsStartSide = startSideEdge.Magnitude > endSideEdge.Magnitude;
+
+                // より遠いのが左の場合右の線分を進める
+                if (maxCenterRayIsStartSide.Value)
+                {
+                    endSideIndex--;
+                }
+                else
+                {
+                    startSideIndex++;
+                }
+            }
+
+            // ここに来る段階でleftIndex == rightIndex - 2のはず
+            // 開始/終了線分が終端位置にはならないように1, N-2でClampする
+            var edgeBaseIndex = Mathf.Clamp((startSideIndex + endSideIndex) / 2, 1, edges.Count - 2);
+            return edgeBaseIndex;
         }
 
 

--- a/Runtime/Util/GeoGraph/GeoGraphEx.cs
+++ b/Runtime/Util/GeoGraph/GeoGraphEx.cs
@@ -317,6 +317,90 @@ namespace PLATEAU.Util.GeoGraph
         /// </summary>
         /// <param name="vertices"></param>
         /// <param name="cellSize"></param>
+        /// <returns></returns>
+        public static Dictionary<Vector3, Vector3> MergeVertices2(IEnumerable<Vector3> vertices, float cellSize = 0.1f)
+        {
+            var len = cellSize / Mathf.Sqrt(3);
+
+            // HashSetだと全く同じ値が来たときに消えないのでListにする
+            var cells = new SortedDictionary<Vector3Int, List<Vector3>>();
+            var min = Vector3Int.one * int.MaxValue;
+            foreach (var v in vertices)
+            {
+                var c = (v / len).ToVector3Int();
+                cells.GetValueOrCreate(c).Add(v);
+                min = Vector3Int.Min(min, c);
+            }
+
+            // z,y,xの順でソート
+            var keys = cells.Keys.ToList();
+            keys.Sort((a, b) =>
+            {
+                var d = a.z - b.z;
+                if (d != 0)
+                    return d;
+                d = a.y - b.y;
+                if (d != 0)
+                    return d;
+                return a.x - b.x;
+            });
+
+            var del1 = GetNeighborDistance3D(1);
+            //foreach (var k in keys)
+            if (cells.Any())
+            {
+                var k = cells.Keys.First();
+                var queue = new Queue<Vector3Int>();
+                queue.Enqueue(k);
+
+                List<Vector3> subGroup = new();
+
+                while (queue.Any())
+                {
+                    var c = queue.Dequeue();
+                    foreach (var d in del1)
+                    {
+                        var n = c + d;
+                        if (cells.ContainsKey(n) == false)
+                            continue;
+                        if (n == k)
+                            continue;
+
+                        // 指定した距離以上は無視
+                        if ((k - n).Abs().Max() > 1)
+                            continue;
+
+                        // 重複があった場合はそっちに近づけるため単純にAddRangeする
+                        subGroup.AddRange(cells[n]);
+                        cells[k].AddRange(cells[n]);
+
+
+                        cells.Remove(n);
+                        queue.Enqueue(n);
+                    }
+                }
+            }
+
+            var ret = new Dictionary<Vector3, Vector3>();
+
+            foreach (var c in cells)
+            {
+                // #NOTE : 1セルに1つの頂点しかない場合は無視でよい(メモリ最適化)
+                if (c.Value.Count == 1)
+                    continue;
+
+                var center = c.Value.Aggregate(Vector3.zero, (v, a) => v + a) / c.Value.Count;
+                foreach (var v in c.Value)
+                    ret[v] = center;
+            }
+
+            return ret;
+        }
+        /// <summary>
+        /// 点群verticesをセルサイズcellSizeでグリッド化し、頂点をまとめた結果を返す
+        /// </summary>
+        /// <param name="vertices"></param>
+        /// <param name="cellSize"></param>
         /// <param name="mergeCellLength"></param>
         /// <returns></returns>
         public static Dictionary<Vector3, Vector3> MergeVertices(IEnumerable<Vector3> vertices, float cellSize = 0.1f,
@@ -594,7 +678,7 @@ namespace PLATEAU.Util.GeoGraph
         }
 
         /// <summary>
-        /// verticesで表される線分を, toleranceAngleDeg/midPointToleranceを使った同一直線判定でグルーピングする
+        /// verticesで表される線分を, isCollinearを使った同一直線判定でグルーピングする
         /// 戻り値はグループの始点インデックス
         /// 例) (v0, v1, v2, v3, v4, v5)
         /// v0~v1, v1~v5が同一直線なら[0, 2, 5]が返る
@@ -632,6 +716,19 @@ namespace PLATEAU.Util.GeoGraph
             return ret;
         }
 
+        /// <summary>
+        /// verticesで表される線分を, toleranceAngleDeg/midPointToleranceを使った同一直線判定でグルーピングする
+        /// 戻り値はグループの始点インデックス
+        /// 例) (v0, v1, v2, v3, v4, v5)
+        /// v0~v1, v1~v5が同一直線なら[0, 2, 5]が返る
+        /// v0~v5が同一直線なら[0, 5]が返る
+        /// </summary>
+        /// <param name="vertices"></param>
+        /// <param name="toVec3"></param>
+        /// <param name="toleranceAngleDeg"></param>
+        /// <param name="midPointTolerance"></param>
+        /// <param name="checkAdjustSegmentAngleOnly"></param>
+        /// <returns></returns>
         public static List<int> SplitByCollinearSegment<T>(IReadOnlyList<T> vertices, Func<T, Vector3> toVec3,
             float toleranceAngleDeg, float midPointTolerance, bool checkAdjustSegmentAngleOnly = false)
         {


### PR DESCRIPTION
﻿## 関連リンク
https://synesthesias.atlassian.net/browse/PLTSDK3-471

## 実装内容

### 交差点に同じ道路のPrev/Nextがどっちもつながっているような形状の時に垂直化がうまく動かないバグ酒精
図のように, 道路のPrev/Nextが同じ交差点につながっている場合に, 垂直化処理がスキップされるようになっていた。
![image](https://github.com/user-attachments/assets/1da84110-b623-41b6-9203-0b20c9232164)

RnRoad.TryGetVerticalSliceSegmentで中央線から5[m]下げて切断する際に, 境界線がキツイ斜めだと, 中央から5[m]だと足りない状況が発生するため, 隣接する歩道の端点から中央線に射影した点も考慮するようにしていたが、Prev/Next両方つながっていると, それが反対側の歩道の境界線も見てしまうのが原因。
境界線から, 10[m]以内の歩道のみを対象にすることで解決
![image](https://github.com/user-attachments/assets/34cac1a1-952f-49b5-892e-f6380ebbf354)


#### 動作確認
メッシュコード53393660
tran_f956a9ec-2165-4eb5-9201-b3eeea4149ab
で確認。
問題なく垂直化の処理が行われているかチェックする.


### 交差点の垂直化処理の修正 & 交差点で境界線が連続しているときに間に微小なエッジを入れる処理を削除

停止線を手前に下げる処理の時に、元のLineStringを編集するようにしていた結果, 交差点で境界線が連続しているときに形状が壊れる状況が発生した為, 最初に交差点に対して連続した境界線の間に微小なエッジを入れる処理を入れていたが, 
53393672_tran_6697_op.gml
tran_644ed99e-f534-4175-9ba0-c559b31c9881付近
のような3つの交差点がつながっているような場所で処理が暴発し, 交差点の輪郭が閉路にならないバグがあった。
![image](https://github.com/user-attachments/assets/c448d80b-fce3-41e6-a579-7d9a32ffe6a2)

垂直化処理を, 元のLineStringを直接編集するのではなく
1. 別のエッジとして登録
2. 連続したエッジを一つのエッジに統合
3. 同じRoadBase内で全く同じRnPointのリストを持つLineStringを共通化
という手順に置き換えることで解決。

#### 動作確認
任意の地形で, 道路構造を生成し, ログに以下のエラーが出てこないかチェックする
* ループしていない輪郭の交差点 
* 削除しようとしたエッジが交差点に存在しませんでした. 

歩道も含めて形状が壊れていないか確認する。

### デバッグ用機能追加
デバッグ機能なので特に動作確認必要ないです
* トラック生成時にボロノイ図を使ったパスは生成しない機能追加
  * そのトラックがどの情報から作られたのか確認するため
* シーン上で選んだCityObjectGroupをまとめてテスト用プリセットに追加する機能追加
  * 確認効率向上の為
* RGraphにDeepCopyとCheck関数追加
* ループしていない交差点のデバッグ描画の強調処理
  

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
