### PR TITLE
インスペクタでの属性情報表示をボタントグル式にすることで、選択するだけで重くなる問題を軽減

### DIFF
--- a/Editor/CityInfo/PLATEAUCityObjectGroupEditor.cs
+++ b/Editor/CityInfo/PLATEAUCityObjectGroupEditor.cs
@@ -11,10 +11,22 @@ namespace PLATEAU.Editor.CityInfo
     public class PLATEAUCityObjectGroupEditor : UnityEditor.Editor
     {
         private readonly ScrollView scrollView = new (GUILayout.MaxHeight(400));
+        
+        // 属性情報の文字列は長いことがあるので、繰り返しの取得を避けるためにキャッシュします。
+        private string cachedJson;
+        private bool jsonLoaded = false;
+        
+        // 属性情報の表示制御
+        private bool showAttributeInfo = false;
 
         public void OnEnable()
         {
             ComponentUtility.MoveComponentUp(target as Component);
+            
+            // 選択でキャッシュをリセット
+            cachedJson = null;
+            jsonLoaded = false;
+            showAttributeInfo = false;
         }
 
         public override void OnInspectorGUI()
@@ -25,22 +37,51 @@ namespace PLATEAU.Editor.CityInfo
             PlateauEditorStyle.Heading("粒度", null);
             EditorGUILayout.LabelField(cog.Granularity.ToJapaneseString());
             
-            SerializedProperty prop = serializedObject.FindProperty("serializedCityObjects");
-            var json = prop.stringValue;
-
             PlateauEditorStyle.Heading("属性情報", null);
             using (PlateauEditorStyle.VerticalScopeLevel1())
             {
-                scrollView.Draw(() =>
+                // 属性情報の表示は重いことがあるので、ボタンで切り替えられるようにします。
+                using (new EditorGUILayout.HorizontalScope())
                 {
-                    EditorGUILayout.TextArea(json);
-                });
+                    string buttonText = showAttributeInfo ? "属性情報を非表示" : "属性情報を表示";
+                    if (GUILayout.Button(buttonText))
+                    {
+                        showAttributeInfo = !showAttributeInfo;
+                    }
+                }
+                
+                if (showAttributeInfo)
+                {
+                    // 属性情報文字列をキャッシュから取得
+                    string json = GetCachedJson();
+                    
+                    scrollView.Draw(() =>
+                    {
+                        EditorGUILayout.TextArea(json);
+                    });
+                }
             }
            
             using (new EditorGUI.DisabledScope(true))
             {
                 base.OnInspectorGUI();
             }
+        }
+        
+        /// <summary>
+        /// 属性情報のJSONをキャッシュから取得します。一度取得したらキャッシュを使用し、長い情報の繰り返し取得を避けます。
+        /// </summary>
+        private string GetCachedJson()
+        {
+            // 初回のみprop.stringValueから取得
+            if (!jsonLoaded)
+            {
+                SerializedProperty prop = serializedObject.FindProperty("serializedCityObjects");
+                cachedJson = prop.stringValue;
+                jsonLoaded = true;
+            }
+            
+            return cachedJson ?? string.Empty;
         }
     }
 }


### PR DESCRIPTION
今まで：　地域単位でインポートすると属性情報が多いので、地物をクリック選択するだけでインスペクタ表示が重い
今回：　　属性情報はボタンが押されるまで表示されないようにすることで重さを軽減

