### PR TITLE
RnLane.IsReverse -> IsReversedに変更対応

### DIFF
--- a/Editor/RoadNetwork/AddSystem/Intersection/IntersectionAddSystem.cs
+++ b/Editor/RoadNetwork/AddSystem/Intersection/IntersectionAddSystem.cs
@@ -287,7 +287,7 @@ namespace PLATEAU.Editor.RoadNetwork.AddSystem
 
             // 隣接道路がある輪郭を追加
             var isRoadPrev = data.IsRoadPrev;
-            foreach (var roadBorder in data.Road.MainLanes.Select(l => isRoadPrev ^ l.IsReverse ? l.PrevBorder : l.NextBorder))
+            foreach (var roadBorder in data.Road.MainLanes.Select(l => isRoadPrev ^ l.IsReversed ? l.PrevBorder : l.NextBorder))
             {
                 intersection.AddEdge(data.Road, roadBorder);
             }
@@ -468,7 +468,7 @@ namespace PLATEAU.Editor.RoadNetwork.AddSystem
         private RnPoint GetEdgePoint(RnRoad road, bool useLeftWay, bool isRoadPrev)
         {
             var way = useLeftWay ? road.GetLeftWayOfLanes() : road.GetRightWayOfLanes();
-            return isRoadPrev ^ (useLeftWay ? road.MainLanes[0].IsReverse : road.MainLanes.Last().IsReverse) ^ way.IsReversed
+            return isRoadPrev ^ (useLeftWay ? road.MainLanes[0].IsReversed : road.MainLanes.Last().IsReversed) ^ way.IsReversed
                 ? way.LineString.Points.First()
                 : way.LineString.Points.Last();
         }

--- a/Editor/RoadNetwork/AddSystem/Road/RnRoadAddSystem.cs
+++ b/Editor/RoadNetwork/AddSystem/Road/RnRoadAddSystem.cs
@@ -161,17 +161,17 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                 {
                     if (!scannedLineStrings.Contains(way.LineString))
                     {
-                        ExtendPointsAlongSpline(way.LineString.Points, spline, edgeInfo.Edge.isPrev ^ lane.IsReverse ^ way.IsReversed);
+                        ExtendPointsAlongSpline(way.LineString.Points, spline, edgeInfo.Edge.isPrev ^ lane.IsReversed ^ way.IsReversed);
                         scannedLineStrings.Add(way.LineString);
                     }
                 }
 
                 var newEdge = new RnWay(new RnLineString(new List<RnPoint> {
-                    edgeInfo.Edge.isPrev ^ lane.IsReverse ^ lane.RightWay.IsReversed ? lane.RightWay.LineString.Points.First() : lane.RightWay.LineString.Points.Last(),
-                    edgeInfo.Edge.isPrev ^ lane.IsReverse ^ lane.LeftWay.IsReversed ? lane.LeftWay.LineString.Points.First() : lane.LeftWay.LineString.Points.Last()
+                    edgeInfo.Edge.isPrev ^ lane.IsReversed ^ lane.RightWay.IsReversed ? lane.RightWay.LineString.Points.First() : lane.RightWay.LineString.Points.Last(),
+                    edgeInfo.Edge.isPrev ^ lane.IsReversed ^ lane.LeftWay.IsReversed ? lane.LeftWay.LineString.Points.First() : lane.LeftWay.LineString.Points.Last()
                 }));
                 // ボーダー再構築
-                if (edgeInfo.Edge.isPrev ^ lane.IsReverse)
+                if (edgeInfo.Edge.isPrev ^ lane.IsReversed)
                     lane.SetBorder(RnLaneBorderType.Prev, newEdge);
                 else
                     lane.SetBorder(RnLaneBorderType.Next, newEdge);
