### PR TITLE
AddressableAssetSystemを既に利用しているPJで起きる不具合の修正

### DIFF
--- a/Editor/DynamicTile/DynamicTileExporter.cs
+++ b/Editor/DynamicTile/DynamicTileExporter.cs
@@ -167,7 +167,7 @@ namespace PLATEAU.DynamicTile
                 {
                     PlayerSettings.stripUnusedMeshComponents = false;
                     // Addressablesのビルドを実行
-                    AddressablesUtility.BuildAddressables(context.BuildMode);
+                    AddressablesUtility.BuildAddressables(context.BuildMode, context.AddressableGroupName);
                 }
                 finally
                 {

--- a/Editor/DynamicTile/TileModule/RestoreAddressablesStateForRebuild.cs
+++ b/Editor/DynamicTile/TileModule/RestoreAddressablesStateForRebuild.cs
@@ -31,7 +31,7 @@ namespace PLATEAU.Editor.DynamicTile.TileModule
 
             // 差分ビルドに必要な state ファイルを探します。
             var contentStatePath = Path.Combine(context.BuildFolderPath, ContentStateFileName);
-            
+
             if (File.Exists(contentStatePath))
             {
                 // state ファイルの存在する場所を Addressable の設定に教えます。
@@ -45,7 +45,7 @@ namespace PLATEAU.Editor.DynamicTile.TileModule
                 // New Buildが実行されます。
                 Debug.Log("Addressables content state not found. A full build will be performed.");
             }
-            
+
             return true;
         }
 

--- a/Editor/DynamicTile/TileModule/TileAddressableConfigMaker.cs
+++ b/Editor/DynamicTile/TileModule/TileAddressableConfigMaker.cs
@@ -19,7 +19,7 @@ namespace PLATEAU.Editor.DynamicTile.TileModule
         {
             this.context = context;
         }
-        
+
         /// <summary>
         /// エクスポートの事前処理で、タイルのビルドに必要なAddressable設定を行います。
         /// </summary>
@@ -28,7 +28,7 @@ namespace PLATEAU.Editor.DynamicTile.TileModule
             // すでに同名のグループが存在する場合、一度削除します。
             // こうしないと、Assets内のタイルを更新したケースで更新が反映されなくなります。
             AddressablesUtility.RemoveGroup(context.AddressableGroupName);
-            
+
             // プロファイルを作成
             var profileID = AddressablesUtility.SetOrCreateProfile();
             if (string.IsNullOrEmpty(profileID))
@@ -47,7 +47,7 @@ namespace PLATEAU.Editor.DynamicTile.TileModule
                 AddressablesUtility.SetProfileForAssetBundleInAssets(context.AddressableGroupName);
             }
             AddressablesUtility.SetGroupLoadAndBuildPath(context.AddressableGroupName);
-            
+
             // MonoScript Bundle の生成を無効化します。
             // デフォルトではMonoScript BundleがLibraryフォルダに生成されますが、それを無効化することでLibraryフォルダへの依存がなくなり、他のPCで動作させることが簡単になります。
             // Addressables 2.x では Disabled が削除されたため、Custom に設定して名前を null にすることで生成を抑制します。
@@ -64,9 +64,9 @@ namespace PLATEAU.Editor.DynamicTile.TileModule
                 settings.MonoScriptBundleNaming = MonoScriptBundleNaming.Disabled;
 #endif
             }
-            
+
             AddressablesUtility.SaveAddressableSettings();
-            
+
             return true;
         }
 
@@ -87,25 +87,12 @@ namespace PLATEAU.Editor.DynamicTile.TileModule
             var groupName = context.AddressableGroupName;
             if (string.IsNullOrEmpty(groupName)) return;
 
