### PR TITLE
動的タイルのバグを修正

### DIFF
--- a/Editor/Addressables/AddressablesUtility.cs
+++ b/Editor/Addressables/AddressablesUtility.cs
@@ -317,15 +317,28 @@ namespace PLATEAU.Editor.Addressables
                 Debug.Log("Addressablesのキャッシュをクリアしました。");
             }
 
-            // Addressablesのビルドを実行
-            UnityEditor.AddressableAssets.Settings.AddressableAssetSettings.BuildPlayerContent(out var result);
-            if (!string.IsNullOrEmpty(result.Error))
+            // Addressablesのバージョン1.22の既知のバグを回避するため、GenerateBuildLayoutを一時的にオフにします。
+            // これをしないとビルドに成功しているのにエラーメッセージが出現します。
+            // バージョン2.0.8以降であればこの処理は不要です。
+            bool prevGenerateBuildLayout = ProjectConfigData.GenerateBuildLayout;
+            ProjectConfigData.GenerateBuildLayout = false;
+
+            try
             {
-                Debug.LogError($"Addressablesのビルドでエラーが発生しました: {result.Error}");
+                // Addressablesのビルドを実行
+                AddressableAssetSettings.BuildPlayerContent(out var result);
+                if (!string.IsNullOrEmpty(result.Error))
+                {
+                    Debug.LogError($"Addressablesのビルドでエラーが発生しました: {result.Error}");
+                }
+                else
+                {
+                    Debug.Log("Addressablesのビルドが完了しました。");
+                }
             }
-            else
+            finally
             {
-                Debug.Log("Addressablesのビルドが完了しました。");
+                ProjectConfigData.GenerateBuildLayout = prevGenerateBuildLayout;
             }
         }
 

--- a/Editor/Addressables/AddressablesUtility.cs
+++ b/Editor/Addressables/AddressablesUtility.cs
@@ -119,6 +119,10 @@ namespace PLATEAU.Editor.Addressables
                     entry.SetLabel(label, true);
                 }
             }
+            
+            EditorUtility.SetDirty(settings);
+            EditorUtility.SetDirty(group);
+            AssetDatabase.SaveAssets();
         }
 
         /// <summary>

--- a/Editor/Addressables/AddressablesUtility.cs
+++ b/Editor/Addressables/AddressablesUtility.cs
@@ -3,7 +3,6 @@ using UnityEditor.AddressableAssets;
 using UnityEditor.AddressableAssets.Settings;
 using UnityEngine;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using UnityEditor.AddressableAssets.Settings.GroupSchemas;
 

--- a/Editor/CityImport/PackageImportConfigGUIs/Components/DynamicTileConfigGUI.cs
+++ b/Editor/CityImport/PackageImportConfigGUIs/Components/DynamicTileConfigGUI.cs
@@ -1,5 +1,4 @@
 using PLATEAU.CityImport.Config;
-using PLATEAU.Editor.CityImport.PackageImportConfigGUIs;
 using PLATEAU.Editor.Window.Common;
 using UnityEditor;
 using UnityEngine;

--- a/Editor/CityImport/PackageImportConfigGUIs/Extendables/Components/MeshColliderSetGUI.cs
+++ b/Editor/CityImport/PackageImportConfigGUIs/Extendables/Components/MeshColliderSetGUI.cs
@@ -1,6 +1,5 @@
 using PLATEAU.CityImport.Config.PackageImportConfigs;
 using PLATEAU.Editor.Window.Common;