@@ -198,7 +198,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                 {
                     var laneWay = road.GetLeftWayOfLanes();
                     orderedLanePoints = new List<RnPoint>(laneWay.LineString.Points);
-                    if (isPrev ^ road.MainLanes[0].IsReverse ^ laneWay.IsReversed)
+                    if (isPrev ^ road.MainLanes[0].IsReversed ^ laneWay.IsReversed)
                         orderedLanePoints.Reverse();
                     var index = orderedLanePoints.FindIndex(p => p.Vertex == (sideWalkEdgeInfo.IsInsidePrev ? sideWalkEdgeInfo.Edge.LineString.Points.First().Vertex : sideWalkEdgeInfo.Edge.LineString.Points.Last().Vertex));
                     for (; index < orderedLanePoints.Count; index++)
@@ -213,7 +213,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                 {
                     var laneWay = road.GetRightWayOfLanes();
                     orderedLanePoints = new List<RnPoint>(laneWay.LineString.Points);
-                    if (isPrev ^ road.MainLanes[road.MainLanes.Count - 1].IsReverse ^ laneWay.IsReversed)
+                    if (isPrev ^ road.MainLanes[road.MainLanes.Count - 1].IsReversed ^ laneWay.IsReversed)
                         orderedLanePoints.Reverse();
                     var index = orderedLanePoints.FindIndex(p => p.Vertex == (sideWalkEdgeInfo.IsInsidePrev ? sideWalkEdgeInfo.Edge.LineString.Points.First().Vertex : sideWalkEdgeInfo.Edge.LineString.Points.Last().Vertex));
                     for (; index < orderedLanePoints.Count; index++)

--- a/Editor/RoadNetwork/AddSystem/Road/RnRoadEdgeMaker.cs
+++ b/Editor/RoadNetwork/AddSystem/Road/RnRoadEdgeMaker.cs
@@ -45,12 +45,12 @@ namespace PLATEAU.RoadNetwork.AddSystem
             Vector3 oldEdgeCenter;
             {
                 var way = road.GetLeftWayOfLanes();
-                oldEdgeCenter = extensibleEdge.isPrev ^ road.MainLanes[0].IsReverse ^ way.IsReversed ? way.LineString.Points.First().Vertex : way.LineString.Points.Last().Vertex;
+                oldEdgeCenter = extensibleEdge.isPrev ^ road.MainLanes[0].IsReversed ^ way.IsReversed ? way.LineString.Points.First().Vertex : way.LineString.Points.Last().Vertex;
             }
             Vector3 oldEdgeDirection;
             {
                 var way = road.GetRightWayOfLanes();
-                var secondPoint = extensibleEdge.isPrev ^ road.MainLanes.Last().IsReverse ^ way.IsReversed ? way.LineString.Points.First().Vertex : way.LineString.Points.Last().Vertex;
+                var secondPoint = extensibleEdge.isPrev ^ road.MainLanes.Last().IsReversed ^ way.IsReversed ? way.LineString.Points.First().Vertex : way.LineString.Points.Last().Vertex;
                 oldEdgeDirection = secondPoint - oldEdgeCenter;
             }
 
@@ -73,7 +73,7 @@ namespace PLATEAU.RoadNetwork.AddSystem
 
                 foreach (var way in new[] { lane.LeftWay, lane.RightWay })
                 {
-                    var isPrev = extensibleEdge.isPrev ^ way.IsReversed ^ lane.IsReverse;
+                    var isPrev = extensibleEdge.isPrev ^ way.IsReversed ^ lane.IsReversed;
 
                     RnPoint oldEdgePoint = null;
                     RnPoint newEdgePoint = null;
@@ -145,7 +145,7 @@ namespace PLATEAU.RoadNetwork.AddSystem
         {
             var sideWalks = road.SideWalks;
             var leftWay = road.GetLeftWayOfLanes();
-            var edgePoint = (isPrev ^ road.MainLanes.First().IsReverse ^ leftWay.IsReversed) ? leftWay.LineString.Points.First() : leftWay.LineString.Points.Last();
+            var edgePoint = (isPrev ^ road.MainLanes.First().IsReversed ^ leftWay.IsReversed) ? leftWay.LineString.Points.First() : leftWay.LineString.Points.Last();
             var sideWalk = sideWalks.FirstOrDefault(sideWalk => sideWalk.InsideWay.Contains(edgePoint));
 
             if (sideWalk == null)
@@ -179,7 +179,7 @@ namespace PLATEAU.RoadNetwork.AddSystem
         {
             var sideWalks = road.SideWalks;
             var rightWay = road.GetRightWayOfLanes();
-            var edgePoint = (isPrev ^ road.MainLanes.Last().IsReverse ^ rightWay.IsReversed) ? rightWay.LineString.Points.First() : rightWay.LineString.Points.Last();
+            var edgePoint = (isPrev ^ road.MainLanes.Last().IsReversed ^ rightWay.IsReversed) ? rightWay.LineString.Points.First() : rightWay.LineString.Points.Last();
             var sideWalk = sideWalks.FirstOrDefault(sideWalk => sideWalk.InsideWay.Contains(edgePoint));
 
             if (sideWalk == null)

--- a/Editor/RoadNetwork/AddSystem/Road/RnSideWalkEdgeAligner.cs
+++ b/Editor/RoadNetwork/AddSystem/Road/RnSideWalkEdgeAligner.cs
@@ -85,12 +85,12 @@ namespace PLATEAU.RoadNetwork.AddSystem
                     if (isLeftSideWalk)
                     {
                         laneEdgeWay = road.GetLeftWayOfLanes();
-                        edgePoint = (isRoadPrev ^ road.MainLanes.First().IsReverse ^ laneEdgeWay.IsReversed) ? laneEdgeWay.LineString.Points.First() : laneEdgeWay.LineString.Points.Last();
+                        edgePoint = (isRoadPrev ^ road.MainLanes.First().IsReversed ^ laneEdgeWay.IsReversed) ? laneEdgeWay.LineString.Points.First() : laneEdgeWay.LineString.Points.Last();
                     }
                     else
                     {
                         laneEdgeWay = road.GetRightWayOfLanes();
-                        edgePoint = (isRoadPrev ^ road.MainLanes.Last().IsReverse ^ laneEdgeWay.IsReversed) ? laneEdgeWay.LineString.Points.First() : laneEdgeWay.LineString.Points.Last();
+                        edgePoint = (isRoadPrev ^ road.MainLanes.Last().IsReversed ^ laneEdgeWay.IsReversed) ? laneEdgeWay.LineString.Points.First() : laneEdgeWay.LineString.Points.Last();
                     }
 
                     // Laneの頂点と共有化

--- a/Editor/RoadNetwork/EditingSystemSubMod/LaneLineGizmoGenerator.cs
+++ b/Editor/RoadNetwork/EditingSystemSubMod/LaneLineGizmoGenerator.cs
@@ -27,7 +27,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
         private static readonly Color intersectionOutlineColor = new Color(0.2f, 0.6f, 0.5f);
         private static readonly Color intersectionBorderColor = new Color(0.2f, 1f, 0.2f);
         private static readonly Color mainLaneCenterWayColor = Color.cyan + new Color(0, -0.4f, -0.4f, 0);
-        
+
         /// <summary>
         /// 編集用のギズモの線を生成します。
         /// </summary>
@@ -38,14 +38,14 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
             RnWay slideDummyWay)
         {
             List<ILaneLineDrawer> lineDrawers = new();
-            
+
             if (linkGroupEditorData.TryGetCache("linkGroup", out IEnumerable<RoadGroupEditorData> eConn) == false)
             {
                 Assert.IsTrue(false);
                 return lineDrawers;
             }
-            
-            
+
+
             // RoadGroupが選択されている
             if (selectingElement is EditorData<RnRoadGroup> roadGroupEditorData)
             {
@@ -76,10 +76,10 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                     {
                         way.Add(p);
                     }
-                        
+
                     var parent = wayEditorData.ParentLane;
                     Debug.Assert(parent != null);
-                    if (parent.IsReverse == false)
+                    if (parent.IsReversed == false)
                     {
                         lineDrawers.Add(new LaneLineDrawerSolid(way, leftSideWayColor, LaneLineDrawMethod.Gizmos));
                     }
@@ -151,7 +151,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                 }
 
             }
-            
+
             // 選択中の線を追加
             if (highLightWay != null)
             {
@@ -160,7 +160,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                     lineDrawers.Add(new LaneLineDrawerSolid(selectingWayData.Ref.ToList(), selectingWayColor, LaneLineDrawMethod.Gizmos));
                 }
             }
-            
+
             if (slideDummyWay != null)
             {
                 lineDrawers.Add(new LaneLineDrawerSolid(slideDummyWay.ToList(), slideDummyWayColor, LaneLineDrawMethod.Gizmos));
@@ -175,7 +175,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                         lineDrawers.Add(new LaneLineDrawerSolid(neighbor.Border.ToList(), intersectionBorderColor, LaneLineDrawMethod.Gizmos));
                 }
             }
-            
+
             if (intersectionEditorData != null)
             {
                 foreach (var edge in intersectionEditorData.Ref.Edges.Where(e => e.Road == null))

--- a/Editor/RoadNetwork/EditingSystemSubMod/SplineSystems/RnSplineEditor.cs
+++ b/Editor/RoadNetwork/EditingSystemSubMod/SplineSystems/RnSplineEditor.cs
@@ -91,13 +91,13 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
             Vector3 startLeftPoint, startRightPoint, endLeftPoint, endRightPoint;
             {
                 var way = road.GetLeftWayOfLanes();
-                startLeftPoint = road.MainLanes[0].IsReverse ^ way.IsReversed ? way.LineString.Points.Last().Vertex : way.LineString.Points.First().Vertex;
-                endLeftPoint = road.MainLanes[0].IsReverse ^ way.IsReversed ? way.LineString.Points.First().Vertex : way.LineString.Points.Last().Vertex;
+                startLeftPoint = road.MainLanes[0].IsReversed ^ way.IsReversed ? way.LineString.Points.Last().Vertex : way.LineString.Points.First().Vertex;
+                endLeftPoint = road.MainLanes[0].IsReversed ^ way.IsReversed ? way.LineString.Points.First().Vertex : way.LineString.Points.Last().Vertex;
             }
             {
                 var way = road.GetRightWayOfLanes();
-                startRightPoint = road.MainLanes.Last().IsReverse ^ way.IsReversed ? way.LineString.Points.Last().Vertex : way.LineString.Points.First().Vertex;
-                endRightPoint = road.MainLanes.Last().IsReverse ^ way.IsReversed ? way.LineString.Points.First().Vertex : way.LineString.Points.Last().Vertex;
+                startRightPoint = road.MainLanes.Last().IsReversed ^ way.IsReversed ? way.LineString.Points.Last().Vertex : way.LineString.Points.First().Vertex;
+                endRightPoint = road.MainLanes.Last().IsReversed ^ way.IsReversed ? way.LineString.Points.First().Vertex : way.LineString.Points.Last().Vertex;
             }
 
             core.SetStartPointConstraint(true,
@@ -187,7 +187,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                 var leftStartPoint = leftLane.LeftWay.Points.First();
                 var leftEndPoint = leftLane.LeftWay.Points.Last();
 
-                var nextLeftWayPoints = ConvertSplineToLineStringPointsNonSmooth(spline, offset, leftLane.IsReverse);
+                var nextLeftWayPoints = ConvertSplineToLineStringPointsNonSmooth(spline, offset, leftLane.IsReversed);
                 leftLane.LeftWay.SetPointsUnkeepReference(nextLeftWayPoints);
                 offset -= laneWidth;
 
@@ -200,7 +200,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                 var rightStartPoint = leftLane.RightWay.Points.First();
                 var rightEndPoint = leftLane.RightWay.Points.Last();
 
-                var nextRightWayPoints = ConvertSplineToLineStringPointsNonSmooth(spline, offset, leftLane.IsReverse);
+                var nextRightWayPoints = ConvertSplineToLineStringPointsNonSmooth(spline, offset, leftLane.IsReversed);
                 leftLane.RightWay.SetPointsUnkeepReference(nextRightWayPoints);
 
                 // 端点のみ元の参照を保持
@@ -220,7 +220,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                 var rightStartPoint = rightLane.RightWay.Points.First();
                 var rightEndPoint = rightLane.RightWay.Points.Last();
 
-                var nextRightWayPoints = ConvertSplineToLineStringPointsNonSmooth(spline, offset, rightLane.IsReverse);
+                var nextRightWayPoints = ConvertSplineToLineStringPointsNonSmooth(spline, offset, rightLane.IsReversed);
                 rightLane.RightWay.SetPointsUnkeepReference(nextRightWayPoints);
 
                 // 端点のみ元の参照を保持
@@ -234,7 +234,7 @@ namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
                 var leftStartPoint = rightLane.LeftWay.Points.First();
                 var leftEndPoint = rightLane.LeftWay.Points.Last();
 
-                var nextLeftWayPoints = ConvertSplineToLineStringPointsNonSmooth(spline, offset, rightLane.IsReverse);
+                var nextLeftWayPoints = ConvertSplineToLineStringPointsNonSmooth(spline, offset, rightLane.IsReversed);
                 rightLane.LeftWay.SetPointsUnkeepReference(nextLeftWayPoints);
 
                 // 端点のみ元の参照を保持

--- a/Editor/RoadNetwork/Exporter/RoadNetworkElementLane.cs
+++ b/Editor/RoadNetwork/Exporter/RoadNetworkElementLane.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using PLATEAU.Native;
+using PLATEAU.RoadNetwork.Data;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
-using PLATEAU.Native;
-using PLATEAU.RoadNetwork.Data;
 
 namespace PLATEAU.Editor.RoadNetwork.Exporter
 {
@@ -73,7 +73,7 @@ namespace PLATEAU.Editor.RoadNetwork.Exporter
 
             var points = roadNetworkContext.RoadNetworkGetter.GetPoints();
 
-            var isReverse = OriginLane.IsReverse;
+            var isReverse = OriginLane.IsReversed;
 
             var way = isCenter ? OriginLane.CenterWay : OriginLane.RightWay;
 

--- a/Editor/RoadNetwork/Exporter/RoadNetworkElementLink.cs
+++ b/Editor/RoadNetwork/Exporter/RoadNetworkElementLink.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using PLATEAU.Native;
+using PLATEAU.RoadNetwork.Data;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using PLATEAU.Native;
-using PLATEAU.RoadNetwork.Data;
 
 namespace PLATEAU.Editor.RoadNetwork.Exporter
 {
@@ -177,7 +177,7 @@ namespace PLATEAU.Editor.RoadNetwork.Exporter
             {
                 if (!lane.IsValid) continue;
 
-                if (IsReverse == laneAll[lane.ID].IsReverse)
+                if (IsReverse == laneAll[lane.ID].IsReversed)
                 {
                     lanes.Add(lane);
                 }

--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -118,7 +118,7 @@ namespace PLATEAU.Editor.RoadNetwork.Structure
                         }
                     }
 
-                    lane.IsReverse = EditorGUILayout.Toggle("IsReverse", lane.IsReverse);
+                    lane.IsReversed = EditorGUILayout.Toggle("IsReverse", lane.IsReversed);
                     lane.Attributes = (RnLaneAttribute)EditorGUILayout.EnumFlagsField("Attribute", lane.Attributes);
                     Draw(RnLaneBorderType.Prev);
                     Draw(RnLaneBorderType.Next);

--- a/Runtime/RoadAdjust/RoadMarking/DirectionalArrow/DirectionalArrowComposer.cs
+++ b/Runtime/RoadAdjust/RoadMarking/DirectionalArrow/DirectionalArrowComposer.cs
@@ -14,7 +14,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking.DirectionalArrow
     {
         private IRrTarget target;
         private const float ArrowMeshHeightOffset = 0.07f; // 経験的に道路に埋まらないくらいの高さ
-        
+
         /// <summary> 矢印を停止線からどの距離に置くか </summary>
         private const float ArrowPositionOffset = 4.5f;
 
@@ -45,16 +45,16 @@ namespace PLATEAU.RoadAdjust.RoadMarking.DirectionalArrow
 
                     if (lane.NextBorder != null)
                     {
-                        var inter = lane.IsReverse ? prevIntersection : nextIntersection;
+                        var inter = lane.IsReversed ? prevIntersection : nextIntersection;
                         var nextArrow = GenerateArrow(lane.NextBorder, inter, ArrowPosition(lane, true, out var isSucceedP), ArrowAngle(lane, true, out bool isSucceedA));
-                        if(isSucceedP && isSucceedA) ret.Add(nextArrow);
+                        if (isSucceedP && isSucceedA) ret.Add(nextArrow);
                     }
 
                     if (lane.PrevBorder != null)
                     {
-                        var inter = lane.IsReverse ? nextIntersection : prevIntersection;
+                        var inter = lane.IsReversed ? nextIntersection : prevIntersection;
                         var prevArrow = GenerateArrow(lane.PrevBorder, inter, ArrowPosition(lane, false, out var isSucceedP), ArrowAngle(lane, false, out var isSucceedA));
-                        if(isSucceedP && isSucceedA) ret.Add(prevArrow);
+                        if (isSucceedP && isSucceedA) ret.Add(prevArrow);
                     }
 
 
@@ -101,7 +101,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking.DirectionalArrow
                 posSum += rightWay.PositionAtDistance(ArrowPositionOffset, isNext ^ rightWay.IsReversed);
                 wayCount++;
             }
-            
+
             if (wayCount == 0)
             {
                 Debug.Log("Skipping because way count is 0.");
@@ -136,14 +136,14 @@ namespace PLATEAU.RoadAdjust.RoadMarking.DirectionalArrow
                 angleSum += ArrowAngleOneWay(rightWay, isNext);
                 wayCount++;
             }
-            
+
             if (wayCount == 0)
             {
                 Debug.Log("Skipping Angle because way count is 0.");
                 isSucceed = false;
                 return 0;
             }
-            
+
             isSucceed = true;
             return angleSum / wayCount;
 

--- a/Runtime/RoadAdjust/RoadMarking/MarkedWay/Parts/MCCenterLine.cs
+++ b/Runtime/RoadAdjust/RoadMarking/MarkedWay/Parts/MCCenterLine.cs
@@ -31,19 +31,19 @@ namespace PLATEAU.RoadAdjust.RoadMarking
                 {
                     var lane = carLanes[i];
                     // 隣のレーンと進行方向が異なる場合、Rightwayはセンターラインです。
-                    bool isCenterLane = i < carLanes.Count - 1 && lane.IsReverse != carLanes[i + 1].IsReverse;
+                    bool isCenterLane = i < carLanes.Count - 1 && lane.IsReversed != carLanes[i + 1].IsReversed;
                     // 中央分離帯がある場合、センターラインは2つになるので、隣チェックを両方向で行います。
                     if (medianLaneExist)
                     {
-                        isCenterLane |= i >= 1 && lane.IsReverse != carLanes[i - 1].IsReverse;
+                        isCenterLane |= i >= 1 && lane.IsReversed != carLanes[i - 1].IsReversed;
                     }
-                    
-                    
+
+
                     if (!isCenterLane)
                     {
                         continue;
                     }
-                    
+
                     // センターラインの場合
 
                     var srcWay = WayWithMiddlePoint(lane.RightWay);
@@ -72,12 +72,12 @@ namespace PLATEAU.RoadAdjust.RoadMarking
 
 
                             var lerpedPoint = Vector3.Lerp(srcWay.GetPoint(j - 1), srcWay.GetPoint(j), t);
-                            
+
                             lineString.AddPoint(new RnPoint(lerpedPoint));
 
                             // 線を追加
                             var dstLine = new MWLine(lineString.Points.Select(p => p.Vertex));
-                            ret.Add(new MarkedWay(dstLine, prevInterType, lane.IsReverse));
+                            ret.Add(new MarkedWay(dstLine, prevInterType, lane.IsReversed));
                             lineString = new RnLineString(); // リセット
                             lineString.AddPoint(new RnPoint(lerpedPoint)); // 次の始点
                         }
@@ -87,7 +87,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
                     }
 
                     if (lineString.Count > 0)
-                        ret.Add(new MarkedWay(new MWLine(lineString.Points.Select(p => p.Vertex)), prevInterType, lane.IsReverse));
+                        ret.Add(new MarkedWay(new MWLine(lineString.Points.Select(p => p.Vertex)), prevInterType, lane.IsReversed));
 
                     // センターラインの数は、中央分離帯がなければ最大1個、あれば最大2個です。
                     if ((ret.Count == 1 && !medianLaneExist) || (ret.Count == 2 && medianLaneExist))
@@ -115,8 +115,8 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             var carLanes = road.MainLanes;
             // 片側の道路幅からタイプを判定します
             bool isOver6M =
-                carLanes.Where(l => l.IsReverse).Sum(l => l.CalcWidth()) > WidthThreshold ||
-                carLanes.Where(l => !l.IsReverse).Sum(l => l.CalcWidth()) > WidthThreshold;
+                carLanes.Where(l => l.IsReversed).Sum(l => l.CalcWidth()) > WidthThreshold ||
+                carLanes.Where(l => !l.IsReversed).Sum(l => l.CalcWidth()) > WidthThreshold;
             var type = isOver6M ? MarkedWayType.CenterLineOver6MWidth : MarkedWayType.CenterLineUnder6MWidth;
             return type;
         }
@@ -163,7 +163,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
         /// <summary> 道路のNext方向の交差点までの距離（対象道路を含まない距離） </summary>
         private float NextLength { get; }
         public float LengthBetweenCenterLine { get; }
-        
+
 
         /// <summary>
         /// 交差点を探し、その距離を計算します。
@@ -219,7 +219,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
             float nextSum = nextLen + NextLength;
             return Math.Min(prevSum, nextSum);
         }
-        
+
         private float RoadLength(RnRoad r)
         {
             if (r.MainLanes.Count > 0 && r.MainLanes[0].RightWay != null)

--- a/Runtime/RoadAdjust/RoadMarking/MarkedWay/Parts/MCLaneLine.cs
+++ b/Runtime/RoadAdjust/RoadMarking/MarkedWay/Parts/MCLaneLine.cs
@@ -18,7 +18,7 @@ namespace PLATEAU.RoadAdjust.RoadMarking
                 // 車道のうち、端でない（路側帯線でない）もののLeftWayは車線境界線です。
                 for (int i = 1; i < carLanes.Count - 1; i++)
                 {
-                    ret.Add(new MarkedWay(new MWLine(carLanes[i].LeftWay), MarkedWayType.LaneLine, carLanes[i].IsReverse));
+                    ret.Add(new MarkedWay(new MWLine(carLanes[i].LeftWay), MarkedWayType.LaneLine, carLanes[i].IsReversed));
                 }
             }
             return ret;

--- a/Runtime/RoadAdjust/RoadMarking/MarkedWay/Parts/MCShoulderLine.cs
+++ b/Runtime/RoadAdjust/RoadMarking/MarkedWay/Parts/MCShoulderLine.cs
@@ -23,14 +23,14 @@ namespace PLATEAU.RoadAdjust.RoadMarking
                 var lastLeft = lastLane.LeftWay;
                 if (firstLeft != null)
                 {
-                    ret.Add(new MarkedWay(new MWLine(firstLane.LeftWay), MarkedWayType.ShoulderLine, firstLane.IsReverse));
+                    ret.Add(new MarkedWay(new MWLine(firstLane.LeftWay), MarkedWayType.ShoulderLine, firstLane.IsReversed));
                 }
 
                 if (lastLeft != null)
                 {
-                    ret.Add(new MarkedWay(new MWLine(lastLane.LeftWay), MarkedWayType.ShoulderLine, lastLane.IsReverse));
+                    ret.Add(new MarkedWay(new MWLine(lastLane.LeftWay), MarkedWayType.ShoulderLine, lastLane.IsReversed));
                 }
-                
+
             }
             return ret;
         }

