### PR TITLE
動的タイルに関するバグ修正

### DIFF
--- a/Editor/DynamicTile/PrefabTextureResizer.cs
+++ b/Editor/DynamicTile/PrefabTextureResizer.cs
@@ -4,6 +4,7 @@ using UnityEditor;
 using UnityEngine;
 using System.Collections.Generic;
 using PLATEAU.Util;
+using UnityEngine.Rendering;
 
 namespace PLATEAU.DynamicTile
 {
@@ -85,9 +86,9 @@ namespace PLATEAU.DynamicTile
             textureImporter.textureType = TextureImporterType.Default;
             textureImporter.SaveAndReimport();
 
-            var newTexture = new Texture2D(newWidth, newHeight, sourceTexture.format, textureImporter.mipmapEnabled);
+            var newTexture = new Texture2D(newWidth, newHeight, TextureFormat.RGBA32 /*非圧縮フォーマットを使うこと*/, textureImporter.mipmapEnabled);
             newTexture.name = sourceTexture.name + $"_{zoomLevel}";
-            ResizeTexture(sourceTexture, ref newTexture);
+            ResizeTexture(sourceTexture, newTexture);
 
             // 保存先のディレクトリを作成 (解像度ごとに異なるフォルダに保存)
             string directoryPath = AssetPathUtil.GetFullPath(saveDirectory);
@@ -132,16 +133,26 @@ namespace PLATEAU.DynamicTile
         /// </summary>
         /// <param name="source">ソースTexture2D</param>
         /// <param name="dest">変換用Texture2D</param>
-        private void ResizeTexture(Texture2D source, ref Texture2D dest)
+        private void ResizeTexture(Texture2D source, Texture2D dest)
         {
             RenderTexture rt = RenderTexture.GetTemporary(dest.width, dest.height);
             Graphics.Blit(source, rt);
 
-            RenderTexture.active = rt;
-            dest.ReadPixels(new Rect(0, 0, dest.width, dest.height), 0, 0);
-            dest.Apply();
+            AsyncGPUReadback.Request(rt, 0, request =>
+            {
+                if (request.hasError)
+                {
+                    Debug.LogError("GPU Readback にエラーが発生しました。");
+                    return;
+                }
 
-            RenderTexture.active = null;
+                // リクエストの成功を待たないと、LoadTextureDataに失敗する場合があります。データをTexture2Dにロードします。
+                // この時点ではまだGPUメモリ上にある可能性があるため、GetData<byte>()でCPU側にコピーします。
+                dest.LoadRawTextureData(request.GetData<byte>());
+                dest.Apply();
+            });
+
+            AsyncGPUReadback.WaitAllRequests();
             RenderTexture.ReleaseTemporary(rt);
         }
 

--- a/Runtime/DynamicTile/AddressableLoader.cs
+++ b/Runtime/DynamicTile/AddressableLoader.cs
@@ -184,49 +184,7 @@ namespace PLATEAU.DynamicTile
             
             return "";
         }
-
-        /// <summary>
-        /// カタログのローカルパスを取得します。
-        /// </summary>
-        /// <returns></returns>
-        // private string GetLocalCatalogPath()
-        // {
-        //     foreach (var resourceLocator in Addressables.ResourceLocators)
-        //     {
-        //         foreach (var key in resourceLocator.Keys)
-        //         {
-        //             if (!resourceLocator.Locate(key, typeof(object), out var locations))
-        //             {
-        //                 continue;
-        //             }
-        //             foreach (var loc in locations)
-        //             {
-        //                 string internalId = RemoveFileProtocol(loc.InternalId);
-        //
-        //                 if (!internalId.EndsWith(".bundle"))
-        //                 {
-        //                     continue;
-        //                 }
-        //
-        //                 string dir = Path.GetDirectoryName(internalId);
-        //                 if (string.IsNullOrEmpty(dir))
-        //                 {
-        //                     Debug.LogError("カタログファイルのディレクトリが取得できません");
-        //                     return "";
-        //                 }
-        //                 // カタログファイルのパスを取得
-        //                 var catalogFiles = Directory.GetFiles(dir, "catalog_*.json");
-        //                 if (catalogFiles.Length == 0)
-        //                 {
-        //                     Debug.LogError("カタログファイルが見つかりません");
-        //                     return "";
-        //                 }
-        //                 return catalogFiles[0];
-        //             }
-        //         }
-        //     }
-        //     return "";
-        // }
+        
 
         /// <summary>
         /// meta情報をロードします。

--- a/Runtime/DynamicTile/PLATEAURuntimeCameraTracker.cs
+++ b/Runtime/DynamicTile/PLATEAURuntimeCameraTracker.cs
@@ -35,7 +35,7 @@ namespace PLATEAU.DynamicTile
             }
             catch (System.Exception e)
             {
-                Debug.LogError($"Failed to initialize PLATEAURuntimeCameraTracker: {e.Message}");
+                Debug.LogError($"Failed to initialize PLATEAURuntimeCameraTracker: {e.Message}\n{e.StackTrace}");
                 return;
             }
 

--- a/Runtime/DynamicTile/PLATEAURuntimeCameraTracker.cs
+++ b/Runtime/DynamicTile/PLATEAURuntimeCameraTracker.cs
@@ -35,7 +35,7 @@ namespace PLATEAU.DynamicTile
             }
             catch (System.Exception e)
             {
-                Debug.LogError($"Failed to initialize PLATEAURuntimeCameraTracker: {e.Message}\n{e.StackTrace}");
+                Debug.LogError($"Failed to initialize PLATEAURuntimeCameraTracker: {e}");
                 return;
             }
 


### PR DESCRIPTION
﻿## 🔗 関連リンク

## ✅ レビュー前確認項目
- [ ] ユニットテストが通ること
- [ ] ビルドが通ること

<!-- 社内の人向け: 以下の項目は、開発当初のストーリー設計書通りであれば省略可能です。
                 設計に変更があった場合のみ、変更点を周知するために記載してください。 -->

## 🚀 実装内容
動的タイルに関する次の2つのバグを修正した。
- AddressableのGroupsの設定画面を開き、Play Mode ScriptがUse Asset Database(fastest)であるときに動的タイル化するとタイルのロードに失敗するバグを修正した。
  - なお、動的タイルタブの設定はデフォルトで行う。
<img width="860" height="391" alt="image" src="https://github.com/user-attachments/assets/b4f8e342-9c2a-41b4-972c-d47d674794d2" />

- メニューバーでPLATEAU→Debug→Pack PLATEAU SDK to tarballで出力したtarball形式のプラグインを新規プロジェクトに導入し、テクスチャ付きの地物をインポートして動的タイル化すると失敗するバグを修正した。
  - なお、バグの再現手順にはtarballであることとテクスチャ付きであることが両方必要である。
## 🌐 影響範囲
- タイルロードに関して：タイルがプロジェクトの内部にあるときは、カタログを利用せずAddressableシステムから直接メタデータをロードするようにした
- タイル化時のテクスチャリサイズのコードに変更を加えた
## 🛠️ 動作確認
- 上記「実装内容」で記載のとおり操作して成功することを確認する
## ⚠️ 懸念点
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **新機能**
  * カタログパスが空の場合、Addressable Groupsから直接メタストアを読み込む機能を追加しました。

* **バグ修正**
  * テクスチャリサイズ処理を非同期GPUリードバック方式に変更し、安定性とパフォーマンスを向上させました。

* **改善**
  * エラーログに例外のスタックトレースを追加し、デバッグ情報を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->