### PR TITLE
国土基本図郭の選択範囲対応

### DIFF
--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/BoxGizmoDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/BoxGizmoDrawer.cs
@@ -95,6 +95,15 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
                 Math.Abs(this.CenterPos.x - otherPos.x) <= (Math.Abs(this.Size.x) + Math.Abs(otherSize.x)) * 0.5 &&
                 Math.Abs(this.CenterPos.z - otherPos.z) <= (Math.Abs(this.Size.z) + Math.Abs(otherSize.z)) * 0.5;
         }
+        
+        /// <summary>
+        /// 矩形(areaMin, areaMax)がXZ平面上で重なっているかどうかを判定します。
+        /// </summary>
+        protected bool IsBoxIntersectXZ(Vector3 areaMin, Vector3 areaMax)
+        {
+            return (this.AreaMin.x <= areaMax.x && this.AreaMax.x >= areaMin.x) &&
+                   (this.AreaMin.z <= areaMax.z && this.AreaMax.z >= areaMin.z);
+        }
 
 
         /// <summary>

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/GridCodeGizmoDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/GridCodeGizmoDrawer.cs
@@ -365,13 +365,13 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
                 // 1つでも選択されていれば選択状態に
                 if (intersectedIndices.Any(idx => selectedAreaList[idx]))
                 {
-                    standardMapDrawer.SetSelectArea(GridCode.StringCode, true);
+                    standardMapDrawer.SetMeshCodeSelection(GridCode.StringCode, true);
                 }
 
                 // 全て未選択なら解除
                 if (intersectedIndices.All(idx => !selectedAreaList[idx]))
                 {
-                    standardMapDrawer.SetSelectArea(GridCode.StringCode, false);
+                    standardMapDrawer.SetMeshCodeSelection(GridCode.StringCode, false);
                 }
             }
         }

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/GridCodeGizmoDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/GridCodeGizmoDrawer.cs
@@ -309,7 +309,10 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
                 var rowIndex = GetRowIndex(AreaMin.x, AreaMax.x, divideNumRow, hit.point.x);
                 var columnIndex = GetColumnIndex(AreaMin.z, AreaMax.z, divideNumColumn, hit.point.z);
                 var selectAreaIndex = rowIndex + columnIndex * divideNumColumn;
-                selectedAreaList[selectAreaIndex] = !selectedAreaList[selectAreaIndex];
+                if (0 <= selectAreaIndex && selectAreaIndex < selectedAreaList.Count)
+                {
+                    selectedAreaList[selectAreaIndex] = !selectedAreaList[selectAreaIndex];
+                }
 
                 TrySelectStandardMapGrid(standardMapGridDrawers);
             }
@@ -336,7 +339,11 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
                         continue;
                     }
 
-                    selectedAreaList[row + col * divideNumColumn] = selectValue;
+                    var selectAreaIndex = row + col * divideNumColumn;
+                    if (0 <= selectAreaIndex && selectAreaIndex < selectedAreaList.Count)
+                    {
+                        selectedAreaList[selectAreaIndex] = selectValue;
+                    }
                     TrySelectStandardMapGrid(standardMapGridDrawers);
                 }
             }

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/GridCodeGizmoDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/GridCodeGizmoDrawer.cs
@@ -271,7 +271,7 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
             if(!GridCode.IsNormalGmlLevel && !GridCode.IsSmallerThanNormalGml && gridCodeScreenWidth >= 160 * EditorGUIUtility.pixelsPerPoint) // 2次メッシュコードのとき、画面上の幅が大きいときだけ描画します。
             {
                 var color = isStandardMapGrid ? BoxColorStandardMap : BoxColorNormalLevel2;
-                DrawString(GridCode.StringCode, textPosWorld, BoxColorNormalLevel2, ReturnFontSize());
+                DrawString(GridCode.StringCode, textPosWorld, color, ReturnFontSize());
             }
             else if(GridCode.IsNormalGmlLevel && gridCodeScreenWidth >= 80f) // 3次メッシュコードのとき、画面上の幅が大きいときだけ描画します。
             {

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/GridCodeGizmoDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/GridCodeGizmoDrawer.cs
@@ -26,6 +26,7 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
         private static readonly Color BoxColorNormalLevel2 = Color.black;
         private static readonly Color BoxColorNormalLevel3 = new(0f, 84f / 255f, 1f);
         private static readonly Color BoxColorNormalLevel4 = new(0f, 84f / 255f, 1f);
+        private static readonly Color BoxColorStandardMap = new(0f, 0.7f, 0f);
         private static readonly Color HandleColor = new(1f, 72f / 255f, 0f);
         private static readonly Color SelectedFaceColor = new(1f, 204f / 255f, 153f / 255f, 0.5f);
         private static readonly Color TransparentColor = new(0f, 0f, 0f, 0f);
@@ -41,6 +42,8 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
         private List<bool> selectedAreaList;
         private const int GridCodeDivideNum = 4;
         
+        // 国土基本図郭フラグ
+        private bool isStandardMapGrid;
         
         // FIXME RowがXでColumnがZって直感に反する気がする。逆では？
         private int GetRowIndex(double minX, double maxX, int numGrid, double value)
@@ -93,6 +96,7 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
                 (float)Math.Abs(max.Z - min.Z));
             Init(centerPosTmp, sizeTmp, gridCode);
             GridCode = gridCode;