--- a/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmLaneUV1Calc.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/ContourGenerator/RnmLaneUV1Calc.cs
@@ -16,10 +16,10 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
         private readonly bool reversedLane;
         private readonly RnWay nextBorder;
         private readonly RnWay prevBorder;
-        
+
         public RnmLaneUV1Calc(RnLane lane, int laneCount, int laneIndex, RnWay nextBorder, RnWay prevBorder)
         {
-            reversedLane = lane.IsReverse;
+            reversedLane = lane.IsReversed;
             laneUvLeft = ((float)laneIndex) / laneCount;
             laneUvRight = (((float)laneIndex) + 1) / laneCount;
             nextUvY = reversedLane ? 0 : 1;
@@ -76,7 +76,7 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
             var uvX = reversedLane ? laneUvRight : laneUvLeft;
             return new Vector2(uvX, prevUvY);
         }
-        
+
         /// <summary> 道路の左側Wayの終了地点のUVです。 </summary>
         public Vector2 LeftWayEnd()
         {

--- a/Runtime/RoadNetwork/Data/RnDataLane.cs
+++ b/Runtime/RoadNetwork/Data/RnDataLane.cs
@@ -1,6 +1,7 @@
 ﻿using PLATEAU.RoadNetwork.Structure;
 using System;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace PLATEAU.RoadNetwork.Data
 {
@@ -39,13 +40,12 @@ namespace PLATEAU.RoadNetwork.Data
         [RoadNetworkSerializeMember("centerWay")]
         public RnID<RnDataWay> CenterWay { get; set; }
 
-        // #TODO : IsReversedに変更予定.
-        //       : 既存のデータの後方互換の為以下を入れるがそのテストを行った後にする
-        //       : [field : FormerlySerializedAs("IsReverse")]
         // 親Roadと逆方向(右車線等)
         [field: SerializeField]
+        //       : 既存のデータとの後方互換の為に入れている.
+        [field: FormerlySerializedAs("<IsReverse>k__BackingField")]
         [RoadNetworkSerializeMember]
-        public bool IsReverse { get; set; }
+        public bool IsReversed { get; set; }
 
     }
 

--- a/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
+++ b/Runtime/RoadNetwork/Structure/Drawer/PLATEAURnModelDrawerDebug.cs
@@ -863,7 +863,7 @@ namespace PLATEAU.RoadNetwork.Structure.Drawer
             /// <returns></returns>
             public float GetLaneAlpha(RnLane self)
             {
-                if (self.IsReverse)
+                if (self.IsReversed)
                     return reverseWayAlpha;
                 if (self.IsBothConnectedLane)
                     return bothConnectedLaneAlpha;

--- a/Runtime/RoadNetwork/Structure/RnLane.cs
+++ b/Runtime/RoadNetwork/Structure/RnLane.cs
@@ -115,7 +115,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <summary>
         /// 親Roadと逆方向(右車線等)
         /// </summary>
-        public bool IsReverse { get; set; }
+        public bool IsReversed { get; set; }
 
         /// <summary>
         /// 内部的に持つだけ. 中心線
@@ -385,7 +385,7 @@ namespace PLATEAU.RoadNetwork.Structure
         {
             (PrevBorder, NextBorder) = (NextBorder?.ReversedWay(), PrevBorder?.ReversedWay());
             (LeftWay, RightWay) = (RightWay?.ReversedWay(), LeftWay?.ReversedWay());
-            IsReverse = !IsReverse;
+            IsReversed = !IsReversed;
         }
 
         /// <summary>

--- a/Runtime/RoadNetwork/Structure/RnModel.cs
+++ b/Runtime/RoadNetwork/Structure/RnModel.cs
@@ -1066,7 +1066,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 var prevLeftWay = CopyWay(left.prev, lane.LeftWay);
                 var prevRightWay = CopyWay(right.prev, lane.RightWay);
 
-                var isReverseLane = lane.IsReverse;
+                var isReverseLane = lane.IsReversed;
 
                 // 分割個所の境界線
                 var midBorderWay = new RnWay(RnLineString.Create(new[] { left.midPoint, right.midPoint }));
@@ -1078,7 +1078,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 var newLaneBorder = lane.GetBorder(laneMidBorderType);
                 lane.SetBorder(laneMidBorderType, midBorderWay);
 
-                var newLane = new RnLane(nextLeftWay, nextRightWay, null, null) { IsReverse = isReverseLane };
+                var newLane = new RnLane(nextLeftWay, nextRightWay, null, null) { IsReversed = isReverseLane };
                 newLane.SetBorder(laneMidBorderType, newLaneBorder);
                 newLane.SetBorder(laneMidBorderType.GetOpposite(), midBorderWay);
                 if (lane.IsMedianLane)

--- a/Runtime/RoadNetwork/Structure/RnRoad.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoad.cs
@@ -144,7 +144,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <returns></returns>
         public bool IsLeftLane(RnLane lane)
         {
-            return lane.IsReverse == false;
+            return lane.IsReversed == false;
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace PLATEAU.RoadNetwork.Structure
         /// <returns></returns>
         public bool IsRightLane(RnLane lane)
         {
-            return lane.IsReverse == true;
+            return lane.IsReversed == true;
         }
 
         /// <summary>
@@ -412,7 +412,7 @@ namespace PLATEAU.RoadNetwork.Structure
             // 各レーンのWayの向きは変えずにIsRevereだけ変える
             // 左車線/右車線の関係が変わるので配列の並びも逆にする
             foreach (var lane in AllLanesWithMedian)
-                lane.IsReverse = !lane.IsReverse;
+                lane.IsReversed = !lane.IsReversed;
             mainLanes.Reverse();
 
             // 歩道の設定も逆にする(左車線/右車線の関係が変わるので)

--- a/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
+++ b/Runtime/RoadNetwork/Structure/RnRoadGroup.cs
@@ -721,7 +721,7 @@ namespace PLATEAU.RoadNetwork.Structure
                 var mainLanes = road.MainLanes;
                 var lane = RnDir.Left == dir ? mainLanes.FirstOrDefault() : mainLanes.LastOrDefault();
                 var wayDir = RnDir.Left;
-                wayDir = !lane.IsReverse ? wayDir : wayDir.GetOpposite();
+                wayDir = !lane.IsReversed ? wayDir : wayDir.GetOpposite();
                 wayDir = dir == RnDir.Left ? wayDir : wayDir.GetOpposite();
                 var way = lane.GetSideWay(wayDir);
                 if (way != null)
@@ -1027,7 +1027,7 @@ namespace PLATEAU.RoadNetwork.Structure
                     var nowLane = nowLanes[j];
                     var prevLane = prevLanes[j];
                     // 親の方向と一致している場合はprevLane -> nextLaneの方向になっているかチェックする
-                    if (prevLane.IsReverse == false)
+                    if (prevLane.IsReversed == false)
                     {
                         if (nowLane.PrevBorder.IsSameLineReference(prevLane.NextBorder) == false)
                         {
@@ -1209,7 +1209,7 @@ namespace PLATEAU.RoadNetwork.Structure
 
                     void AdjustWay(RnLane lane, RnWay way)
                     {
-                        if (lane.IsReverse)
+                        if (lane.IsReversed)
                             way = way.ReversedWay();
                         var p = way.GetPoint(lastPointIndex);
                         var n = borderLeft2Right.GetNearestPoint(p.Vertex);


### PR DESCRIPTION


﻿## 関連リンク
https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/pull/449
ここのコメントでRnLane.IsReverse -> IsReversedに変更したいとあるが、リリース前日にシリアライズデータに影響が出る変更を上げるのは怖いということで見送りになっていた。

## 実装内容
RnLane.IsReverse -> IsReversedに変更
後方互換のためにFormerlySerializedAs("<IsReverse>k__BackingField")を追加

## 動作確認
このブランチ取得前(dev/v3)で道路構造を生成しシーン保存まで行う。メッシュコードは何でもよい。
この時、PLATEAURnStructureModelのStorage/Lanes/DataListのElementのIsReverse(画像はIsReversedだがdev/v3ではまだIsReverse)を覚えておく。(true/false両方のエレメントを覚えておく)
![image](https://github.com/user-attachments/assets/a1d35f48-186f-41cb-9607-7d21acddf92d)

デバッグ描画設定で
Lane -> ReverseWayAlphaを0.1などにしておいて、ShowCenterWayのVisibleをtrueにすると
複数レーンある場合に右側車線の中央線だけ色が薄くなるので、これでシーン上で視覚的にどのレーンがIsReverseなのかもわかる
![image](https://github.com/user-attachments/assets/e5ddc6c4-2d51-429f-ae96-f521db1db164)
![image](https://github.com/user-attachments/assets/5a7b5111-9c01-4ea5-a1f7-bb962dfe0a83)

保存した後に、このブランチを取ってきて、シーンを再度開く
インスペクタ上でのエレメントのIsReversedがdev/v3で保存したものと同じになっているか確認。
デバッグ描画でも確認し、保存したデータが引き継がれているか確認


## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること


## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