-            if (context.IsExcludeAssetFolder)
-            {
-                // Assets外: ユーザーの設定を汚さないようグループを削除します。
-                // ロード時にはカタログパスから設定を読み直すので動く仕組みです。
-                AddressablesUtility.RemoveGroup(groupName);
-            }
-            else
-            {
-                // Assets内: グループは残すが IncludeInBuild を false にします。
-                // ビルド対象から外さないとAddressablesメニューからの再ビルド時にタイルバンドルが
-                // 再ビルドされ、カタログはSDK利用者の指定した別の場所(ServerData等)に出力されるため、
-                // PLATEAUBundles内の既存カタログとCRCが不整合になります。
-                // タイルバンドルとカタログは既にPLATEAUBundlesに存在しており、
-                // DynamicTileが明示的にカタログをロードするため問題ありません。
-                // 次回のタイルビルド時はOnTileGenerateStartでグループが再作成されます。
-                AddressablesUtility.SetGroupIncludeInBuild(groupName, false);
-            }
+            // ビルド済みのカタログとバンドルはディスクに存在しており、
+            // ランタイムでは LoadContentCatalogAsync で直接ロードするためグループは不要です。
+            // 次回のタイルビルド時は OnTileGenerateStart でグループが再作成されます。
+            AddressablesUtility.RemoveGroup(groupName);
         }
-        
+
         public void OnTileGenerateStartFailed()
         {
             AddressablesUtility.BackToDefaultProfile();
@@ -122,7 +109,7 @@ namespace PLATEAU.Editor.DynamicTile.TileModule
                 settings.MonoScriptBundleCustomNaming = savedMonoScriptBundleCustomNaming;
                 AddressablesUtility.SaveAddressableSettings();
             }
-            
+
             savedMonoScriptBundleNaming = null;
             savedMonoScriptBundleCustomNaming = null;
         }