+            isStandardMapGrid = gridCode.StringCode.Any(char.IsLetter);
             
             ApplyStyle();
 
@@ -120,25 +124,25 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
             if (GridCode.IsNormalGmlLevel) // 通常のメッシュコード
             {
                 LineWidth = LineWidthLevel3;
-                BoxColor = BoxColorNormalLevel3;
-                divideNumColumn = 4;
-                divideNumRow = 4;
+                BoxColor = isStandardMapGrid ? BoxColorStandardMap : BoxColorNormalLevel3;
+                divideNumColumn = isStandardMapGrid ? 1 : 4;
+                divideNumRow = isStandardMapGrid ? 1 : 4;
                 return;
             }
             if (GridCode.IsSmallerThanNormalGml) // 小さいメッシュコード
             {
                 LineWidth = LineWidthLevel4;
-                BoxColor = BoxColorNormalLevel4;
-                divideNumColumn = 2;
-                divideNumRow = 2;
+                BoxColor = isStandardMapGrid ? BoxColorStandardMap : BoxColorNormalLevel4;
+                divideNumColumn = isStandardMapGrid ? 1 : 2;
+                divideNumRow = isStandardMapGrid ? 1 : 2;
                 return;
             }
 
             // 大きいメッシュコード
             LineWidth = LineWidthLevel2;
-            BoxColor = BoxColorNormalLevel2;
-            divideNumColumn = 4;
-            divideNumRow = 4;
+            BoxColor = isStandardMapGrid ? BoxColorStandardMap : BoxColorNormalLevel2;
+            divideNumColumn = isStandardMapGrid ? 1 : 4;
+            divideNumRow = isStandardMapGrid ? 1 : 4;
         }
 
         public List<string> GetSelectedGridIds()
@@ -152,18 +156,32 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
                     {
                         if (selectedAreaList[row + col * divideNumColumn])
                         {
-                            strGridCodes.Add($"{GridCode.StringCode}{SuffixMeshIds[row + col * divideNumColumn]}");
+                            if (isStandardMapGrid)
+                            {
+                                strGridCodes.Add($"{GridCode.StringCode}");
+                            }
+                            else
+                            {
+                                strGridCodes.Add($"{GridCode.StringCode}{SuffixMeshIds[row + col * divideNumColumn]}");
+                            }
                         }
                     }
                 }
-            }else if (GridCode.IsSmallerThanNormalGml)
+            }
+            else if (GridCode.IsSmallerThanNormalGml)
             {
-                // strGridCodes.Add(GridCode.StringCode);
                 for (int i = 0; i < GridCodeDivideNum; i++)
                 {
                     if (selectedAreaList[i])
                     {
-                        strGridCodes.Add($"{GridCode.StringCode}{(i+1).ToString()}");
+                        if (isStandardMapGrid)
+                        {
+                            strGridCodes.Add($"{GridCode.StringCode}");
+                        }
+                        else
+                        {
+                            strGridCodes.Add($"{GridCode.StringCode}{(i+1).ToString()}");
+                        }
                     }
                 }
             }
