### PR TITLE
範囲選択のキャンセルができなくなっていた問題を修正

### DIFF
--- a/Runtime/CityImport/AreaSelector/AreaSelectorBehaviour.cs
+++ b/Runtime/CityImport/AreaSelector/AreaSelectorBehaviour.cs
@@ -204,7 +204,7 @@ namespace PLATEAU.CityImport.AreaSelector
             AreaSelectorGuideWindow.Disable();
             LodLegendGUI.Disable();
             var selectedGridCodes = this.gizmosDrawer.SelectedGridCodes;
-            var areaSelectResult = new AreaSelectResult(confBeforeAreaSelect, selectedGridCodes);
+            var areaSelectResult = new AreaSelectResult(confBeforeAreaSelect, selectedGridCodes, AreaSelectResult.ResultReason.Confirm);
 
             // 無名関数のキャプチャを利用して、シーン終了後も必要なデータが渡るようにします。
             #if UNITY_EDITOR
@@ -218,7 +218,7 @@ namespace PLATEAU.CityImport.AreaSelector
             AreaSelectorGuideWindow.Disable();
             LodLegendGUI.Disable();
             IsAreaSelectEnabled = false;
-            var emptyAreaSelectResult = new AreaSelectResult(confBeforeAreaSelect, GridCodeList.Empty);
+            var emptyAreaSelectResult = new AreaSelectResult(confBeforeAreaSelect, GridCodeList.Empty, AreaSelectResult.ResultReason.Cancel);
             #if UNITY_EDITOR
             AreaSelectorDataPass.Exec(this.prevScenePath, emptyAreaSelectResult, this.areaSelectResultReceiver, this.prevEditorWindow);
             #endif

--- a/Runtime/CityImport/AreaSelector/AreaSelectorDataPass.cs
+++ b/Runtime/CityImport/AreaSelector/AreaSelectorDataPass.cs
@@ -29,7 +29,7 @@ namespace PLATEAU.CityImport.AreaSelector
             areaSelectResult = areaSelectResultArg;
             areaSelectResultReceiver = areaSelectResultReceiverArg;
             
-            EditorSceneManager.sceneOpened += OnBackToPrevScene;
+            EditorSceneManager.sceneOpened += OnBackToPrevScene; // 元のシーンに戻るときに一度だけ実行する処理
             EditorSceneManager.OpenScene(prevScenePath);
             // MacOSだと、範囲選択のときに PlateauWindow が背面に回ってしまい見失いがちなので再表示します。
             prevEditorWindow.Focus();
@@ -37,6 +37,9 @@ namespace PLATEAU.CityImport.AreaSelector
 #endif
 
 #if UNITY_EDITOR
+        /// <summary>
+        /// 範囲選択画面を終了して元のシーンに戻るときに実行される処理です。
+        /// </summary>
         private static void OnBackToPrevScene(Scene scene, OpenSceneMode __)
         {
             EditorSceneManager.sceneOpened -= OnBackToPrevScene;
@@ -51,9 +54,15 @@ namespace PLATEAU.CityImport.AreaSelector
         /// </summary>
         private static void PassAreaSelectDataToBehaviour()
         {
+            if (areaSelectResult.Reason == AreaSelectResult.ResultReason.Cancel)
+            {
+                Debug.Log("範囲選択はキャンセルされました。");
+                return;
+            }
             if (areaSelectResult.AreaGridCodes.Count == 0)
             {
                 Debug.Log("地域は選択されませんでした。");
+                return;
             }
             areaSelectResultReceiver.ReceiveResult(areaSelectResult);
         }

--- a/Runtime/CityImport/AreaSelector/IAreaSelectResultReceiver.cs
+++ b/Runtime/CityImport/AreaSelector/IAreaSelectResultReceiver.cs
@@ -16,15 +16,43 @@ namespace PLATEAU.CityImport.AreaSelector
     /// </summary>
     public class AreaSelectResult
     {
+        /// <summary>
+        /// 範囲選択画面が終了した理由を表す列挙型です。
+        /// </summary>
+        public enum ResultReason
+        {
+            /// <summary>
+            /// ユーザーが範囲選択を決定した
+            /// </summary>
+            Confirm,
+            
+            /// <summary>
+            /// ユーザーが範囲選択をキャンセルした
+            /// </summary>
+            Cancel
+        }
+        
         public ConfigBeforeAreaSelect ConfBeforeAreaSelect { get; }
         public GridCodeList AreaGridCodes { get; }
         public PackageToLodDict PackageToLodDict { get; }
-
-        public AreaSelectResult(ConfigBeforeAreaSelect confBeforeAreaSelect, GridCodeList areaGridCodes)
+        
+        /// <summary>
+        /// 範囲選択画面が終了した理由
+        /// </summary>
+        public ResultReason Reason { get; }
+    
+        /// <summary>
+        /// 範囲選択結果を作成します。
+        /// </summary>
+        /// <param name="confBeforeAreaSelect">範囲選択前の設定</param>
+        /// <param name="areaGridCodes">選択されたグリッドコードのリスト</param>
+        /// <param name="reason">範囲選択画面が終了した理由</param>
+        public AreaSelectResult(ConfigBeforeAreaSelect confBeforeAreaSelect, GridCodeList areaGridCodes, ResultReason reason)
         {
             ConfBeforeAreaSelect = confBeforeAreaSelect;
             AreaGridCodes = areaGridCodes;
             PackageToLodDict = areaGridCodes.CalcAvailablePackageLodInGridCodes(ConfBeforeAreaSelect.DatasetSourceConfig);
+            Reason = reason;
         }
 
     }

--- a/Runtime/CityImport/Config/GridCodeList.cs
+++ b/Runtime/CityImport/Config/GridCodeList.cs
@@ -80,7 +80,7 @@ namespace PLATEAU.CityImport.Config
             int gmlCount = gmlFiles.Length;
             if (gmlCount == 0)
             {
-                throw new Exception("GMLがありません。");
+                return ret;
             }
             using var progressBar = new ProgressBar();
             for (int i = 0; i < gmlCount; i++)

--- a/Tests/TestUtils/TestCityDefinition.cs
+++ b/Tests/TestUtils/TestCityDefinition.cs
@@ -91,7 +91,7 @@ namespace PLATEAU.Tests.TestUtils
                     ? new DatasetSourceConfigRemote(this.rootDirName, NetworkConfig.MockServerUrl, "")
                     : new DatasetSourceConfigLocal(SrcRootDirPathLocal);
             
-            var dummyAreaSelectResult = new AreaSelectResult(new ConfigBeforeAreaSelect(datasetSourceConfig, CoordinateZoneId), AreaGridCodes);
+            var dummyAreaSelectResult = new AreaSelectResult(new ConfigBeforeAreaSelect(datasetSourceConfig, CoordinateZoneId), AreaGridCodes, AreaSelectResult.ResultReason.Confirm);
             var conf = CityImportConfig.CreateWithAreaSelectResult(dummyAreaSelectResult);
             
             


### PR DESCRIPTION
﻿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - エリア選択結果に「確定」または「キャンセル」の理由が明示されるようになりました。

- **バグ修正**
  - GMLファイルが存在しない場合、例外を投げずに空の結果を返すようになりました。
  - エリア選択キャンセル時や選択が空の場合、無効なデータが渡されないよう制御が強化されました。

- **ドキュメント**
  - 内部メソッドに説明コメントが追加されました。

- **テスト**
  - テスト用ダミーデータが新しい仕様に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->