--- a/Editor/DynamicTile/TileRebuilder.cs
+++ b/Editor/DynamicTile/TileRebuilder.cs
@@ -221,7 +221,7 @@ namespace PLATEAU.Editor.DynamicTile
             {
                 PlayerSettings.stripUnusedMeshComponents = false; // UV4を使うために必要
                 // addressableビルド
-                AddressablesUtility.BuildAddressables(context.BuildMode);
+                AddressablesUtility.BuildAddressables(context.BuildMode, context.AddressableGroupName);
             }
             catch (Exception ex) 
             {

--- a/Editor/TileAddressables/AddressablesUtility.cs
+++ b/Editor/TileAddressables/AddressablesUtility.cs
@@ -497,6 +497,11 @@ namespace PLATEAU.Editor.TileAddressables
         /// <param name="tileGroupName">ビルド対象のタイルグループ名</param>
         public static void BuildAddressables(TileBuildMode buildMode, string tileGroupName)
         {
+            if (string.IsNullOrEmpty(tileGroupName))
+            {
+                Debug.LogWarning("ビルド対象のタイルグループ名が指定されていません。");
+                return;
+            }
             var settings = RequireAddressableSettings();
             if (settings == null)
             {
@@ -643,6 +648,11 @@ namespace PLATEAU.Editor.TileAddressables
 
                 settings.RemoveGroup(group);
                 Debug.Log($"Addressableグループを削除しました: {groupName}");
+                
+                //一応
+                EditorUtility.SetDirty(settings);
+                AssetDatabase.SaveAssets();
+                
                 return true;
             }
             catch (Exception ex)

--- a/Editor/TileAddressables/AddressablesUtility.cs
+++ b/Editor/TileAddressables/AddressablesUtility.cs
@@ -23,7 +23,16 @@ namespace PLATEAU.Editor.TileAddressables
         private const string SafeDefaultPathLoad  = "[UnityEngine.AddressableAssets.Addressables.RuntimePath]/[BuildTarget]";
         private const string SafeDefaultPathBuild = "[UnityEngine.AddressableAssets.Addressables.BuildPath]/[BuildTarget]";
         private const string ContentStateFileName = "addressables_content_state.bin";
-        
+
+        /// <summary>
+        /// PLATEAU SDK用のビルド時に Library/com.unity.addressables に出力されるランタイム設定ファイル名。
+        /// デフォルトの "settings.json" / "catalog.bin" を使うとSDK利用者のAddressablesランタイム設定を上書きしてしまうため、
+        /// PLATEAU専用のファイル名を使います。PLATEAUはカタログを明示的にロードするためこれらのファイルは不要ですが、
+        /// ビルドスクリプトが必ず出力するため名前を分離します。
+        /// </summary>
+        private const string PlateauRuntimeSettingsFilename = "settings_plateau.json";
+        private const string PlateauRuntimeCatalogFilename = "catalog_plateau.bin";
+
         /// <summary>
         /// AddressableAssetSettingsを取得。nullの場合は警告を出す。
         /// </summary>
@@ -82,7 +91,7 @@ namespace PLATEAU.Editor.TileAddressables
 
             return group;
         }
-        
+
         /// <summary>
         /// 指定したアセットを指定グループにAddressableとして登録
         /// <param name="assetPath">登録するアセットのパス</param>
@@ -112,7 +121,7 @@ namespace PLATEAU.Editor.TileAddressables
 
             // パスに含まれる /./ を削除して正規化
             assetPath = assetPath.Replace("/./", "/");
-            
+
             var guid = AssetDatabase.AssetPathToGUID(assetPath);
             if (string.IsNullOrEmpty(guid))
             {
@@ -132,7 +141,7 @@ namespace PLATEAU.Editor.TileAddressables
                 foreach (var label in labels)
                 {
                     if (string.IsNullOrEmpty(label)) continue;
-                    
+
                     if (!settings.GetLabels().Contains(label))
                     {
                         settings.AddLabel(label, true);
@@ -142,7 +151,7 @@ namespace PLATEAU.Editor.TileAddressables
                 }
             }
         }
-        
+
         public static void BackToDefaultProfile()
         {
             var addrSettings = AddressableAssetSettingsDefaultObject.Settings;
@@ -168,13 +177,13 @@ namespace PLATEAU.Editor.TileAddressables
             // Defaultプロファイルであっても、PLATEAU_BuildPathとPLATEAU_LoadPathの値は
             // PLATEAU_TileBuildProfileから引き継ぐようにします。
             // これによりDefaultプロファイルのままでもAddressableビルドが成功するようにします。
-            
+
             // 現在のプロファイル（TileBuildProfileのはず）から設定値を取得してDefaultにコピーします。
             // これにより、Assets内出力かAssets外出力かに関わらず、正しいパス設定が引き継がれます。
             var currentProfileId = addrSettings.activeProfileId;
             var currentBuildPath = profileSettings.GetValueByName(currentProfileId, ProfileVariableNameBuild);
             var currentLoadPath = profileSettings.GetValueByName(currentProfileId, ProfileVariableNameLoad);
-            
+
             // Defaultプロファイルに変数がなければ作成
             if (!profileSettings.GetVariableNames().Contains(ProfileVariableNameLoad))
             {
@@ -204,10 +213,10 @@ namespace PLATEAU.Editor.TileAddressables
 
             // プロファイルを切り替え
             addrSettings.activeProfileId = defaultProfileId;
-            
+
             // BuildRemotePathの設定を変えます。この設定が正しくないとアプリビルドに失敗します。
             bool isExternalPath = !currentLoadPath.Contains("StreamingAssets") && !currentLoadPath.Contains("[UnityEngine.AddressableAssets.Addressables.RuntimePath]");
-            
+
             if (!isExternalPath)
             {
                 addrSettings.BuildRemoteCatalog = false;
@@ -216,7 +225,7 @@ namespace PLATEAU.Editor.TileAddressables
             {
                 addrSettings.BuildRemoteCatalog = true;
             }
-            
+
             EditorUtility.SetDirty(addrSettings);
             SaveAddressableSettings();
         }
@@ -234,7 +243,7 @@ namespace PLATEAU.Editor.TileAddressables
             settings.BuildRemoteCatalog = true;
 
             var profileSettings = settings.profileSettings;
-            
+
             if (!profileSettings.GetVariableNames().Contains(ProfileVariableNameLoad))
             {
                 profileSettings.CreateValue(ProfileVariableNameLoad, SafeDefaultPathLoad);
@@ -243,21 +252,21 @@ namespace PLATEAU.Editor.TileAddressables
             {
                 profileSettings.CreateValue(ProfileVariableNameBuild, SafeDefaultPathBuild);
             }
-            
+
             // 出力パス: Assets/StreamingAssets/PLATEAUBundles/{GroupName}
             // AddressablesではAssets/StreamingAssetsを指定するとビルド時に自動的にそこに出力されます。
             // また、実行時(Runtime)もStreamingAssetsは特別なパスとして処理されるため整合性が取れます。
-            
+
             string buildPath = $"Assets/StreamingAssets/{PLATEAU.DynamicTile.AddressableLoader.AddressableLocalBuildFolderName}/{groupName}";
             // ランタイムではApplication.streamingAssetsPathを使って動的に解決させる
             string loadPath = $"{{UnityEngine.Application.streamingAssetsPath}}/{PLATEAU.DynamicTile.AddressableLoader.AddressableLocalBuildFolderName}/{groupName}";
 
             profileSettings.SetValue(settings.activeProfileId, ProfileVariableNameBuild, buildPath);
             profileSettings.SetValue(settings.activeProfileId, ProfileVariableNameLoad, loadPath);
-            
+
             OverwriteStandardPathVariables(profileSettings, settings.activeProfileId, buildPath, loadPath);
-            
-            
+
+
             // addressables_content_state.binもビルド先に保存
             settings.ContentStateBuildPath = BuildPath(settings);
 
@@ -300,7 +309,7 @@ namespace PLATEAU.Editor.TileAddressables
                 Debug.LogWarning("BundledAssetGroupSchemaが見つかりません。");
                 return;
             }
-            
+
             if (!settings.profileSettings.GetVariableNames().Contains(ProfileVariableNameLoad))
             {
                 settings.profileSettings.CreateValue(ProfileVariableNameLoad, SafeDefaultPathLoad); // デフォルト値はあとで必要なパスに書き換えること
@@ -317,7 +326,7 @@ namespace PLATEAU.Editor.TileAddressables
 
             SetGroupSchema(bundledSchema);
         }
-        
+
         /// <summary>
         /// プロファイルを設定します。
         /// </summary>
@@ -328,19 +337,19 @@ namespace PLATEAU.Editor.TileAddressables
                 Debug.LogError("pathパラメータが無効です。");
                 return;
             }
-            
+
             if (string.IsNullOrEmpty(pathVar))
             {
                 Debug.LogError("pathVarパラメータが無効です。");
                 return;
             }
-            
+
             var settings = RequireAddressableSettings();
             if (settings == null)
             {
                 return;
             }
-            
+
             // カタログ設定
             settings.BuildRemoteCatalog = true;
 
@@ -361,10 +370,10 @@ namespace PLATEAU.Editor.TileAddressables
             settings.RemoteCatalogLoadPath.SetVariableByName(settings, ProfileVariableNameLoad);
 
             OverwriteStandardPathVariables(profileSettings, settings.activeProfileId, path, path);
-            
+
             // addressables_content_state.binもビルド先に保存します。これは差分ビルドで利用します。
             settings.ContentStateBuildPath = BuildPath(settings);
-            
+
             SaveAddressableSettings();
         }
 
@@ -476,11 +485,17 @@ namespace PLATEAU.Editor.TileAddressables
             settings.activeProfileId = newProfileId;
             return newProfileId;
         }