@@ -252,11 +270,13 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
             
             if(!GridCode.IsNormalGmlLevel && !GridCode.IsSmallerThanNormalGml && gridCodeScreenWidth >= 160 * EditorGUIUtility.pixelsPerPoint) // 2次メッシュコードのとき、画面上の幅が大きいときだけ描画します。
             {
+                var color = isStandardMapGrid ? BoxColorStandardMap : BoxColorNormalLevel2;
                 DrawString(GridCode.StringCode, textPosWorld, BoxColorNormalLevel2, ReturnFontSize());
             }
             else if(GridCode.IsNormalGmlLevel && gridCodeScreenWidth >= 80f) // 3次メッシュコードのとき、画面上の幅が大きいときだけ描画します。
             {
-                DrawString(GridCode.StringCode, textPosWorld , BoxColorNormalLevel3, ReturnFontSizeBlue());
+                var color = isStandardMapGrid ? BoxColorStandardMap : BoxColorNormalLevel3;
+                DrawString(GridCode.StringCode, textPosWorld , color, ReturnFontSizeBlue());
             }
         }
 

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/GridCodeGizmoDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/GridCodeGizmoDrawer.cs
@@ -118,7 +118,10 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
 
         protected void SetSelectArea(int selectAreaIndex, bool isSelect)
         {
-            selectedAreaList[selectAreaIndex] = isSelect;
+            if (0 <= selectAreaIndex && selectAreaIndex < selectedAreaList.Count)
+            {
+                selectedAreaList[selectAreaIndex] = isSelect;
+            }
         }
 
         protected virtual void ApplyStyle()
@@ -306,8 +309,6 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
                 var rowIndex = GetRowIndex(AreaMin.x, AreaMax.x, divideNumRow, hit.point.x);
                 var columnIndex = GetColumnIndex(AreaMin.z, AreaMax.z, divideNumColumn, hit.point.z);
                 var selectAreaIndex = rowIndex + columnIndex * divideNumColumn;
-
-                // FIXME 同じ式の繰り返し
                 selectedAreaList[selectAreaIndex] = !selectedAreaList[selectAreaIndex];
 
                 TrySelectStandardMapGrid(standardMapGridDrawers);

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/StandardMapGizmoDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/StandardMapGizmoDrawer.cs
@@ -41,7 +41,7 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
             divideNumRow = 1;
         }
         
