### PR TITLE
Release/v4.2.0

### DIFF
--- a/Runtime/RoadAdjust/RoadNetworkToMesh/Contour/RnmMaterialType.cs
+++ b/Runtime/RoadAdjust/RoadNetworkToMesh/Contour/RnmMaterialType.cs
@@ -22,7 +22,7 @@ namespace PLATEAU.RoadAdjust.RoadNetworkToMesh
             var mat = type switch
             {
                 RnmMaterialType.RoadCarLane => FallbackMaterial.LoadByMaterialFileName("PlateauGenericRoadWithUV"),
-                RnmMaterialType.IntersectionCarLane => FallbackMaterial.LoadByMaterialFileName("PlateauGenericRoad"),
+                RnmMaterialType.IntersectionCarLane => FallbackMaterial.LoadByMaterialFileName("PlateauGenericRoadWithUV"),
                 RnmMaterialType.SideWalk => FallbackMaterial.LoadByMaterialFileName("PlateauGenericRoadWithUVTile"),
                 RnmMaterialType.MedianLane => FallbackMaterial.LoadByMaterialFileName("PlateauRoadStone"),
                 _ => throw new ArgumentOutOfRangeException()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.synesthesias.plateau-unity-sdk",
-    "version": "4.1.0-beta",
+    "version": "4.2.0",
     "displayName": "PLATEAU SDK for Unity",
     "description": "このパッケージには、PLATEAUの3D都市モデルデータを利用するためのAPI、サンプルが含まれます。PLATEAU SDK for Unityを利用することで、実世界を舞台にしたゲームの開発や、PLATEAUの豊富なデータを活用したシミュレーションを簡単に行うことができます。",
     "unity": "6000.3",


### PR DESCRIPTION
- バージョン情報更新
- HDRP環境で道路ネットワークを作成したとき、道路と交差点の色がかなり違うのを修正

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates package version metadata and changes a single material mapping for intersection lanes, affecting visuals but not core data or logic.
> 
> **Overview**
> Updates the package version from `4.1.0-beta` to `4.2.0`.
> 
> Fixes road-network meshing visuals by assigning the same `PlateauGenericRoadWithUV` material to `IntersectionCarLane` as regular road lanes, reducing color/appearance differences (notably in HDRP).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a74bfc223e85548fd43741e46f1e0dfea03dc851. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * バージョン 4.2.0 にアップデートしました

* **改善**
  * 交差点の車線材質レンダリングを改善しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->