-        
+
         /// <summary>
         /// Addressablesのビルドを実行します。
+        /// ビルド前にタイルグループ以外の IncludeInBuild を無効化し、ビルド後に復元します。
+        /// また、BuildPlayerContent を直接使わずビルダーを呼び出すことで、
+        /// RuntimeSettingsFilename / RuntimeCatalogFilename を PLATEAU専用に変更し、
+        /// SDK利用者の settings.json / catalog.bin を上書きしません。
         /// </summary>
-        public static void BuildAddressables(TileBuildMode buildMode)
+        /// <param name="buildMode">ビルドモード</param>
+        /// <param name="tileGroupName">ビルド対象のタイルグループ名</param>
+        public static void BuildAddressables(TileBuildMode buildMode, string tileGroupName)
         {
             var settings = RequireAddressableSettings();
             if (settings == null)
@@ -495,23 +510,49 @@ namespace PLATEAU.Editor.TileAddressables
             bool prevGenerateBuildLayout = ProjectConfigData.GenerateBuildLayout;
             ProjectConfigData.GenerateBuildLayout = false;
 
+            // タイルグループ以外の IncludeInBuild を一時的に false にし、
+            // タイルビルドに他グループが含まれないようにします。
+            var savedIncludeInBuild = DisableNonTileGroupsIncludeInBuild(settings, tileGroupName);
+
             try
             {
-                // Addressablesのビルドを実行
-                AddressablesPlayerBuildResult result;
+                // BuildPlayerContent の前処理: BundleFileId をクリア（BuildPlayerContent 内部と同等の処理）
+                foreach (var group in settings.groups)
+                {
+                    if (group == null) continue;
+                    foreach (var entry in group.entries)
+                        entry.BundleFileId = null;
+                }
+
+                AddressablesDataBuilderInput builderInput;
                 switch (buildMode)
                 {
                     case TileBuildMode.New:
-                        AddressableAssetSettings.BuildPlayerContent(out result);
+                        builderInput = new AddressablesDataBuilderInput(settings);
                         break;
                     case TileBuildMode.Add:
                         var contentStatePath = Path.Combine(BuildPath(settings), ContentStateFileName);
-                        result = ContentUpdateScript.BuildContentUpdate(settings, contentStatePath);
+                        var cacheData = ContentUpdateScript.LoadContentState(contentStatePath);
+                        if (cacheData == null)
+                        {
+                            Debug.LogError($"差分ビルド用の状態ファイルが読み込めません: {contentStatePath}");
+                            return;
+                        }
+                        builderInput = new AddressablesDataBuilderInput(settings, cacheData.playerVersion);
+                        builderInput.PreviousContentState = cacheData;
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
-                
+
+                // SDK利用者の settings.json / catalog.bin を上書きしないよう、PLATEAU専用のファイル名を使用します。
+                // PLATEAUはカタログを LoadContentCatalogAsync で直接ロードするため、
+                // Library/com.unity.addressables 内のこれらのファイルは参照しません。
+                builderInput.RuntimeSettingsFilename = PlateauRuntimeSettingsFilename;
+                builderInput.RuntimeCatalogFilename = PlateauRuntimeCatalogFilename;
+
+                var result = settings.ActivePlayerDataBuilder.BuildData<AddressablesPlayerBuildResult>(builderInput);
+
                 if (!string.IsNullOrEmpty(result.Error))
                 {
                     Debug.LogError($"Addressablesのビルドでエラーが発生しました: {result.Error}");
@@ -523,40 +564,47 @@ namespace PLATEAU.Editor.TileAddressables
             }
             finally
             {
-                // 設定を元に戻します
+                RestoreGroupsIncludeInBuild(savedIncludeInBuild);
                 ProjectConfigData.GenerateBuildLayout = prevGenerateBuildLayout;
             }
         }
-        
+
         /// <summary>
-        /// 指定したグループの IncludeInBuild を設定します。
+        /// タイルグループ以外の全グループの IncludeInBuild を false にし、
+        /// 元の値を返します。ビルド後に RestoreGroupsIncludeInBuild で復元してください。
         /// </summary>
-        public static void SetGroupIncludeInBuild(string groupName, bool includeInBuild)
+        private static Dictionary<AddressableAssetGroup, bool> DisableNonTileGroupsIncludeInBuild(
+            AddressableAssetSettings settings, string tileGroupName)
         {
-            var settings = RequireAddressableSettings();
-            if (settings == null)
+            var saved = new Dictionary<AddressableAssetGroup, bool>();
+
+            foreach (var group in settings.groups)
             {
-                Debug.LogError("AddressableAssetSettingsが見つかりません。");
-                return;
+                if (group == null) continue;
+                if (group.Name == tileGroupName) continue;
+                // ReadOnly グループ（Built In Data等）はスキーマを持たないのでスキップ
+                var schema = group.GetSchema<BundledAssetGroupSchema>();
+                if (schema == null) continue;
+
+                saved[group] = schema.IncludeInBuild;
+                schema.IncludeInBuild = false;
             }
 
-            var group = settings.FindGroup(groupName);
-            if (group == null)
-            {
-                Debug.LogWarning($"グループが見つかりません: {groupName}");
-                return;
-            }
+            return saved;
+        }
 
-            var bundledSchema = group.GetSchema<BundledAssetGroupSchema>();
-            if (bundledSchema == null)
+        /// <summary>
+        /// DisableNonTileGroupsIncludeInBuild で退避した IncludeInBuild を復元します。
+        /// </summary>
+        private static void RestoreGroupsIncludeInBuild(
+            Dictionary<AddressableAssetGroup, bool> saved)
+        {
+            foreach (var (group, wasIncluded) in saved)
             {
-                Debug.LogWarning("BundledAssetGroupSchemaが見つかりません。");
-                return;
+                var schema = group.GetSchema<BundledAssetGroupSchema>();
+                if (schema == null) continue;
+                schema.IncludeInBuild = wasIncluded;
             }
-
-            bundledSchema.IncludeInBuild = includeInBuild;
-            EditorUtility.SetDirty(bundledSchema);
-            SaveAddressableSettings();
         }
 
         /// <summary>
@@ -571,7 +619,7 @@ namespace PLATEAU.Editor.TileAddressables
                 Debug.LogWarning("グループ名が指定されていません。");
                 return false;
             }
-            
+
             try
             {
                 var settings = RequireAddressableSettings();
@@ -579,20 +627,20 @@ namespace PLATEAU.Editor.TileAddressables
                 {
                     return false;
                 }
-                
+
                 var group = settings.FindGroup(groupName);
                 if (group == null)
                 {
                     Debug.Log($"group does not exist. skipping. group name: {groupName}");
                     return false;
                 }
-                
+
                 if (group == settings.DefaultGroup)
                 {
                     Debug.LogWarning("デフォルトグループは削除できません。");
                     return false;
                 }
-                
+
                 settings.RemoveGroup(group);
                 Debug.Log($"Addressableグループを削除しました: {groupName}");
                 return true;
@@ -612,4 +660,4 @@ namespace PLATEAU.Editor.TileAddressables
             Add
         }
     }