-        public void SetSelectArea(string meshCode, bool isSelected)
+        public void SetMeshCodeSelection(string meshCode, bool isSelected)
         {
             if (isSelected)
             {

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/StandardMapGizmoDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/StandardMapGizmoDrawer.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
+{
+    /// <summary>
+    /// 国土基本図郭の範囲を表示するギズモの描画クラスです。
+    /// </summary>
+    internal class StandardMapGizmoDrawer : GridCodeGizmoDrawer
+    {
+        private static readonly Color BoxColorStandardMap = new(0f, 0.7f, 0f);
+        protected override Color BoxColorNormalLevel2 => BoxColorStandardMap;
+        protected override Color BoxColorNormalLevel3 => BoxColorStandardMap;
+        protected override Color HandleColor => new(1f, 250f / 255f, 203f / 255f);
+        
+        private readonly List<string> selectedMeshCodes = new ();
+        
+        protected override void ApplyStyle()
+        {
+            if (GridCode.IsNormalGmlLevel) // 通常のメッシュコード
+            {
+                LineWidth = LineWidthLevel3;
+                BoxColor = BoxColorStandardMap;
+                divideNumColumn = 1;
+                divideNumRow = 1;
+                return;
+            }
+            if (GridCode.IsSmallerThanNormalGml) // 小さいメッシュコード
+            {
+                LineWidth = LineWidthLevel4;
+                BoxColor = BoxColorStandardMap;
+                divideNumColumn = 1;
+                divideNumRow = 1;
+                return;
+            }
+
+            // 大きいメッシュコード
+            LineWidth = LineWidthLevel2;
+            BoxColor = BoxColorStandardMap;
+            divideNumColumn = 1;
+            divideNumRow = 1;
+        }
+        
+        public void SetSelectArea(string meshCode, bool isSelected)
+        {
+            if (isSelected)
+            {
+                if (selectedMeshCodes.Contains(meshCode))
+                {
+                    return;
+                }
+                selectedMeshCodes.Add(meshCode);
+                SetSelectArea(0, true);
+            }
+            else
+            {
+                if (!selectedMeshCodes.Contains(meshCode))
+                {
+                    return;
+                }
+                selectedMeshCodes.Remove(meshCode);
+                if (selectedMeshCodes.Count == 0)
+                {
+                    SetSelectArea(0, false);
+                }
+            }
+        }
+
+        public override void ResetSelectedArea()
+        {
+            base.ResetSelectedArea();
+            selectedMeshCodes.Clear();
+        }
+    }
+}

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/StandardMapGizmoDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/StandardMapGizmoDrawer.cs
@@ -13,7 +13,7 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos.AreaRectangles
         protected override Color BoxColorNormalLevel3 => BoxColorStandardMap;
         protected override Color HandleColor => new(1f, 250f / 255f, 203f / 255f);
         
-        private readonly List<string> selectedMeshCodes = new ();
+        private readonly HashSet<string> selectedMeshCodes = new ();
         
         protected override void ApplyStyle()
         {

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/StandardMapGizmoDrawer.cs.meta
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaRectangles/StandardMapGizmoDrawer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 43f9a30ba8de49bd92582d4360c47f75
+timeCreated: 1746599524

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaSelectGizmosDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaSelectGizmosDrawer.cs
@@ -204,8 +204,13 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
                         {
                             foreach (var meshCodeGizmoDrawer in this.gridCodeDrawers) 
                             {
+                                if (meshCodeGizmoDrawer.IsStandardMapGrid) 
+                                {
+                                    continue;
+                                }
                                 #if UNITY_EDITOR
-                                meshCodeGizmoDrawer.ToggleSelectArea(currentEvent.mousePosition);
+                                meshCodeGizmoDrawer.ToggleSelectArea(currentEvent.mousePosition,
+                                    gridCodeDrawers.Where(d => d.IsStandardMapGrid).ToList());
                                 #endif
                             }
                         }
@@ -213,8 +218,16 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
                         {
                             foreach (var meshCodeGizmoDrawer in this.gridCodeDrawers) 
                             {
+                                if (meshCodeGizmoDrawer.IsStandardMapGrid) 
+                                {
+                                    continue;
+                                }
                                 #if UNITY_EDITOR
-                                meshCodeGizmoDrawer.SetSelectArea(this.areaSelectionGizmoDrawer.AreaSelectionMin, this.areaSelectionGizmoDrawer.AreaSelectionMax, this.isLeftMouseButtonMoved);
+                                meshCodeGizmoDrawer.SetSelectArea(
+                                    this.areaSelectionGizmoDrawer.AreaSelectionMin,
+                                    this.areaSelectionGizmoDrawer.AreaSelectionMax,
+                                    this.isLeftMouseButtonMoved,
+                                    gridCodeDrawers.Where(d => d.IsStandardMapGrid).ToList());
                                 #endif
                             }
                         }

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaSelectGizmosDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaSelectGizmosDrawer.cs
@@ -101,7 +101,9 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
                 }
 
                 if (isDuplicate) continue;
-                var drawer = new GridCodeGizmoDrawer();
+                var drawer = gridCode.StringCode.Any(char.IsLetter) 
+                    ? new StandardMapGizmoDrawer() 
+                    : new GridCodeGizmoDrawer();
                 drawer.SetUp(GridCode.CopyFrom(gridCode.Handle), outGeoReference);
                 this.gridCodeDrawers.Add(drawer);
             }
@@ -204,13 +206,15 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
                         {
                             foreach (var meshCodeGizmoDrawer in this.gridCodeDrawers) 
                             {
-                                if (meshCodeGizmoDrawer.IsStandardMapGrid) 
+                                if (meshCodeGizmoDrawer is StandardMapGizmoDrawer) 
                                 {
                                     continue;
                                 }
                                 #if UNITY_EDITOR
                                 meshCodeGizmoDrawer.ToggleSelectArea(currentEvent.mousePosition,
-                                    gridCodeDrawers.Where(d => d.IsStandardMapGrid).ToList());
+                                    gridCodeDrawers
+                                        .OfType<StandardMapGizmoDrawer>()
+                                        .ToList());
                                 #endif
                             }
                         }
