### PR TITLE
glTFエクスポート時のテクスチャ参照を相対パスに修正

### DIFF
--- a/Runtime/CityExport/Exporters/CityExporterGltf.cs
+++ b/Runtime/CityExport/Exporters/CityExporterGltf.cs
@@ -24,7 +24,7 @@ namespace PLATEAU.CityExport.Exporters
             string dirPath = Path.Combine(destDir, fileNameWithoutExtension);
             Directory.CreateDirectory(dirPath);
             string gltfFilePath = Path.Combine(dirPath, fileNameWithoutExtension + fileExtension);
-            string textureDir = Path.Combine(dirPath, "textures");
+            string textureDir = "./textures";
                         
             gltfWriter.Write(gltfFilePath, model, new GltfWriteOptions(GltfFileFormat, textureDir));
         }


### PR DESCRIPTION
﻿## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->

## 実装内容
<!-- 実装した内容、背景について書く。妥協点があれば書いておく。 -->
テクスチャ参照を絶対パスから相対パスに変更しました。

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->
glTFエクスポートし、フォルダごと移動してもテクスチャ参照があることを確認してください。

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