-} 
+}

--- a/Tests/EditModeTests/TestDynamicTile/TestImportToDynamicTile.cs
+++ b/Tests/EditModeTests/TestDynamicTile/TestImportToDynamicTile.cs
@@ -65,7 +65,7 @@ namespace PLATEAU.Tests.TestDynamicTile
             yield return null;
 
             // Assets 内出力時、ビルド後にグループの IncludeInBuild が false になっていること
-            AssertGroupIncludeInBuildIsFalse();
+            AssertGroupRemovedAfterBuild();
         }
 
         /// <summary>
@@ -301,21 +301,18 @@ namespace PLATEAU.Tests.TestDynamicTile
         }
 
         /// <summary>
-        /// Assets 内出力時、ビルド完了後に対象グループの BundledAssetGroupSchema.IncludeInBuild が false であることを検証します。
-        /// IncludeInBuild が true のまま残ると、Addressables メニューからの再ビルド時にカタログ CRC が不整合になります。
+        /// ビルド完了後に対象グループが削除されていることを検証します。
+        /// ビルド済みのカタログとバンドルはディスクに存在し、ランタイムでは LoadContentCatalogAsync で
+        /// 直接ロードするためグループは不要です。
         /// </summary>
-        private void AssertGroupIncludeInBuildIsFalse()
+        private void AssertGroupRemovedAfterBuild()
         {
             var settings = AddressableAssetSettingsDefaultObject.Settings;
             Assert.IsNotNull(settings, "AddressableAssetSettings が存在する");
 
             var groupName = DynamicTileProcessingContext.AddressableGroupBaseName + "_" + Path.GetFileName(outputDir);
             var group = settings.FindGroup(groupName);
-            Assert.IsNotNull(group, $"Addressable グループ '{groupName}' が存在する");
-
-            var schema = group.GetSchema<BundledAssetGroupSchema>();
-            Assert.IsNotNull(schema, $"グループ '{groupName}' に BundledAssetGroupSchema が存在する");
-            Assert.IsFalse(schema.IncludeInBuild, $"グループ '{groupName}' の IncludeInBuild がビルド後に false になっている");
+            Assert.IsNull(group, $"Addressable グループ '{groupName}' がビルド後に削除されている");
         }
 
         private static void AssertTileObjectExists(string[] gridsAssertedToExist)