@@ -218,7 +222,7 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
                         {
                             foreach (var meshCodeGizmoDrawer in this.gridCodeDrawers) 
                             {
-                                if (meshCodeGizmoDrawer.IsStandardMapGrid) 
+                                if (meshCodeGizmoDrawer is StandardMapGizmoDrawer) 
                                 {
                                     continue;
                                 }
@@ -227,7 +231,9 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
                                     this.areaSelectionGizmoDrawer.AreaSelectionMin,
                                     this.areaSelectionGizmoDrawer.AreaSelectionMax,
                                     this.isLeftMouseButtonMoved,
-                                    gridCodeDrawers.Where(d => d.IsStandardMapGrid).ToList());
+                                    gridCodeDrawers
+                                        .OfType<StandardMapGizmoDrawer>()
+                                        .ToList());
                                 #endif
                             }
                         }

--- a/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaSelectGizmosDrawer.cs
+++ b/Runtime/CityImport/AreaSelector/Display/Gizmos/AreaSelectGizmosDrawer.cs
@@ -178,6 +178,7 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
             if (currentEvent == null)
                 return;
             
+            var standardMapDrawers = gridCodeDrawers.OfType<StandardMapGizmoDrawer>().ToList();
             switch (currentEvent.type)
             {
                 case EventType.MouseDown:
@@ -211,10 +212,7 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
                                     continue;
                                 }
                                 #if UNITY_EDITOR
-                                meshCodeGizmoDrawer.ToggleSelectArea(currentEvent.mousePosition,
-                                    gridCodeDrawers
-                                        .OfType<StandardMapGizmoDrawer>()
-                                        .ToList());
+                                meshCodeGizmoDrawer.ToggleSelectArea(currentEvent.mousePosition, standardMapDrawers);
                                 #endif
                             }
                         }
@@ -231,9 +229,7 @@ namespace PLATEAU.CityImport.AreaSelector.Display.Gizmos
                                     this.areaSelectionGizmoDrawer.AreaSelectionMin,
                                     this.areaSelectionGizmoDrawer.AreaSelectionMax,
                                     this.isLeftMouseButtonMoved,
-                                    gridCodeDrawers
-                                        .OfType<StandardMapGizmoDrawer>()
-                                        .ToList());
+                                    standardMapDrawers);
                                 #endif
                             }
                         }


### PR DESCRIPTION
﻿## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->
https://synesthesias.atlassian.net/browse/CPSDK25-93

- メッシュコード選択時に国土基本図郭の範囲を選択したかどうかの判定を追加
- 範囲が選択されていれば、国土基本図郭の選択をアクティブに
- 選択が解除されていれば、国土基本図郭の選択を解除
- 国土基本図郭の範囲を描画する用のクラスを作成して、国土基本図郭の処理を寄せる

## 実装内容
<!-- 実装した内容、背景について書く。妥協点があれば書いておく。 -->

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 標準地図グリッドエリア（国土基本図郭）用の新しい選択・描画機能を追加しました。
- **改善**
  - グリッド選択の連携やスタイル設定の拡張性が向上しました。
  - 選択範囲の描画パフォーマンスを改善しました。
  - マウス操作時のグリッド選択処理が標準地図グリッドと連携するようになりました。
- **その他**
  - 内部処理の整理と最適化を行いました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->