-using UnityEditor;
 
 namespace PLATEAU.Editor.CityImport.PackageImportConfigGUIs.Extendables.Components
 {

--- a/Editor/CityImport/PackageImportConfigGUIs/Extendables/Components/SetAttrInfoGUI.cs
+++ b/Editor/CityImport/PackageImportConfigGUIs/Extendables/Components/SetAttrInfoGUI.cs
@@ -1,6 +1,5 @@
 using PLATEAU.CityImport.Config.PackageImportConfigs;
 using PLATEAU.Editor.Window.Common;
-using UnityEditor;
 
 namespace PLATEAU.Editor.CityImport.PackageImportConfigGUIs.Extendables.Components
 {

--- a/Editor/CityImport/PackageImportConfigGUIs/Extendables/PackageImportConfigOverrideGUI.cs
+++ b/Editor/CityImport/PackageImportConfigGUIs/Extendables/PackageImportConfigOverrideGUI.cs
@@ -2,7 +2,6 @@ using PLATEAU.CityImport.Config.PackageImportConfigs;
 using PLATEAU.Dataset;
 using PLATEAU.Editor.CityImport.PackageImportConfigGUIs.Extendables.Components;
 using PLATEAU.Editor.Window.Common;
-using UnityEditor;
 
 namespace PLATEAU.Editor.CityImport.PackageImportConfigGUIs.Extendables
 {

--- a/Editor/CityImport/PackageImportConfigGUIs/PackageImportConfigGUI.cs
+++ b/Editor/CityImport/PackageImportConfigGUIs/PackageImportConfigGUI.cs
@@ -4,7 +4,6 @@ using PLATEAU.Dataset;
 using PLATEAU.Editor.CityImport.PackageImportConfigGUIs.Components;
 using PLATEAU.Editor.CityImport.PackageImportConfigGUIs.Extendables;
 using PLATEAU.Editor.Window.Common;
-using UnityEditor;
 
 namespace PLATEAU.Editor.CityImport.PackageImportConfigGUIs
 {

--- a/Editor/CityInfo/PLATEAUCityObjectGroupEditor.cs
+++ b/Editor/CityInfo/PLATEAUCityObjectGroupEditor.cs
@@ -1,5 +1,4 @@
-﻿using MessagePack;
-using PLATEAU.CityInfo;
+﻿using PLATEAU.CityInfo;
 using PLATEAU.Editor.Window.Common;
 using PLATEAU.PolygonMesh;
 using PLATEAU.Util;

--- a/Editor/DynamicTile/DynamicTileExporter.cs
+++ b/Editor/DynamicTile/DynamicTileExporter.cs
@@ -10,13 +10,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using UnityEditor;
-using UnityEditor.AddressableAssets;
 using UnityEditor.SceneManagement;
 using UnityEngine;
-using UnityEngine.AddressableAssets;
-using UnityEngine.AddressableAssets.Initialization;
 
 namespace PLATEAU.DynamicTile
 {

--- a/Editor/DynamicTile/DynamicTileExporter.cs
+++ b/Editor/DynamicTile/DynamicTileExporter.cs
@@ -46,7 +46,7 @@ namespace PLATEAU.DynamicTile
             
             PLATEAUEditorEventListener.disableProjectChangeEvent = true; // タイル生成中フラグを設定
             
-            // DynamicTile管理用Managerを破棄
+            // DynamicTile管理用Managerがすでにあるなら、後で作り直すので破棄
             var manager = GameObject.FindObjectOfType<PLATEAUTileManager>();
             if (manager != null)
             {
@@ -374,8 +374,12 @@ namespace PLATEAU.DynamicTile
             {
                 PLATEAUEditorEventListener.disableProjectChangeEvent = false; // タイル生成中フラグを設定
 
-                var manager = GameObject.FindObjectOfType<PLATEAUTileManager>();
-                if (manager != null)
+                var manager = GameObject.FindObjectsOfType<PLATEAUTileManager>().FirstOrDefault(m => m!= null);
+                if (manager == null)
+                {
+                    Debug.LogError("manager is null.");
+                }
+                else
                 {
                     PLATEAUSceneViewCameraTracker.Initialize();
                     manager.InitializeTiles().ContinueWithErrorCatch(); // タイルの初期化

--- a/Editor/DynamicTile/DynamicTileExporter.cs
+++ b/Editor/DynamicTile/DynamicTileExporter.cs
@@ -325,7 +325,7 @@ namespace PLATEAU.DynamicTile
         /// DynamicTileの完了処理を行います（メタストア保存、Addressable処理、マネージャー設定）
         /// 成否を返します。
         /// </summary>
-        public bool CompleteProcessing()
+        public bool CompleteProcessing(PLATEAUInstancedCityModel sourceModel)
         {
             if (Context == null || !Context.IsValid())
             {
@@ -338,16 +338,20 @@ namespace PLATEAU.DynamicTile
                 // メタデータを保存
                 SaveAndRegisterMetaData(Context.MetaStore, Context.AssetConfig.AssetPath, Context.AddressableGroupName);
                 
+                // managerを生成
+                var managerObj = new GameObject("DynamicTileManager");
+                var manager = managerObj.AddComponent<PLATEAUTileManager>();
+                manager.Init(sourceModel);
+                
                 // アセットバンドルのビルド時に「シーンを保存しますか」とダイアログが出てくるのがうっとうしいので前もって保存して抑制します。
                 // 保存については処理前にダイアログでユーザーに了承を得ています。
+                EditorUtility.SetDirty(manager);
                 EditorSceneManager.SaveOpenScenes();                
 
                 // Addressablesのビルドを実行
                 AddressablesUtility.BuildAddressables(false);
 
-                // managerを生成
-                var managerObj = new GameObject("DynamicTileManager");
-                var manager = managerObj.AddComponent<PLATEAUTileManager>();
+                
 
                 if (Context.IsExcludeAssetFolder)
                 {
@@ -364,7 +368,7 @@ namespace PLATEAU.DynamicTile
                     // 一時フォルダーを削除
                     CleanupTempFolder();
 
-                    // 上で自動保存しておいてTileManagerの生成を保存しないのは中途半端なのでここでも保存します。
+                    // 上で自動保存しておいてカタログパスを保存しないのは中途半端なのでここでも保存します。
                     EditorSceneManager.SaveOpenScenes();
                 }
 

--- a/Editor/DynamicTile/DynamicTileExporter.cs
+++ b/Editor/DynamicTile/DynamicTileExporter.cs
@@ -343,7 +343,7 @@ namespace PLATEAU.DynamicTile
                 SaveAndRegisterMetaData(Context.MetaStore, Context.AssetConfig.AssetPath, Context.AddressableGroupName);
 
                 // Addressablesのビルドを実行
-                AddressablesUtility.BuildAddressables(true);
+                AddressablesUtility.BuildAddressables(false);
 
                 // managerを生成
                 var managerObj = new GameObject("DynamicTileManager");

--- a/Editor/DynamicTile/DynamicTileExporter.cs
+++ b/Editor/DynamicTile/DynamicTileExporter.cs
@@ -10,9 +10,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using UnityEditor;
+using UnityEditor.AddressableAssets;
 using UnityEditor.SceneManagement;
 using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.AddressableAssets.Initialization;
 
 namespace PLATEAU.DynamicTile
 {
@@ -258,7 +262,6 @@ namespace PLATEAU.DynamicTile
             dataPath = dataPath.Replace('\\', '/');
             
             AssetDatabase.CreateAsset(metaStore, dataPath);
-            AssetDatabase.SaveAssets();
 
             // メタデータをAddressableに登録
             AddressablesUtility.RegisterAssetAsAddressable(

--- a/Editor/DynamicTile/DynamicTileExporter.cs
+++ b/Editor/DynamicTile/DynamicTileExporter.cs
@@ -341,6 +341,10 @@ namespace PLATEAU.DynamicTile
             {
                 // メタデータを保存
                 SaveAndRegisterMetaData(Context.MetaStore, Context.AssetConfig.AssetPath, Context.AddressableGroupName);
+                
+                // アセットバンドルのビルド時に「シーンを保存しますか」とダイアログが出てくるのがうっとうしいので前もって保存して抑制します。
+                // 保存については処理前にダイアログでユーザーに了承を得ています。
+                EditorSceneManager.SaveOpenScenes();                
 
                 // Addressablesのビルドを実行
                 AddressablesUtility.BuildAddressables(false);
@@ -363,6 +367,9 @@ namespace PLATEAU.DynamicTile
                     
                     // 一時フォルダーを削除
                     CleanupTempFolder();
+
+                    // 上で自動保存しておいてTileManagerの生成を保存しないのは中途半端なのでここでも保存します。
+                    EditorSceneManager.SaveOpenScenes();
                 }
 
                 Dialogue.Display("動的タイルの保存が完了しました！", "OK");

--- a/Editor/DynamicTile/DynamicTileProcessingContext.cs
+++ b/Editor/DynamicTile/DynamicTileProcessingContext.cs
@@ -98,14 +98,10 @@ namespace PLATEAU.DynamicTile
         private string GenerateAddressableGroupName()
         {
             var groupName = AddressableGroupBaseName;
-            if (IsExcludeAssetFolder)
-            {
-                // Assets外のパスを指定する場合はグループを分ける
-                var directoryName = Path.GetFileName(
-                    BuildFolderPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-                var sanitizedDirectoryName = System.Text.RegularExpressions.Regex.Replace(directoryName, @"[^\w\-_]", "_");
-                groupName += "_" + sanitizedDirectoryName;
-            }
+            var directoryName = Path.GetFileName(
+                BuildFolderPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            var sanitizedDirectoryName = System.Text.RegularExpressions.Regex.Replace(directoryName, @"[^\w\-_]", "_");
+            groupName += "_" + sanitizedDirectoryName;
             return groupName;
         }
         

--- a/Editor/DynamicTile/ImportToDynamicTile.cs
+++ b/Editor/DynamicTile/ImportToDynamicTile.cs
@@ -3,7 +3,6 @@ using PLATEAU.CityImport.Config;
 using PLATEAU.CityImport.Import;
 using PLATEAU.DynamicTile;
 using PLATEAU.Util;
-using PLATEAU.Util.Async;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Editor/DynamicTile/ImportToDynamicTile.cs
+++ b/Editor/DynamicTile/ImportToDynamicTile.cs
@@ -55,9 +55,7 @@ namespace PLATEAU.Editor.DynamicTile
             };
             
             // インポートを実行
-            var task = CityImporter.ImportAsync(config, progressDisplay, cancelToken, postGmlImport);
-
-            await task;
+            await CityImporter.ImportAsync(config, progressDisplay, cancelToken, postGmlImport);
             
             // 事後処理
             try

--- a/Editor/DynamicTile/ImportToDynamicTile.cs
+++ b/Editor/DynamicTile/ImportToDynamicTile.cs
@@ -3,6 +3,7 @@ using PLATEAU.CityImport.Config;
 using PLATEAU.CityImport.Import;
 using PLATEAU.DynamicTile;
 using PLATEAU.Util;
+using PLATEAU.Util.Async;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Editor/DynamicTile/ImportToDynamicTile.cs
+++ b/Editor/DynamicTile/ImportToDynamicTile.cs
@@ -1,6 +1,7 @@
 using PLATEAU.CityAdjust.ChangeActive;
 using PLATEAU.CityImport.Config;
 using PLATEAU.CityImport.Import;
+using PLATEAU.CityInfo;
 using PLATEAU.DynamicTile;
 using PLATEAU.Util;
 using System.Collections.Generic;
@@ -74,14 +75,15 @@ namespace PLATEAU.Editor.DynamicTile
             };
             
             // インポートを実行
-            await CityImporter.ImportAsync(config, progressDisplay, cancelToken, postGmlImport);
+            var rootTrans = await CityImporter.ImportAsync(config, progressDisplay, cancelToken, postGmlImport);
             
             // 事後処理
             try
             {
                 progressDisplay?.SetProgress(TileProgressTitle, 90f, "最終処理を実行中...");
                 // 実際の完了処理をDynamicTileExporterに委譲
-                dynamicTileExporter.CompleteProcessing();
+                var cityModel = rootTrans.GetComponent<PLATEAUInstancedCityModel>();
+                dynamicTileExporter.CompleteProcessing(cityModel);
             }catch (System.OperationCanceledException)
             {
                 Debug.Log("動的タイルインポート処理がキャンセルされました。");

--- a/Editor/DynamicTile/ImportToDynamicTile.cs
+++ b/Editor/DynamicTile/ImportToDynamicTile.cs
@@ -7,7 +7,9 @@ using PLATEAU.Util.Async;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using UnityEditor.SceneManagement;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace PLATEAU.Editor.DynamicTile
 {
@@ -30,6 +32,23 @@ namespace PLATEAU.Editor.DynamicTile
         /// </summary>
         public async Task ExecAsync(CityImportConfig config, CancellationToken cancelToken)
         {
+            // アセットバンドルのビルド時はシーンの保存が求められますが、
+            // 処理の途中で「保存しますか」と聞くよりも最初に聞いた方が良いので聞きます。
+            if (SceneManager.GetActiveScene().isDirty)
+            {
+                bool saveScene = Dialogue.Display("シーンの保存が必要です。保存して続行しますか？", "続行", "キャンセル");
+                
+                if (saveScene)
+                {
+                    EditorSceneManager.SaveOpenScenes();
+                }
+                else
+                {
+                    Debug.Log("シーンの保存が拒否されたため処理を中止します。");
+                    return;
+                }
+            }
+            
             // 動的タイルのバリデーション
             if (!config.ValidateForTile())
             {

--- a/Editor/DynamicTile/PLATEAUSceneViewCameraTracker.cs
+++ b/Editor/DynamicTile/PLATEAUSceneViewCameraTracker.cs
@@ -1,8 +1,6 @@
 ﻿using PLATEAU.Util.Async;
 using System.Threading.Tasks;
 using UnityEditor;
-using UnityEditor.Build;
-using UnityEditor.Build.Reporting;
 using UnityEditor.Compilation;
 using UnityEditor.SceneManagement;
 using UnityEngine;

--- a/Editor/DynamicTile/PLATEAUTileManagerEditor.cs
+++ b/Editor/DynamicTile/PLATEAUTileManagerEditor.cs
@@ -101,7 +101,7 @@ namespace PLATEAU.DynamicTile
                 EditorGUILayout.LabelField($"Instantiate Coroutine: ", tileManager.IsCoroutineRunning? "Running" : "Complete", new GUIStyle(EditorStyles.label) { normal = { textColor = tileManager.IsCoroutineRunning ? Color.red : Color.green } });
 
                 // Zoom Levelごとのロード距離
-                foreach (var dist in tileManager.loadDistances.LoadDistances)
+                foreach (var dist in tileManager.loadDistances.loadDistances)
                 {
                     var zoomLevel = dist.ZoomLevel;
                     GUILayout.Box("", GUILayout.ExpandWidth(true), GUILayout.Height(3));

--- a/Editor/DynamicTile/PLATEAUTileManagerEditor.cs
+++ b/Editor/DynamicTile/PLATEAUTileManagerEditor.cs
@@ -93,7 +93,7 @@ namespace PLATEAU.DynamicTile
                 }
 
                 // Tile情報の表示
-                var dynamicTiles = tileManager.DynamicTiles;
+                var dynamicTiles = tileManager.TileCollection;
                 EditorGUILayout.LabelField($"State: ", tileManager.State.ToString());
                 EditorGUILayout.LabelField($"TileCreationInProgress: ", PLATEAUEditorEventListener.disableProjectChangeEvent.ToString());
                 EditorGUILayout.IntField($"Tile num: ", dynamicTiles.Count);
@@ -101,13 +101,12 @@ namespace PLATEAU.DynamicTile
                 EditorGUILayout.LabelField($"Instantiate Coroutine: ", tileManager.IsCoroutineRunning? "Running" : "Complete", new GUIStyle(EditorStyles.label) { normal = { textColor = tileManager.IsCoroutineRunning ? Color.red : Color.green } });
 
                 // Zoom Levelごとのロード距離
-                foreach (var dist in tileManager.loadDistances)
+                foreach (var dist in tileManager.loadDistances.LoadDistances)
                 {
-                    var zoomLevel = dist.Key;
-                    var (min, max) = dist.Value;
+                    var zoomLevel = dist.ZoomLevel;
                     GUILayout.Box("", GUILayout.ExpandWidth(true), GUILayout.Height(3));
                     EditorGUILayout.IntField($"ZoomLevel: ", zoomLevel);
-                    EditorGUILayout.Vector2Field($"Load Distance: ", new Vector2(min, max));
+                    EditorGUILayout.Vector2Field($"Load Distance: ", new Vector2(dist.MinDistance, dist.MaxDistance));
                 }
 
                 // 各タイルの情報を表示
@@ -147,7 +146,7 @@ namespace PLATEAU.DynamicTile
             isShowingZoomLevel = false;
         }
 
-        private Dictionary<int, Color> zoomLevelColors = new Dictionary<int, Color>
+        private readonly Dictionary<int, Color> zoomLevelColors = new Dictionary<int, Color>
         {
             { 9, Color.red },
             { 10, Color.yellow },
@@ -171,7 +170,7 @@ namespace PLATEAU.DynamicTile
             }
 
             PLATEAUTileManager tileManager = (PLATEAUTileManager)target;
-            foreach (var tile in tileManager.DynamicTiles)
+            foreach (var tile in tileManager.TileCollection)
             {
                 if (tile.NextLoadState == LoadState.Load )
                 {
@@ -197,7 +196,7 @@ namespace PLATEAU.DynamicTile
         private void ShowBounds()
         {
             PLATEAUTileManager tileManager = (PLATEAUTileManager)target;
-            foreach (var tile in tileManager.DynamicTiles)
+            foreach (var tile in tileManager.TileCollection)
             {
                 DebugEx.DrawBounds(tile.Extent, Color.red, 3f);
             }

--- a/Editor/DynamicTile/PrefabTextureResizer.cs
+++ b/Editor/DynamicTile/PrefabTextureResizer.cs
@@ -1,11 +1,8 @@
 ﻿using System.IO;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using System.Collections.Generic;
 using PLATEAU.Util;
-using System.Threading.Tasks;
-using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 
 namespace PLATEAU.DynamicTile

--- a/Editor/RoadNetwork/AddSystem/RnSkeletonHandles.cs
+++ b/Editor/RoadNetwork/AddSystem/RnSkeletonHandles.cs
@@ -1,12 +1,8 @@
-﻿using NetTopologySuite.Operation.Valid;
-using PLATEAU.RoadNetwork;
-using PLATEAU.RoadNetwork.Structure;
+﻿using PLATEAU.RoadNetwork;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.Splines;
 
 namespace PLATEAU.Editor.RoadNetwork.AddSystem
 {

--- a/Editor/RoadNetwork/AddSystem/Road/RnRoadAddSystem.cs
+++ b/Editor/RoadNetwork/AddSystem/Road/RnRoadAddSystem.cs
@@ -1,5 +1,4 @@
 ﻿using PLATEAU.Editor.RoadNetwork.AddSystem;
-using PLATEAU.RoadAdjust.RoadMarking;
 using PLATEAU.RoadNetwork;
 using PLATEAU.RoadNetwork.AddSystem;
 using PLATEAU.RoadNetwork.Structure;

--- a/Editor/RoadNetwork/AddSystem/Road/RnRoadEdgeMaker.cs
+++ b/Editor/RoadNetwork/AddSystem/Road/RnRoadEdgeMaker.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.Splines;
 
 namespace PLATEAU.RoadNetwork.AddSystem
 {

--- a/Editor/RoadNetwork/CodeGen/RnDataSerializeCodeGen.cs
+++ b/Editor/RoadNetwork/CodeGen/RnDataSerializeCodeGen.cs
@@ -1,14 +1,10 @@
-﻿using PLATEAU.CityInfo;
-using PLATEAU.RoadNetwork.Data;
-using PLATEAU.RoadNetwork.Structure;
+﻿using PLATEAU.RoadNetwork.Structure;
 using PLATEAU.Util;
 using System;
-using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace PLATEAU.Editor.RoadNetwork.CodeGen

--- a/Editor/RoadNetwork/EditingSystem/RoadLaneDetailEditor.cs
+++ b/Editor/RoadNetwork/EditingSystem/RoadLaneDetailEditor.cs
@@ -5,7 +5,6 @@ using PLATEAU.RoadAdjust.RoadNetworkToMesh;
 using PLATEAU.RoadNetwork.Structure;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.Splines;
 

--- a/Editor/RoadNetwork/EditingSystemSubMod/LaneLineGizmoGenerator.cs
+++ b/Editor/RoadNetwork/EditingSystemSubMod/LaneLineGizmoGenerator.cs
@@ -1,13 +1,8 @@
 ﻿using PLATEAU.RoadNetwork.Structure;
-using PLATEAU.Util;
-using PLATEAU.Util.GeoGraph;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.Assertions;
-using UnityEngine.Rendering;
 
 namespace PLATEAU.Editor.RoadNetwork.EditingSystemSubMod
 {

--- a/Editor/RoadNetwork/EditingSystemSubMod/SplineSystems/RnSplineSystemBase.cs
+++ b/Editor/RoadNetwork/EditingSystemSubMod/SplineSystems/RnSplineSystemBase.cs
@@ -1,8 +1,6 @@
-﻿using PLATEAU.RoadNetwork.Data;
-using PLATEAU.RoadNetwork.Structure;
+﻿using PLATEAU.RoadNetwork.Structure;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.Splines;
 

--- a/Editor/RoadNetwork/EditingSystemSubMod/SplineSystems/SplineCreateHandles.cs
+++ b/Editor/RoadNetwork/EditingSystemSubMod/SplineSystems/SplineCreateHandles.cs
@@ -1,8 +1,5 @@
-﻿using NUnit.Framework;
-using PLATEAU.Util.GeoGraph;
-using System;
+﻿using PLATEAU.Util.GeoGraph;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Splines;

--- a/Editor/RoadNetwork/EditingSystemSubMod/SplineSystems/SplineEditorCore.cs
+++ b/Editor/RoadNetwork/EditingSystemSubMod/SplineSystems/SplineEditorCore.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Unity.Mathematics;
+﻿using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.Splines;
 

--- a/Editor/RoadNetwork/Exporter/RoadNetworkElementLink.cs
+++ b/Editor/RoadNetwork/Exporter/RoadNetworkElementLink.cs
@@ -1,7 +1,6 @@
 ﻿using PLATEAU.Native;
 using PLATEAU.RoadNetwork.Data;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 namespace PLATEAU.Editor.RoadNetwork.Exporter

--- a/Editor/RoadNetwork/Exporter/RoadNetworkElementNode.cs
+++ b/Editor/RoadNetwork/Exporter/RoadNetworkElementNode.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using PLATEAU.CityInfo;
 using PLATEAU.Native;
 using PLATEAU.RoadNetwork.Data;
 

--- a/Editor/RoadNetwork/RoadNetworkEditTargetSelectButton.cs
+++ b/Editor/RoadNetwork/RoadNetworkEditTargetSelectButton.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using PLATEAU.Util;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.Assertions;
 
 namespace PLATEAU.Editor.RoadNetwork
 {

--- a/Editor/RoadNetwork/Structure/PLATEAURnStructureModelEditor.cs
+++ b/Editor/RoadNetwork/Structure/PLATEAURnStructureModelEditor.cs
@@ -1,5 +1,4 @@
-﻿using PLATEAU.Editor.RoadNetwork.EditingSystem;
-using PLATEAU.RoadNetwork.Structure;
+﻿using PLATEAU.RoadNetwork.Structure;
 using PLATEAU.RoadNetwork.Structure.Drawer;
 using PLATEAU.RoadNetwork.Util;
 using PLATEAU.Util;

--- a/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
+++ b/Editor/RoadNetwork/Structure/RnModelDebugEditorWindow.cs
@@ -1,5 +1,4 @@
 ﻿using PLATEAU.RoadNetwork;
-using PLATEAU.RoadNetwork.Data;
 using PLATEAU.RoadNetwork.Structure;
 using PLATEAU.RoadNetwork.Util;
 using PLATEAU.Util;

--- a/Editor/Util/PropertyDrawersEditor.cs
+++ b/Editor/Util/PropertyDrawersEditor.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
 
 /// PropertyDrawersとセットで使用する

--- a/Editor/Window/Main/Tab/RoadAdjustGui.cs
+++ b/Editor/Window/Main/Tab/RoadAdjustGui.cs
@@ -1,7 +1,6 @@
 ﻿using PLATEAU.Editor.Window.Common;
 using PLATEAU.Editor.Window.Main.Tab.RoadGuiParts;
 using PLATEAU.Util;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;

--- a/Editor/Window/Main/Tab/RoadGUIParts/RoadAddPanel.cs
+++ b/Editor/Window/Main/Tab/RoadGUIParts/RoadAddPanel.cs
@@ -1,7 +1,5 @@
 ﻿using PLATEAU.Editor.RoadNetwork;
 using PLATEAU.Editor.RoadNetwork.AddSystem;
-using PLATEAU.Editor.RoadNetwork.EditingSystem;
-using System;
 using UnityEngine;
 using UnityEngine.UIElements;
 

--- a/Editor/Window/Main/Tab/RoadGUIParts/RoadExportPanel.cs
+++ b/Editor/Window/Main/Tab/RoadGUIParts/RoadExportPanel.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using UnityEngine;
 using UnityEngine.UIElements;
 using UnityEditor;

--- a/Runtime/CityAdjust/ConvertToAsset/ConvertToAsset.cs
+++ b/Runtime/CityAdjust/ConvertToAsset/ConvertToAsset.cs
@@ -275,7 +275,7 @@ namespace PLATEAU.CityAdjust.ConvertToAsset
         /// <returns>アセットファイルの場合true</returns>
         private bool IsAssetFile(string extension)
         {
-            // .metaファイル以外をアセットとして扱う
+            // 漏れがないほうが重要なので、.metaファイル以外はすべてアセットとみなします
             return extension != ".meta";
         }
     }

--- a/Runtime/CityAdjust/ConvertToAsset/ConvertToAsset.cs
+++ b/Runtime/CityAdjust/ConvertToAsset/ConvertToAsset.cs
@@ -147,6 +147,7 @@ namespace PLATEAU.CityAdjust.ConvertToAsset
         /// </summary>
         private void ImportAndAdjustFbxAssets(ConvertToAssetConfig conf, string fbxNameWithoutExtension)
         {
+#if UNITY_EDITOR
             var allAssets = GetAllAssetsInDirectory(conf.AssetPath);
             
             PLATEAUAssetPostProcessor.PostProcessHandler assetProcess = () =>
@@ -186,6 +187,9 @@ namespace PLATEAU.CityAdjust.ConvertToAsset
             
 
             AssetDatabase.Refresh();
+#else 
+            throw new NotImplementedException("ConvertToAssetはランタイムでの実行には未対応です。");
+#endif
         }
 
         /// <summary>

--- a/Runtime/CityImport/AreaSelector/AreaSelectorBehaviour.cs
+++ b/Runtime/CityImport/AreaSelector/AreaSelectorBehaviour.cs
@@ -26,15 +26,26 @@ namespace PLATEAU.CityImport.AreaSelector
     internal class AreaSelectorBehaviour : MonoBehaviour
     {
         [SerializeField] private string prevScenePath;
+        
+        // インポート設定
         private ConfigBeforeAreaSelect confBeforeAreaSelect;
+        
+        // ギズモ表示
         private AreaSelectGizmosDrawer gizmosDrawer;
+        
+        // 範囲選択画面の返し先
         private IAreaSelectResultReceiver areaSelectResultReceiver;
+        
         private GeoReference geoReference;
         private bool prevSceneCameraRotationLocked;
+        
+        // カメラ位置に応じて地図を切り替え
         private GSIMapLoaderZoomSwitch mapLoader;
         private Extent entireExtent;
         #if UNITY_EDITOR
         private EditorWindow prevEditorWindow;
+        
+        // 「メッシュコードから検索」機能
         private GridCodeSearchWindow gridSearchWindow;
         #endif
 

--- a/Runtime/CityImport/Import/CityImporter.cs
+++ b/Runtime/CityImport/Import/CityImporter.cs
@@ -28,13 +28,14 @@ namespace PLATEAU.CityImport.Import
         /// メインスレッドで呼ぶ必要があります。
         /// GMLを1つ読み込んだあとにしたい処理を<paramref name="postGmlProcessors"/>に渡します。
         /// </summary>
-        public static async Task ImportAsync(CityImportConfig config, IProgressDisplay progressDisplay,
+        /// <returns>設置したゲームオブジェクトのルート</returns>
+        public static async Task<Transform> ImportAsync(CityImportConfig config, IProgressDisplay progressDisplay,
             CancellationToken? token, IEnumerable<IPostGmlImportProcessor> postGmlProcessors = null)
         {
             if (config == null)
             {
                 Debug.LogError("CityImportConfig が null です。");
-                return;
+                return null;
             }
             
             progressDisplay ??= new DummyProgressDisplay();
@@ -44,7 +45,7 @@ namespace PLATEAU.CityImport.Import
             if ((datasetSourceConfig is DatasetSourceConfigLocal localConf) && (!Directory.Exists(localConf.LocalSourcePath)))
             {
                 Debug.LogError($"インポート元パスが存在しません。 sourcePath = {localConf.LocalSourcePath}");
-                return;
+                return null;
             }
             
             progressDisplay.SetProgress("GMLファイル検索", 10f, "");
@@ -68,7 +69,7 @@ namespace PLATEAU.CityImport.Import
             if (targetGmls == null || targetGmls.Count <= 0)
             {
                 Debug.LogError("該当するGMLファイルがありません。");
-                return;
+                return null;
             }
 
             foreach (var gml in targetGmls)
@@ -163,6 +164,8 @@ namespace PLATEAU.CityImport.Import
                     }
                 }
             }
+
+            return rootTrans;
         }
         
         

--- a/Runtime/DynamicTile/AddressableLoader.cs
+++ b/Runtime/DynamicTile/AddressableLoader.cs
@@ -1,4 +1,5 @@
 using PLATEAU.Util;
+using PLATEAU.Util.Async;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -43,9 +44,9 @@ namespace PLATEAU.DynamicTile
         /// <summary>
         /// 初期化処理
         /// </summary>
-        /// <param name="catalogPath"></param>
         /// <returns></returns>
-        public async Task<PLATEAUDynamicTileMetaStore> InitializeAsync(string catalogPath)
+        public async Task<PLATEAUDynamicTileMetaStore> InitializeAsync(string catalogPath, string metaStoreAddress)
+        
         {
             using var init = Addressables.InitializeAsync(false).ToDisposable();
             await WaitForCompletionAsync(init);
@@ -103,15 +104,15 @@ namespace PLATEAU.DynamicTile
 #endif
             }
 
-            var metaStorePath = await LoadCatalog(catalogPathToUse, DynamicTileLabelName);
-            if (metaStorePath.IsNullOrEmpty())
+            await LoadCatalog(catalogPathToUse);
+            if (metaStoreAddress.IsNullOrEmpty())
             {
-                Debug.LogError("カタログのロードに失敗しました。アドレスが見つかりません。");
+                Debug.LogError("MetaStoreのアドレスがありません。");
                 return null;
             }
 
             // meta情報をロード
-            var metaStore = LoadMetaStore(metaStorePath);
+            var metaStore = LoadMetaStore(metaStoreAddress);
             if (metaStore == null)
             {
                 return null;
@@ -133,17 +134,11 @@ namespace PLATEAU.DynamicTile
         /// カタログファイルをロードします
         /// </summary>
         /// <param name="catalogPath">カタログファイルのパス</param>
-        /// <param name="label">ラベル</param>
-        /// <returns>ロードされたGameObjectのリスト</returns>
-        private async Task<string> LoadCatalog(string catalogPath, string label)
+        private async Task LoadCatalog(string catalogPath)
         {
-            var bundlePath = string.Empty;
 
             // パスを正規化（バックスラッシュをスラッシュに変換）
             catalogPath = catalogPath.Replace('\\', '/');
-
-            // bundlePathを保持
-            bundlePath = Path.GetDirectoryName(catalogPath);
 
             // file://プロトコルを追加
             if (!catalogPath.StartsWith("file://"))
@@ -155,7 +150,7 @@ namespace PLATEAU.DynamicTile
             if (string.IsNullOrEmpty(removedProtocolPath) || !File.Exists(removedProtocolPath))
             {
                 Debug.LogError($"カタログファイルが見つかりません: {removedProtocolPath}");
-                return null;
+                return;
             }
 
             // カタログファイルをロード
@@ -165,85 +160,63 @@ namespace PLATEAU.DynamicTile
             if (catalogHandle.Status != AsyncOperationStatus.Succeeded)
             {
                 Debug.LogError($"カタログファイルのロードに失敗しました: {catalogPath}");
-                return null;
+                return;
             }
-
-            // DynamicTileメタ情報のアドレスを取得
-            if (catalogHandle.Result.Locate(label, typeof(PLATEAUDynamicTileMetaStore),
-                    out var scriptableObjectLocations))
-            {
-                foreach (var location in scriptableObjectLocations)
-                {
-                    if (location.Dependencies.Count <= 0)
-                    {
-                        continue;
-                    }
-
-                    if (bundlePath != null)
-                    {
-                        // メタ情報のパスを返す
-                        foreach (var iResourceLocation in location.Dependencies)
-                        {
-                            var fullPath = Path.GetFullPath(iResourceLocation.InternalId);
-                            var dirName = Path.GetDirectoryName(fullPath);
-
-                            // ディレクトリ名が一致するか確認
-                            if (dirName != null && dirName.Contains(bundlePath))
-                            {
-                                return iResourceLocation.InternalId;
-                            }
-                        }
-                    }
-                }
-            }
-
-            return null;
         }
 
 
         /// <summary>
-        /// パスをもとに、meta情報をロードします。
+        /// meta情報をロードします。
         /// </summary>
         /// <returns></returns>
-        private PLATEAUDynamicTileMetaStore LoadMetaStore(string metaStorePath)
+        private PLATEAUDynamicTileMetaStore LoadMetaStore(string metaStoreAddress)
         {
-            PLATEAUDynamicTileMetaStore metaStore = null;
-            try
+            using var handle = Addressables.LoadAssetAsync<PLATEAUDynamicTileMetaStore>(metaStoreAddress).ToDisposable();
+            WaitForCompletionAsync(handle).ContinueWithErrorCatch();
+            if (handle.Status != AsyncOperationStatus.Succeeded)
             {
-                // ファイルの存在確認
-                if (!File.Exists(metaStorePath))
-                {
-                    Debug.LogError($"ファイルが存在しません: {metaStorePath}");
-                    return null;
-                }
-
-                // Addressable経由だとロードできないので、直接ファイルシステムから読み込み
-                var bundle = AssetBundle.LoadFromFile(metaStorePath);
-                if (bundle != null)
-                {
-                    // バンドル内のアセット名をログ出力
-                    string[] assetNames = bundle.GetAllAssetNames();
-                    if (assetNames.Length == 0)
-                    {
-                        Debug.LogWarning($"バンドル内にアセットが見つかりません: {metaStorePath}");
-                        return null;
-                    }
-
-                    metaStore = bundle.LoadAsset<PLATEAUDynamicTileMetaStore>(assetNames[0]);
-                    bundle.Unload(false);
-                }
-                else
-                {
-                    Debug.LogError($"MetaStoreのロードに失敗しました: {metaStorePath}");
-                    return null;
-                }
-            }
-            catch (System.Exception ex)
-            {
-                Debug.LogError($"MetaStoreのロード中にエラーが発生しました: {ex.Message}\n{ex.StackTrace}");
+                Debug.LogError("Failed to load PLATEAUDynamicTileMetaStore: " + metaStoreAddress);
+                return null;
             }
 
-            return metaStore;
+            return handle.Result;
+            // PLATEAUDynamicTileMetaStore metaStore = null;
+            // try
+            // {
+            //     // ファイルの存在確認
+            //     if (!File.Exists(metaStorePath))
+            //     {
+            //         Debug.LogError($"ファイルが存在しません: {metaStorePath}");
+            //         return null;
+            //     }
+            //
+            //     // Addressable経由だとロードできないので、直接ファイルシステムから読み込み
+            //     var bundle = AssetBundle.LoadFromFile(metaStorePath);
+            //     if (bundle != null)
+            //     {
+            //         // バンドル内のアセット名をログ出力
+            //         string[] assetNames = bundle.GetAllAssetNames();
+            //         if (assetNames.Length == 0)
+            //         {
+            //             Debug.LogWarning($"バンドル内にアセットが見つかりません: {metaStorePath}");
+            //             return null;
+            //         }
+            //
+            //         metaStore = bundle.LoadAsset<PLATEAUDynamicTileMetaStore>(assetNames[0]);
+            //         bundle.Unload(false);
+            //     }
+            //     else
+            //     {
+            //         Debug.LogError($"MetaStoreのロードに失敗しました: {metaStorePath}");
+            //         return null;
+            //     }
+            // }
+            // catch (System.Exception ex)
+            // {
+            //     Debug.LogError($"MetaStoreのロード中にエラーが発生しました: {ex.Message}\n{ex.StackTrace}");
+            // }
+            //
+            // return metaStore;
         }
     }
 }

--- a/Runtime/DynamicTile/AddressableLoader.cs
+++ b/Runtime/DynamicTile/AddressableLoader.cs
@@ -1,5 +1,6 @@
 using PLATEAU.Util;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -37,7 +38,7 @@ namespace PLATEAU.DynamicTile
 
             return handle.Result;
         }
-        
+
 
         /// <summary>
         /// 初期化処理
@@ -54,51 +55,65 @@ namespace PLATEAU.DynamicTile
                 return null;
             }
 
-            if (!string.IsNullOrEmpty(catalogPath))
+            // カタログから取得
+            string catalogPathToUse;
+            if (!catalogPath.IsNullOrEmpty())
             {
-                // カタログから取得
-                var metaStorePath = await LoadCatalog(catalogPath, DynamicTileLabelName);
-                if (metaStorePath.IsNullOrEmpty())
-                {
-                    Debug.LogError("カタログのロードに失敗しました。アドレスが見つかりません。");
-                    return null;
-                }
-
-                // meta情報をロード
-                var metaStore = LoadMetaStore(metaStorePath);
-                if (metaStore == null)
-                {
-                    return null;
-                }
-
-                return metaStore;
+                // プロジェクトの外からカタログを取得する場合
+                catalogPathToUse = catalogPath;
             }
             else
             {
-                // catalogPathが空なのでUnityプロジェクト内のAddressable Groupから取得
-                using var handle =
-                    Addressables.LoadResourceLocationsAsync(DynamicTileLabelName, typeof(PLATEAUDynamicTileMetaStore)).ToDisposable();
-                await WaitForCompletionAsync(handle);
+                // 設定されたcatalogPathが空のときはプロジェクトの中からカタログを取得します。
+                // プロジェクト内であれば一見カタログパスなど求めなくてもロード可能に思えますが、
+                // 実際はAddressables.LoadContentCatalogAsync(catalogPath)からカタログを読み直さないと処理を2回したときに1回目のデータが残る不具合が起きます。
+#if UNITY_EDITOR
+                var folderProject = Path.GetDirectoryName(Application.dataPath);
+                var folderBuild = Path.GetFullPath(Path.Combine(folderProject, Addressables.BuildPath));
 
-                if (handle.Status != AsyncOperationStatus.Succeeded || handle.Result.Count == 0)
+                if (!Directory.Exists(folderBuild))
                 {
-                    Debug.LogError($"ラベル '{DynamicTileLabelName}' の PLATEAUDynamicTileMetaStore が見つかりません");
-                    return null;
+                    Debug.LogError("folder not found: " + folderBuild);
                 }
 
-                // 最初に見つかったメタストアを直接ロード
-                using var metaStoreHandle = Addressables.LoadAssetAsync<PLATEAUDynamicTileMetaStore>(handle.Result[0]).ToDisposable();
-                await WaitForCompletionAsync(metaStoreHandle);
+                var catalogFiles = Directory.GetFiles(folderBuild, "catalog_*.json", SearchOption.AllDirectories);
 
-                if (metaStoreHandle.Status != AsyncOperationStatus.Succeeded)
+                if (catalogFiles.Length == 0)
                 {
-                    Debug.LogError("PLATEAUDynamicTileMetaStore のロードに失敗しました");
-                    return null;
+                    Debug.LogError("catalog file is not found.");
                 }
 
-                var metaStore = metaStoreHandle.Result;
-                return metaStore;
+                catalogPathToUse = catalogFiles.OrderByDescending(File.GetLastWriteTimeUtc).FirstOrDefault();
+#else
+                    var folderRuntime = Addressables.RuntimePath;
+                    if (!Directory.Exists(folderRuntime))
+                    {
+                        Debug.LogError("folder not found: " + folderRuntime);
+                    }
+                    var files = Directory.GetFiles(folderRuntime, "catalog_*.json", SearchOption.AllDirectories);
+                    if (files.Length == 0)
+                    {
+                        Debug.LogError("catalog file is not found.");
+                    }
+                    catalogPathToUse = files.OrderByDescending(File.GetLastWriteTimeUtc).FirstOrDefault();
+#endif
             }
+
+            var metaStorePath = await LoadCatalog(catalogPathToUse, DynamicTileLabelName);
+            if (metaStorePath.IsNullOrEmpty())
+            {
+                Debug.LogError("カタログのロードに失敗しました。アドレスが見つかりません。");
+                return null;
+            }
+
+            // meta情報をロード
+            var metaStore = LoadMetaStore(metaStorePath);
+            if (metaStore == null)
+            {
+                return null;
+            }
+
+            return metaStore;
         }
 
         /// <summary>
@@ -165,7 +180,7 @@ namespace PLATEAU.DynamicTile
                         // メタ情報のパスを返す
                         foreach (var iResourceLocation in location.Dependencies)
                         {
-                            var fullPath = iResourceLocation.InternalId;
+                            var fullPath = Path.GetFullPath(iResourceLocation.InternalId);
                             var dirName = Path.GetDirectoryName(fullPath);
 
                             // ディレクトリ名が一致するか確認

--- a/Runtime/DynamicTile/AddressableLoader.cs
+++ b/Runtime/DynamicTile/AddressableLoader.cs
@@ -1,10 +1,8 @@
 using PLATEAU.Util;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
-using UnityEngine.AddressableAssets.ResourceLocators;
 using UnityEngine.ResourceManagement.AsyncOperations;
 
 namespace PLATEAU.DynamicTile

--- a/Runtime/DynamicTile/AddressableLoader.cs
+++ b/Runtime/DynamicTile/AddressableLoader.cs
@@ -74,6 +74,7 @@ namespace PLATEAU.DynamicTile
                 if (!Directory.Exists(folderBuild))
                 {
                     Debug.LogError("folder not found: " + folderBuild);
+                    return null;
                 }
 
                 var catalogFiles = Directory.GetFiles(folderBuild, "catalog_*.json", SearchOption.AllDirectories);
@@ -81,6 +82,7 @@ namespace PLATEAU.DynamicTile
                 if (catalogFiles.Length == 0)
                 {
                     Debug.LogError("catalog file is not found.");
+                    return null;
                 }
 
                 catalogPathToUse = catalogFiles.OrderByDescending(File.GetLastWriteTimeUtc).FirstOrDefault();
@@ -89,11 +91,13 @@ namespace PLATEAU.DynamicTile
                     if (!Directory.Exists(folderRuntime))
                     {
                         Debug.LogError("folder not found: " + folderRuntime);
+                        return null;
                     }
                     var files = Directory.GetFiles(folderRuntime, "catalog_*.json", SearchOption.AllDirectories);
                     if (files.Length == 0)
                     {
                         Debug.LogError("catalog file is not found.");
+                        return null;
                     }
                     catalogPathToUse = files.OrderByDescending(File.GetLastWriteTimeUtc).FirstOrDefault();
 #endif
@@ -231,6 +235,7 @@ namespace PLATEAU.DynamicTile
                 else
                 {
                     Debug.LogError($"MetaStoreのロードに失敗しました: {metaStorePath}");
+                    return null;
                 }
             }
             catch (System.Exception ex)

--- a/Runtime/DynamicTile/DisposableAsyncOperationHandle.cs
+++ b/Runtime/DynamicTile/DisposableAsyncOperationHandle.cs
@@ -1,0 +1,79 @@
+using System;
+using UnityEngine.ResourceManagement.AsyncOperations;
+
+namespace PLATEAU.DynamicTile
+{
+    /// <summary>
+    /// AsyncOperationHandleのラッパークラスです。
+    /// using文で自動的にReleaseされるので、すぐReleaseしたいケースでのRelease忘れを防止できます。
+    /// </summary>
+    public class DisposableAsyncOperationHandle<T> : IDisposable
+    {
+        private AsyncOperationHandle<T> handle;
+        private bool disposed;
+
+        /// <summary>
+        /// 内部のAsyncOperationHandle
+        /// </summary>
+        public AsyncOperationHandle<T> Handle => handle;
+
+        /// <summary>
+        /// 操作の結果
+        /// </summary>
+        public T Result => handle.Result;
+
+        /// <summary>
+        /// 操作の状態
+        /// </summary>
+        public AsyncOperationStatus Status => handle.Status;
+        
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="handle">ラップするAsyncOperationHandle</param>
+        public DisposableAsyncOperationHandle(AsyncOperationHandle<T> handle)
+        {
+            this.handle = handle;
+        }
+        
+
+        /// <summary>
+        /// リソースを解放します
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// リソースを解放します
+        /// </summary>
+        /// <param name="disposing">マネージドリソースを解放するかどうか</param>
+        private void Dispose(bool disposing)
+        {
+            if (!disposed && disposing)
+            {
+                if (handle.IsValid())
+                {
+                    UnityEngine.AddressableAssets.Addressables.Release(handle);
+                }
+                disposed = true;
+            }
+        }
+        
+    }
+
+    public static class DisposableAsyncOperationHandleEx
+    {
+        /// <summary>
+        /// AsyncOperationHandleを変換し、usingで自動的にReleaseされるDisposableAsyncOperationHandleにします。
+        /// </summary>
+        public static DisposableAsyncOperationHandle<T> ToDisposable<T>(this AsyncOperationHandle<T> handle)
+        {
+            return new DisposableAsyncOperationHandle<T>(handle);
+        }
+    }
+    
+} 

--- a/Runtime/DynamicTile/DisposableAsyncOperationHandle.cs
+++ b/Runtime/DynamicTile/DisposableAsyncOperationHandle.cs
@@ -20,12 +20,12 @@ namespace PLATEAU.DynamicTile
         /// <summary>
         /// 操作の結果
         /// </summary>
-        public T Result => handle.Result;
+        public T Result => handle.IsValid() ? handle.Result : default;
 
         /// <summary>
         /// 操作の状態
         /// </summary>
-        public AsyncOperationStatus Status => handle.Status;
+        public AsyncOperationStatus Status => handle.IsValid() ? handle.Status : AsyncOperationStatus.None;
         
 
         /// <summary>

--- a/Runtime/DynamicTile/DisposableAsyncOperationHandle.cs.meta
+++ b/Runtime/DynamicTile/DisposableAsyncOperationHandle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59d50122635a7344f9e13db36c6af832
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/DynamicTile/DynamicTileCollection.cs
+++ b/Runtime/DynamicTile/DynamicTileCollection.cs
@@ -2,7 +2,6 @@ using PLATEAU.CityInfo;
 using PLATEAU.Util;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Collections;
 using UnityEngine;
 using UnityEngine.AddressableAssets;

--- a/Runtime/DynamicTile/DynamicTileCollection.cs
+++ b/Runtime/DynamicTile/DynamicTileCollection.cs
@@ -1,0 +1,258 @@
+using PLATEAU.CityInfo;
+using PLATEAU.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Unity.Collections;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+namespace PLATEAU.DynamicTile
+{
+    /// <summary>
+    /// PLATEAUDynamicTileのコレクションを管理するクラス。
+    /// タイルの追加、削除、クリア、アンロードなどの操作を担当します。
+    /// </summary>
+    public class DynamicTileCollection : IEnumerable<PLATEAUDynamicTile>
+    {
+        /// <summary>
+        /// タイルのリスト
+        /// </summary>
+        private List<PLATEAUDynamicTile> Tiles { get; } = new();
+
+        /// <summary>
+        /// タイルのアドレスとタイルのマッピング
+        /// </summary>
+        private Dictionary<string, PLATEAUDynamicTile> tileAddressesDict = new();
+
+        /// <summary>
+        /// LODごとの親Transformを管理する辞書
+        /// </summary>
+        private Dictionary<int, Transform> lodParentDict = new();
+
+        /// <summary>
+        /// 最大LODレベル
+        /// </summary>
+        private const int MaxLodLevel = 4;
+
+        private readonly ConditionalLogger logger;
+
+        public DynamicTileCollection(ConditionalLogger logger)
+        {
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// タイルをコレクションに追加します。
+        /// </summary>
+        /// <param name="tile">追加するタイル</param>
+        /// <returns>追加に成功したかどうか</returns>
+        public bool AddTile(PLATEAUDynamicTile tile)
+        {
+            if (tile == null)
+            {
+                logger.LogWarn("nullのタイルは追加できません");
+                return false;
+            }
+
+            if (Tiles.Contains(tile))
+            {
+                logger.LogWarn("既に追加済みのタイルです");
+                return false;
+            }
+
+            if (tileAddressesDict.ContainsKey(tile.Address))
+            {
+                logger.LogWarn("既に追加済みのタイルAddressです");
+                return false;
+            }
+
+            Tiles.Add(tile);
+            tileAddressesDict[tile.Address] = tile;
+            return true;
+        }
+
+        /// <summary>
+        /// アドレスを指定してタイルを取得します。
+        /// </summary>
+        /// <param name="address">タイルのアドレス</param>
+        /// <returns>対応するタイル、見つからない場合はnull</returns>
+        public PLATEAUDynamicTile GetTileByAddress(string address)
+        {
+            return tileAddressesDict.GetValueOrDefault(address);
+        }
+        
+        /// <summary>
+        /// タイルのメタ情報からタイルリストを構築します。すでに存在するタイルはクリアされます。
+        /// </summary>
+        public void RefreshByTileMetas(IEnumerable<PLATEAUDynamicTileMetaInfo> metas)
+        {
+            ClearTiles(); // 既存のタイルリストをクリア
+            foreach (var meta in metas)
+            {
+                var tile = new PLATEAUDynamicTile(meta, logger);
+                AddTile(tile);
+            }
+        }
+
+        /// <summary>
+        /// すべてのタイルをクリアします。
+        /// </summary>
+        public void ClearTiles()
+        {
+            ClearTileAssets();
+            Tiles.Clear();
+            tileAddressesDict.Clear();
+            lodParentDict.Clear();
+        }
+
+        /// <summary>
+        /// すべてのロード済みオブジェクトをアンロードします。
+        /// </summary>
+        public void ClearTileAssets()
+        {
+            foreach (var tile in Tiles)
+            {
+                try
+                {
+                    if (tile.LoadHandle.IsValid())
+                    {
+                        Addressables.Release(tile.LoadHandle);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarn($"タイルのアンロード中にエラーが発生しました: {tile.Address} {ex.Message}");
+                }
+                finally
+                {
+                    DeleteGameObjectInstance(tile.LoadedObject);
+                    tile.Reset();
+                }
+            }
+
+            ClearLodChildren();
+        }
+
+        /// <summary>
+        /// LOD直下の子オブジェクトをすべてアンロードします。
+        /// </summary>
+        private void ClearLodChildren()
+        {
+            var instance = GameObject.FindObjectOfType<PLATEAUInstancedCityModel>()?.gameObject;
+            if (instance == null)
+                return;
+
+            for (int lod = 0; lod <= MaxLodLevel; lod++)
+            {
+                var lodName = $"LOD{lod}";
+                var lodParent = instance.transform.Find(lodName)?.gameObject;
+                if (lodParent != null)
+                {
+                    for (int i = lodParent.transform.childCount - 1; i >= 0; i--)
+                    {
+                        var child = lodParent.transform.GetChild(i);
+                        if (child != null)
+                        {
+                            DeleteGameObjectInstance(child.gameObject);
+                        }
+                    }
+                    DeleteGameObjectInstance(lodParent);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 指定されたLODから親Transformを取得または作成します。
+        /// </summary>
+        /// <param name="lod">LODレベル</param>
+        /// <param name="parentTransform">親Transform</param>
+        /// <returns>LODの親Transform</returns>
+        public Transform FindParent(int lod, Transform parentTransform)
+        {
+            if (lodParentDict.TryGetValue(lod, out var existingParent))
+            {
+                if (existingParent != null)
+                    return existingParent;
+            }
+
+            var lodName = $"LOD{lod}";
+            GameObject lodObject = null;
+
+            if (parentTransform != null)
+            {
+                lodObject = parentTransform.Find(lodName)?.gameObject;
+                if (lodObject == null)
+                {
+                    lodObject = new GameObject(lodName);
+                    lodObject.transform.SetParent(parentTransform, false);
+                }
+            }
+
+            if (lodObject != null)
+            {
+                lodParentDict[lod] = lodObject.transform;
+                return lodObject.transform;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// GameObjectインスタンスを削除します。
+        /// </summary>
+        /// <param name="obj">削除するGameObject</param>
+        public static void DeleteGameObjectInstance(GameObject obj)
+        {
+            if (obj == null)
+                return;
+
+            if (Application.isPlaying)
+                UnityEngine.Object.Destroy(obj);
+            else
+                UnityEngine.Object.DestroyImmediate(obj);
+        }
+
+        /// <summary>
+        /// コレクション内のタイル数を取得します。
+        /// </summary>
+        /// <returns>タイル数</returns>
+        public int Count => Tiles.Count;
+
+        /// <summary>
+        /// コレクションが空かどうかを確認します。
+        /// </summary>
+        /// <returns>空の場合true</returns>
+        public bool IsEmpty => Tiles.Count == 0;
+
+        public PLATEAUDynamicTile At(int index)
+        {
+            return Tiles[index];
+        }
+
+        public List<PLATEAUDynamicTile> ToList()
+        {
+            return new List<PLATEAUDynamicTile>(Tiles);
+        }
+        
+
+        public void ComposeTileBounds(NativeArray<TileBounds> outBounds)
+        {
+            for (int i = 0; i < Tiles.Count; i++)
+            {
+                var tile = Tiles[i];
+                outBounds[i] = tile.GetTileBoundsStruct();
+            }
+        }
+        
+        public IEnumerator<PLATEAUDynamicTile> GetEnumerator()
+        {
+            return Tiles.GetEnumerator();
+        }
+        
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+} 

--- a/Runtime/DynamicTile/DynamicTileCollection.cs
+++ b/Runtime/DynamicTile/DynamicTileCollection.cs
@@ -85,9 +85,9 @@ namespace PLATEAU.DynamicTile
         /// <summary>
         /// タイルのメタ情報からタイルリストを構築します。すでに存在するタイルはクリアされます。
         /// </summary>
-        public void RefreshByTileMetas(IEnumerable<PLATEAUDynamicTileMetaInfo> metas)
+        public void RefreshByTileMetas(IEnumerable<PLATEAUDynamicTileMetaInfo> metas, PLATEAUInstancedCityModel cityModel)
         {
-            ClearTiles(); // 既存のタイルリストをクリア
+            ClearTiles(cityModel); // 既存のタイルリストをクリア
             foreach (var meta in metas)
             {
                 var tile = new PLATEAUDynamicTile(meta, logger);
@@ -98,9 +98,9 @@ namespace PLATEAU.DynamicTile
         /// <summary>
         /// すべてのタイルをクリアします。
         /// </summary>
-        public void ClearTiles()
+        public void ClearTiles(PLATEAUInstancedCityModel cityModel)
         {
-            ClearTileAssets();
+            ClearTileAssets(cityModel);
             tiles.Clear();
             tileAddressesDict.Clear();
             lodParentDict.Clear();
@@ -109,7 +109,7 @@ namespace PLATEAU.DynamicTile
         /// <summary>
         /// すべてのロード済みオブジェクトをアンロードします。
         /// </summary>
-        public void ClearTileAssets()
+        public void ClearTileAssets(PLATEAUInstancedCityModel cityModel)
         {
             foreach (var tile in tiles)
             {
@@ -131,22 +131,21 @@ namespace PLATEAU.DynamicTile
                 }
             }
 
-            ClearLodChildren();
+            ClearLodChildren(cityModel);
         }
 
         /// <summary>
         /// LOD直下の子オブジェクトをすべてアンロードします。
         /// </summary>
-        private void ClearLodChildren()
+        private void ClearLodChildren(PLATEAUInstancedCityModel cityModel)
         {
-            var instance = Object.FindObjectOfType<PLATEAUInstancedCityModel>()?.gameObject;
-            if (instance == null)
+            if (cityModel == null)
                 return;
 
             for (int lod = 0; lod <= MaxLodLevel; lod++)
             {
                 var lodName = $"LOD{lod}";
-                var lodParent = instance.transform.Find(lodName)?.gameObject;
+                var lodParent = cityModel.transform.Find(lodName)?.gameObject;
                 if (lodParent != null)
                 {
                     for (int i = lodParent.transform.childCount - 1; i >= 0; i--)
@@ -242,7 +241,7 @@ namespace PLATEAU.DynamicTile
         {
             if (outBounds.Length != tiles.Count)
             {
-                throw new ArgumentException("arrow size didn't match.");
+                throw new ArgumentException("array size didn't match.");
             }
             
             for (int i = 0; i < tiles.Count; i++)

--- a/Runtime/DynamicTile/DynamicTileCollection.cs.meta
+++ b/Runtime/DynamicTile/DynamicTileCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0af124a83f62ad4fa29c3f6fd048166
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/DynamicTile/PLATEAUDynamicTile.cs
+++ b/Runtime/DynamicTile/PLATEAUDynamicTile.cs
@@ -67,6 +67,8 @@ namespace PLATEAU.DynamicTile
         public LoadState NextLoadState { get; set; } = LoadState.None;
 
         public PLATEAUTileManager.LoadResult LastLoadResult { get; set; } = PLATEAUTileManager.LoadResult.None;
+        
+        /// <summary> ログを出す設定の時だけ出す用 </summary>
         private ConditionalLogger logger;
 
         // Job Systemで使用するための構造体を返す
@@ -226,6 +228,7 @@ namespace PLATEAU.DynamicTile
                     {
                         // ロードが完了していない場合はキャンセル
                         LoadHandleCancellationTokenSource?.Cancel();
+                        Addressables.Release(LoadHandle);
                         return false;
                     }
                     Addressables.Release(LoadHandle);

--- a/Runtime/DynamicTile/PLATEAUDynamicTileInstantiation.cs
+++ b/Runtime/DynamicTile/PLATEAUDynamicTileInstantiation.cs
@@ -134,7 +134,7 @@ namespace PLATEAU.DynamicTile
     /// <summary>
     /// Unityエディタ上でコルーチンを実行するためのクラス。
     /// </summary>
-    internal class EditorCoroutineRunner
+    internal static class EditorCoroutineRunner
     {
         private static List<IEnumerator> coroutines = new List<IEnumerator>();
 

--- a/Runtime/DynamicTile/PLATEAUDynamicTileJobSystem.cs
+++ b/Runtime/DynamicTile/PLATEAUDynamicTileJobSystem.cs
@@ -1,7 +1,5 @@
 ﻿using PLATEAU.Util;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Unity.Jobs;

--- a/Runtime/DynamicTile/PLATEAUDynamicTileLoadTask.cs
+++ b/Runtime/DynamicTile/PLATEAUDynamicTileLoadTask.cs
@@ -1,6 +1,5 @@
 ﻿using PLATEAU.Util;
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;

--- a/Runtime/DynamicTile/PLATEAURuntimeCameraTracker.cs
+++ b/Runtime/DynamicTile/PLATEAURuntimeCameraTracker.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.LowLevel;
 

--- a/Runtime/DynamicTile/PLATEAUTileManager.cs
+++ b/Runtime/DynamicTile/PLATEAUTileManager.cs
@@ -87,6 +87,9 @@ namespace PLATEAU.DynamicTile
 
         public PLATEAUTileManager()
         {
+            // 通常のMonoBehaviourではデフォルトコンストラクタは非推奨ですが、
+            // 動的タイル機能はエディタ時・ランタイム時を問わず様々なタイミングで実行する必要があることから、
+            // 通常のAwakeやStartだけでは不足です。様々なタイミングで動作開始させるために必要です。
             logger = new ConditionalLogger(() => this.showDebugLog);
             TileCollection = new DynamicTileCollection(logger);
         }
@@ -311,6 +314,10 @@ namespace PLATEAU.DynamicTile
 
                         return true;
                     }
+                }
+                else
+                {
+                    logger.Log($"LOD {tile.Lod} の親Transformがありません。タイル: {tile.Address}");
                 }
             }
             return false;

--- a/Runtime/DynamicTile/PLATEAUTileManager.cs
+++ b/Runtime/DynamicTile/PLATEAUTileManager.cs
@@ -112,6 +112,7 @@ namespace PLATEAU.DynamicTile
 
             if (!loadDistances.Validate())
             {
+                logger.LogWarn("Load distances validation failed.");
                 return;
             }
 

--- a/Runtime/DynamicTile/PLATEAUTileManager.cs
+++ b/Runtime/DynamicTile/PLATEAUTileManager.cs
@@ -1,16 +1,17 @@
 using PLATEAU.CityInfo;
 using PLATEAU.Util;
 using PLATEAU.Util.Async;
-using System;
 using System.Linq;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnityEngine;
-using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;
 
 namespace PLATEAU.DynamicTile
 {
+    /// <summary>
+    /// 動的タイルの管理を行うMonoBehaviourです。
+    /// シーンを開いたときやPlayモード切替などのタイミングでは<see cref="PLATEAUSceneViewCameraTracker"/>, <see cref="PLATEAUEditorEventListener"/>から処理を呼び出されます。
+    /// </summary>
     public class PLATEAUTileManager : MonoBehaviour
     {
         /// <summary>
@@ -98,6 +99,11 @@ namespace PLATEAU.DynamicTile
         {
             if (State == ManagerState.Initializing)
                 return;
+
+            if (!loadDistances.Validate())
+            {
+                return;
+            }
 
             State = ManagerState.Initializing;
 

--- a/Runtime/DynamicTile/PLATEAUTileManager.cs
+++ b/Runtime/DynamicTile/PLATEAUTileManager.cs
@@ -226,8 +226,10 @@ namespace PLATEAU.DynamicTile
         {
             var originalState = State == ManagerState.CleaningUp ? ManagerState.Operating : State;
             State = ManagerState.CleaningUp;
-
+            
             TileCollection.ClearTileAssets();
+            loadTask?.DisposeAsync().AsTask().ContinueWithErrorCatch();
+            
             State = originalState;
         }
 

--- a/Runtime/DynamicTile/PLATEAUTileManager.cs
+++ b/Runtime/DynamicTile/PLATEAUTileManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.Serialization;
 
 namespace PLATEAU.DynamicTile
 {
@@ -47,6 +48,9 @@ namespace PLATEAU.DynamicTile
 
         [SerializeField]
         private string catalogPath;
+
+        [SerializeField]
+        private string metaAddress;
 
         [SerializeField]
         private bool showDebugTileInfo = true; // Debug情報を表示するかどうか
@@ -96,9 +100,10 @@ namespace PLATEAU.DynamicTile
             TileCollection = new DynamicTileCollection(logger);
         }
 
-        public void Init(PLATEAUInstancedCityModel sourceModelArg)
+        public void Init(PLATEAUInstancedCityModel sourceModelArg, string metaAddressArg)
         {
             sourceModel = sourceModelArg;
+            metaAddress = metaAddressArg;
         }
 
         /// <summary>
@@ -119,7 +124,7 @@ namespace PLATEAU.DynamicTile
             State = ManagerState.Initializing;
 
             // PLATEAUDynamicTileMetaStoreをAddressablesからロード
-            var metaStore = await addressableLoader.InitializeAsync(catalogPath);
+            var metaStore = await addressableLoader.InitializeAsync(catalogPath, metaAddress);
             if (metaStore == null || metaStore.TileMetaInfos.Count == 0)
             {
                 logger.LogWarn("No tiles found in the meta store. Please check the catalog path or ensure tiles are registered.");
@@ -140,7 +145,6 @@ namespace PLATEAU.DynamicTile
         /// <summary>
         /// カタログパスを保存します。
         /// </summary>
-        /// <param name="path"></param>
         public void SaveCatalogPath(string path)
         {
             // パスを正規化（バックスラッシュをスラッシュに変換）

--- a/Runtime/DynamicTile/TileLoadDistanceCollection.cs
+++ b/Runtime/DynamicTile/TileLoadDistanceCollection.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PLATEAU.DynamicTile
+{
+    /// <summary>
+    /// 各ズームレベルは、カメラからの距離が何メートルのときに利用するかを設定します。
+    /// </summary>
+    [Serializable]
+    public class TileLoadDistanceCollection
+    {
+        /// <summary>
+        /// ロード距離設定のリスト
+        /// </summary>
+        public List<TileLoadDistance> LoadDistances = new List<TileLoadDistance>
+        {
+            new TileLoadDistance(11, -10000f, 500f),
+            new TileLoadDistance(10, 500f, 1500f),
+            new TileLoadDistance(9, 1500f, 10000f)
+        };
+
+
+        /// <summary>
+        /// 指定されたズームレベルのロード距離設定を取得します。
+        /// </summary>
+        /// <param name="zoomLevel">ズームレベル</param>
+        /// <returns>ロード距離設定、見つからない場合はnull</returns>
+        public TileLoadDistance GetLoadDistance(int zoomLevel)
+        {
+            return LoadDistances.FirstOrDefault(ld => ld.ZoomLevel == zoomLevel);
+        }
+
+        /// <summary>
+        /// 指定された距離が指定されたズームレベルのロード範囲内にあるかどうかを判定します。
+        /// </summary>
+        /// <param name="distance">判定する距離</param>
+        /// <param name="zoomLevel">ズームレベル</param>
+        /// <returns>範囲内の場合true</returns>
+        public bool IsWithinRange(float distance, int zoomLevel)
+        {
+            var loadDistance = GetLoadDistance(zoomLevel);
+            return loadDistance?.IsWithinRange(distance) ?? false;
+        }
+
+        
+        
+        /// <summary>
+        /// 各ズームレベルごとのロード距離範囲を表現するクラス。
+        /// </summary>
+        [Serializable]
+        public class TileLoadDistance
+        {
+            /// <summary>
+            /// ズームレベル
+            /// </summary>
+            public int ZoomLevel { get; set; }
+
+            /// <summary>
+            /// 最小ロード距離
+            /// </summary>
+            public float MinDistance { get; set; }
+
+            /// <summary>
+            /// 最大ロード距離
+            /// </summary>
+            public float MaxDistance { get; set; }
+
+            /// <summary>
+            /// コンストラクタ
+            /// </summary>
+            /// <param name="zoomLevel">ズームレベル</param>
+            /// <param name="minDistance">最小ロード距離</param>
+            /// <param name="maxDistance">最大ロード距離</param>
+            public TileLoadDistance(int zoomLevel, float minDistance, float maxDistance)
+            {
+                ZoomLevel = zoomLevel;
+                MinDistance = minDistance;
+                MaxDistance = maxDistance;
+            }
+
+            /// <summary>
+            /// 指定された距離がこのロード範囲内にあるかどうかを判定します。
+            /// </summary>
+            /// <param name="distance">判定する距離</param>
+            /// <returns>範囲内の場合true</returns>
+            public bool IsWithinRange(float distance)
+            {
+                return distance >= MinDistance && distance <= MaxDistance;
+            }
+
+        }
+    }
+} 

--- a/Runtime/DynamicTile/TileLoadDistanceCollection.cs
+++ b/Runtime/DynamicTile/TileLoadDistanceCollection.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace PLATEAU.DynamicTile
 {
@@ -13,7 +15,7 @@ namespace PLATEAU.DynamicTile
         /// <summary>
         /// ロード距離設定のリスト
         /// </summary>
-        public List<TileLoadDistance> LoadDistances = new List<TileLoadDistance>
+        public List<TileLoadDistance> loadDistances = new List<TileLoadDistance>
         {
             new TileLoadDistance(11, -10000f, 500f),
             new TileLoadDistance(10, 500f, 1500f),
@@ -28,7 +30,7 @@ namespace PLATEAU.DynamicTile
         /// <returns>ロード距離設定、見つからない場合はnull</returns>
         public TileLoadDistance GetLoadDistance(int zoomLevel)
         {
-            return LoadDistances.FirstOrDefault(ld => ld.ZoomLevel == zoomLevel);
+            return loadDistances.FirstOrDefault(ld => ld.ZoomLevel == zoomLevel);
         }
 
         /// <summary>
@@ -43,6 +45,21 @@ namespace PLATEAU.DynamicTile
             return loadDistance?.IsWithinRange(distance) ?? false;
         }
 
+        public bool Validate()
+        {
+            bool hasData =
+                loadDistances.Any(d => d.ZoomLevel == 9) &&
+                loadDistances.Any(d => d.ZoomLevel == 10) &&
+                loadDistances.Any(d => d.ZoomLevel == 11);
+            if (!hasData)
+            {
+                Debug.LogError("TileLoadDistanceCollectionの設定が正しくありません。ズームレベル9, 10, 11の設定が必要です。");
+                return false;
+            }
+
+            return true;
+        }
+
         
         
         /// <summary>
@@ -54,17 +71,24 @@ namespace PLATEAU.DynamicTile
             /// <summary>
             /// ズームレベル
             /// </summary>
-            public int ZoomLevel { get; set; }
+            public int ZoomLevel;
 
             /// <summary>
             /// 最小ロード距離
             /// </summary>
-            public float MinDistance { get; set; }
+            public float MinDistance;
 
             /// <summary>
             /// 最大ロード距離
             /// </summary>
-            public float MaxDistance { get; set; }
+            public float MaxDistance;
+
+            /// <summary>
+            /// デフォルトコンストラクタ（Unityのシリアライザー用）
+            /// </summary>
+            public TileLoadDistance()
+            {
+            }
 
             /// <summary>
             /// コンストラクタ

--- a/Runtime/DynamicTile/TileLoadDistanceCollection.cs
+++ b/Runtime/DynamicTile/TileLoadDistanceCollection.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace PLATEAU.DynamicTile
 {

--- a/Runtime/DynamicTile/TileLoadDistanceCollection.cs.meta
+++ b/Runtime/DynamicTile/TileLoadDistanceCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68acb30b69a2f7742835436e0f1445ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Util/ConditionalLogger.cs
+++ b/Runtime/Util/ConditionalLogger.cs
@@ -19,5 +19,10 @@ namespace PLATEAU.Util
         {
             if(this.condition()) Debug.Log(logText);
         }
+
+        public void LogWarn(string logText)
+        {
+            if(condition()) Debug.LogWarning(logText);
+        }
     }
 }

--- a/Runtime/Util/ProgressDisplay/ProgressBar.cs
+++ b/Runtime/Util/ProgressDisplay/ProgressBar.cs
@@ -1,5 +1,6 @@
 
 using System;
+using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -7,9 +8,9 @@ using UnityEditor;
 namespace PLATEAU.Util
 {
     /// <summary>
-    /// Editorの場合、<see cref="Display"/>でプログレスバーを表示し、廃棄時にプログレスバーを消します。
+    /// Editorの場合、<see cref="UnityEngine.Display"/>でプログレスバーを表示し、廃棄時にプログレスバーを消します。
     /// Editorでない場合、何もしません。
-    /// <see cref="Display"/>にinfo文字列を与えない場合に表示されるデフォルト文字列をコンストラクタで指定できます。
+    /// <see cref="UnityEngine.Display"/>にinfo文字列を与えない場合に表示されるデフォルト文字列をコンストラクタで指定できます。
     /// 指定しない場合は空文字列がデフォルトになります。
     /// </summary>
     public class ProgressBar : IProgressBar
@@ -31,7 +32,7 @@ namespace PLATEAU.Util
         public void Display(string info, float progress)
         {
             #if UNITY_EDITOR
-            EditorUtility.DisplayProgressBar("PLATEAU", info, progress);
+            EditorUtility.DisplayProgressBar("PLATEAU", info, Mathf.Clamp01(progress));
             #endif
         }
 

--- a/Runtime/Util/ProgressDisplay/ProgressBar.cs
+++ b/Runtime/Util/ProgressDisplay/ProgressBar.cs
@@ -23,6 +23,11 @@ namespace PLATEAU.Util
         
         public ProgressBar() : this(""){}
         
+        /// <summary>
+        /// プログレスバーを表示します。
+        /// </summary>
+        /// <param name="info">ユーザーに提示する文字列</param>
+        /// <param name="progress">0f～1fでの進捗</param>
         public void Display(string info, float progress)
         {
             #if UNITY_EDITOR


### PR DESCRIPTION
﻿## 🔗 関連リンク
[Jira](https://synesthesias.atlassian.net/browse/CPSDK25-168)

## ✅ レビュー前確認項目
- [x] ユニットテストが通ること
- [x] ビルドが通ること

<!-- 社内の人向け: 以下の項目は、開発当初のストーリー設計書通りであれば省略可能です。
                 設計に変更があった場合のみ、変更点を周知するために記載してください。 -->

## 🚀 実装内容
- 2回目に動的タイル化しても1回目の都市モデルが出てくる問題を修正しました
- スクリプトのリロードが入ると動的タイルの読み込みが停止する問題を修正しました
- 動的タイル化でのアセットバンドルのビルドに成功しているのにエラーログが出る問題を解消しました
- 動的タイルの読み込みで「Leak Detected」というログが出ていたのでメモリリークを修正しました
- 「Assetsに保存」でアセットとして生成されたファイルのUnityインポート処理中にプログレスバーが何度も行ったり来たりしていたのを改善し、あまりプログレスバーが戻らないようにしました
- 動的タイル化の処理中に「シーンを保存しますか」というダイアログが出ていたのを、処理の最初に出てくるようにしました
## 🌐 影響範囲
動的タイル化に関してリファクタリングをしたのでβ版向け機能に影響があります
## 🛠️ 動作確認
上記のバグが修正されていること
## ⚠️ 懸念点
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * タイル管理用のDynamicTileCollectionクラスとズームレベルごとのTileLoadDistanceCollectionクラスを追加し、管理の効率化と柔軟性を向上。
  * Addressablesの非同期操作を自動解放可能なDisposableラッパーで管理し、リソースリークを防止。
  * タイルのアンロード処理を強化し、エラー時の詳細なログ出力を実装。
  * インポート処理でルートTransformを取得可能にし、インポート前のシーン保存確認を追加。

* **機能改善**
  * タイルロード・アンロード処理のリファクタリングによりパフォーマンスと安定性を向上。
  * ロギングをConditionalLoggerに統一し、警告ログの追加でデバッグ性を改善。
  * シーン保存のタイミング調整や非同期初期化の挙動最適化、Addressablesビルドのエラーハンドリング改善を実施。
  * タイル管理の内部構造を整理し、親Transform管理やコルーチンの起動方法を改善。
  * Addressablesカタログの読み込みをファイルシステムベースに変更し、リソース管理を最適化。

* **ドキュメント**
  * 日本語コメントやXMLドキュメントを追加し、コードの可読性を向上。

* **スタイル**
  * 多数の未使用usingディレクティブを削除し、コードフォーマットを微調整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->