--- a/Tests/EditModeTests/TestDynamicTile/TestImportToDynamicTile.cs
+++ b/Tests/EditModeTests/TestDynamicTile/TestImportToDynamicTile.cs
@@ -64,7 +64,7 @@ namespace PLATEAU.Tests.TestDynamicTile
             yield return TestImport(gridCodesB, new string[] { gridCodeStrA, gridCodeStrB });
             yield return null;
 
-            // Assets 内出力時、ビルド後にグループの IncludeInBuild が false になっていること
+            // Assets 内出力時、ビルド後にグループが削除されてるかチェック
             AssertGroupRemovedAfterBuild();
         }
 


### PR DESCRIPTION
﻿## 🔗 関連リンク
<!-- 関連するPR、仕様書のリンク(社外の方を除く)、Jiraチケットのリンク(社外の方を除く)等を書いてください。 -->
https://synesthesias.atlassian.net/browse/CPSDK25-299
## ✅ レビュー前確認項目
- [ ] ユニットテストが通ること
- [ ] ビルドが通ること

<!-- 社内の人向け: 以下の項目は、開発当初のストーリー設計書通りであれば省略可能です。
                 設計に変更があった場合のみ、変更点を周知するために記載してください。 -->

## 🚀 実装内容
<!-- GUIに関する実装がある場合はスクリーンショットを貼ってください。実装した内容について書いてください。 -->

- タイルのビルド前にPLATAUEのGroup以外をIncludeInBuild = falseにする（これをしてないせいでタイルビルド時に全てのリソースがビルドされてた）
- Library/com.unity.addressables/aa　に配置されたAssetBundleのカタログがタイルのビルド時に上書きされてしまいデータが取得できなくなってしまうケースの修正（別名にして保存させるようにして干渉しないようにした）
- タイルビルド後にGroupを削除するように変更（従来はAssets以外の場合は削除してたが、基本削除するように変更。SDK利用者がGroupに対して何か設定を変えたりした際に不整合が起きる可能性があるので）

## 🌐 影響範囲
<!-- 既存の実装に対して行った変更や、影響がある部分があれば書いてください(特に同時並行している他の作業に影響する時、今後必要な変更を書く)。また社内の人は、影響先の担当者に対して周知をお願いします。 -->
## 🛠️ 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->
## ⚠️ 懸念点
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **機能改善**
  * タイル生成時のAddressablesグループ管理を見直し、グループは条件にかかわらず確実に削除されます。
  * ビルド出力にPLATEAU専用の設定・カタログファイルを使用するよう更新しました。
  * ビルド処理がグループ単位で実行できるようになり、インクリメンタルビルドの信頼性が向上しました。

* **テスト**
  * 動作確認テストを更新し、グループ削除後の挙動を検証するように変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->